### PR TITLE
Various small fixes

### DIFF
--- a/lib/lexer_top.mll
+++ b/lib/lexer_top.mll
@@ -10,6 +10,9 @@ rule token = parse
                  { `Output  str :: token lexbuf }
 
 and phrase acc buf = parse
+  | "\n  \\\n  "
+      { Lexing.new_line lexbuf;
+        phrase ("" :: Buffer.contents buf :: acc) (Buffer.create 8) lexbuf }
   | "\n  "
       { Lexing.new_line lexbuf;
         phrase (Buffer.contents buf :: acc) (Buffer.create 8) lexbuf }

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -57,7 +57,7 @@ module Lexbuf = struct
     pos_fname = toplevel_fname;
     pos_lnum = pos.pos_lnum - start.pos_lnum + 1;
     pos_bol  = pos.pos_bol  - start.pos_cnum - 1;
-    pos_cnum = pos.pos_cnum - start.pos_cnum - 1;
+    pos_cnum = pos.pos_cnum - start.pos_cnum ;
   }
 
   let shift_toplevel_location ~start loc =

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -121,6 +121,7 @@ module Phrase = struct
         if lexbuf.Lexing.lex_last_action <> Lexbuf.semisemi_action then begin
           let rec aux () = match Lexer.token lexbuf with
             | Parser.SEMISEMI | Parser.EOF -> ()
+            | exception Lexer.Error (_, _) -> ()
             | _ -> aux ()
           in
           aux ();

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -108,7 +108,7 @@ module Phrase = struct
   let parse lines =
     let contents = String.concat " " lines in
     let lexbuf = Lexing.from_string contents in
-    let startpos = lexbuf.Lexing.lex_curr_p in
+    let startpos = lexbuf.Lexing.lex_start_p in
     let parsed = match Parse.toplevel_phrase lexbuf with
       | phrase -> Ok phrase
       | exception exn ->
@@ -580,6 +580,7 @@ let patch_env () =
   in ()
 
 let init ~verbose:v ~silent:s ~verbose_findlib () =
+  Clflags.real_paths := false;
   Toploop.set_paths ();
   Compmisc.init_path true;
   Toploop.toplevel_env := Compmisc.initial_env ();

--- a/lib/toplevel.ml
+++ b/lib/toplevel.ml
@@ -42,6 +42,7 @@ let dump ppf ({ line; command; output } : t) =
 let pp_command ?(pad=0) ppf (t : t) = match t.command with
   | [] -> ()
   | l  ->
+    let l = List.map (function "" -> "\\" | s  -> s) l in
     let sep ppf () = Fmt.pf ppf "\n%a  " pp_pad pad in
     Fmt.pf ppf "%a# %a\n" pp_pad pad Fmt.(list ~sep string) l
 

--- a/test/errors.md
+++ b/test/errors.md
@@ -1,0 +1,29 @@
+Errors should be well localized:
+
+```ocaml
+# class ['a] stack init = object
+    val mutable v = init
+  \
+    method pop =
+      match v with
+      | hd :: tl ->
+        v <- tl;
+        Some hd
+      | [] -> None
+  \
+    method push hd =
+      v <- hd :: v
+  end;;
+Characters 0-191:
+Error: Some type variables are unbound in this type:
+         class ['a] stack :
+           'b list ->
+           object
+             val mutable v : 'b list
+             method pop : 'b option
+             method push : 'b -> unit
+           end
+       The method pop has type 'b option where 'b is unbound
+```
+
+Hi!

--- a/test/jbuild
+++ b/test/jbuild
@@ -21,6 +21,13 @@
 
 (alias
  ((name runtest)
+  (deps (errors.md (package mdx)))
+  (action (progn
+           (run mdx test ${<})
+           (diff? ${<} ${<}.corrected)))))
+
+(alias
+ ((name runtest)
   (deps (heredoc.md section.md (package mdx)))
   (action (progn
            (run mdx test ${<})

--- a/test/lines.md
+++ b/test/lines.md
@@ -23,7 +23,7 @@ And
   | 0 -> 1
   | n ->
   n + "foo"
-Characters 38-43:
+Characters 39-44:
 Error: This expression has type string but an expression was expected of type
          int
 ```

--- a/test/mlt.md
+++ b/test/mlt.md
@@ -5,7 +5,7 @@ Mdx can also understand ocaml code blocks:
 # let x = 3;;
 val x : int = 3
 # x + "foo";;
-Characters 3-8:
+Characters 4-9:
 Error: This expression has type string but an expression was expected of type
          int
 ```


### PR DESCRIPTION
- use short-paths
- allow to have empty command lines (need to end them by `\`)
- fix a shift-by-one error in location reporting
