### PR TITLE
Better support for empty lines

### DIFF
--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -106,11 +106,11 @@ let eval_test c test =
   Mdx_top.eval c (Toplevel.command test)
 
 let eval_raw c ~line lines =
-  let t = Toplevel.{line; command = lines; output = [] } in
+  let t = Toplevel.{vpad=0; hpad=0; line; command = lines; output = [] } in
   let _ = eval_test c t in
   ()
 
-let run_toplevel_tests c ppf pad tests t =
+let run_toplevel_tests c ppf tests t =
   Block.pp_header ppf t;
   List.iter (fun test ->
       let lines = eval_test c test in
@@ -119,7 +119,8 @@ let run_toplevel_tests c ppf pad tests t =
         if Output.equal output test.output then test.output
         else output
       in
-      Toplevel.pp_command ~pad ppf test;
+      let pad = test.hpad in
+      Toplevel.pp_command ppf test;
       List.iter (function
           | `Ellipsis    -> Output.pp ~pad ppf `Ellipsis
           | `Output line ->
@@ -176,7 +177,7 @@ let run ()
             | true, false, `Non_det `Output, Cram { tests; _ } ->
               Block.pp ppf t;
               List.iter (fun t -> let _ = run_test temp_file t in ()) tests
-            | true, false, `Non_det `Output, Toplevel { tests; _ } ->
+            | true, false, `Non_det `Output, Toplevel tests ->
               Block.pp ppf t;
               List.iter (fun t -> let _ = eval_test c t in ()) tests
             (* Run raw OCaml code *)
@@ -187,8 +188,8 @@ let run ()
             | true, _, _, Cram { tests; pad } ->
               run_cram_tests ?root ppf temp_file pad tests t
             (* Top-level tests. *)
-            | true, _, _, Toplevel { tests; pad } ->
-              run_toplevel_tests c ppf pad tests t
+            | true, _, _, Toplevel tests ->
+              run_toplevel_tests c ppf tests t
         ) items;
       Format.pp_print_flush ppf ();
       Buffer.contents buf);

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -22,7 +22,7 @@ type value =
   | OCaml
   | Error of string list
   | Cram of { pad: int; tests: Cram.t list }
-  | Toplevel of { pad: int; tests: Toplevel.t list }
+  | Toplevel of Toplevel.t list
 
 type section = int * string
 (** The type for sections. *)

--- a/lib/lexer_top.mll
+++ b/lib/lexer_top.mll
@@ -4,10 +4,11 @@ let ws = ' ' | '\t'
 rule token = parse
  | eof           { [] }
  | "..." ws* eol { `Ellipsis :: token lexbuf }
+ | '\n'          { `Output "" :: token lexbuf }
  | "# "          { let c = phrase [] (Buffer.create 8) lexbuf in
                    `Command c :: token lexbuf }
- | ([^'#'] [^'\n']* as str) eol
-                 { `Output  str :: token lexbuf }
+ | ([^'#' '\n'] [^'\n']* as str) eol
+                 { `Output str :: token lexbuf }
 
 and phrase acc buf = parse
   | ("\n"* as nl) "\n  "

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -16,7 +16,7 @@
 
 open Astring
 
-let pad_of_lines = function
+let hpad_of_lines = function
   | []   -> 0
   | h::_ ->
     let i = ref 0 in

--- a/lib/toplevel.ml
+++ b/lib/toplevel.ml
@@ -21,6 +21,8 @@ open Astring
 open Misc
 
 type t = {
+  vpad   : int;
+  hpad   : int;
   line   : int;
   command: string list;
   output : Output.t list;
@@ -30,28 +32,38 @@ let dump_line ppf = function
   | #Output.t as o -> Output.dump ppf o
   | `Command c     -> Fmt.pf ppf "`Command %a" Fmt.(Dump.list dump_string) c
 
+let dump_lines = Fmt.(Dump.list dump_line)
+
 let command t = t.command
 let output t = t.output
 
-let dump ppf ({ line; command; output } : t) =
-  Fmt.pf ppf "@[{line=%d;@ command=%a;@ output=%a}@]"
-    line
+let dump ppf ({vpad; hpad; line; command; output} : t) =
+  Fmt.pf ppf "@[{vpad=%d;@ hpad=%d;@ line=%d;@ command=%a;@ output=%a}@]"
+    vpad hpad line
     Fmt.(Dump.list dump_string) command
     Fmt.(Dump.list Output.dump) output
 
-let pp_command ?(pad=0) ppf (t : t) = match t.command with
+let pp_vpad ppf t =
+  let rec aux = function
+    | 0 -> ()
+    | i -> Fmt.pf ppf "\n"; aux (i-1)
+  in
+  aux t.vpad
+
+let pp_command ppf (t : t) = match t.command with
   | [] -> ()
   | l  ->
+    pp_vpad ppf t;
     List.iteri (fun i s ->
-        if i = 0 then Fmt.pf ppf "%a# %s\n" pp_pad pad s
+        if i = 0 then Fmt.pf ppf "%a# %s\n" pp_pad t.hpad s
         else match s with
           | "" -> Fmt.string ppf "\n"
-          | _  -> Fmt.pf ppf "%a  %s\n" pp_pad pad s
+          | _  -> Fmt.pf ppf "%a  %s\n" pp_pad t.hpad s
       ) l
 
-let pp ?pad ppf (t : t) =
-  pp_command ?pad ppf t;
-  pp_lines (Output.pp ?pad) ppf t.output
+let pp ppf (t : t) =
+  pp_command ppf t;
+  pp_lines (Output.pp ~pad:t.vpad) ppf t.output
 
 let lexbuf ~file ~line s =
   let lexbuf = Lexing.from_string s in
@@ -65,27 +77,38 @@ let lexbuf ~file ~line s =
   lexbuf.lex_curr_p <- curr;
   lexbuf
 
+let vpad_of_lines t =
+  let rec aux i = function
+    | `Output h :: t when String.trim h = "" -> aux (i+1) t
+    | t -> i, t
+  in
+  aux 0 t
+
 let of_lines ~file ~line t =
-  let pad = pad_of_lines t in
+  let hpad = hpad_of_lines t in
   let unpad line =
-    if String.length line < pad then Fmt.failwith "invalide padding: %S" line
-    else String.with_index_range line ~first:pad
+    if String.length line < hpad then Fmt.failwith "invalide padding: %S" line
+    else String.with_index_range line ~first:hpad
   in
   let lines = List.map unpad t in
   let lines = String.concat ~sep:"\n" lines in
   let lines = Lexer_top.token (lexbuf ~file ~line lines) in
+  let vpad, lines = vpad_of_lines lines in
   Log.debug (fun l ->
-      l "Toplevel.of_lines (pad=%d) %a" pad Fmt.(Dump.list dump_line) lines
+      l "Toplevel.of_lines (vpad=%d, hpad=%d) %a" vpad hpad dump_lines lines
     );
-  let mk command line output = { command; line; output = List.rev output } in
-  let rec aux command line output acc = function
-    | []                  -> List.rev (mk command line output :: acc)
-    | `Ellipsis as o :: t -> aux command line (o :: output) acc t
-    | `Output _ as o :: t -> aux command line (o :: output) acc t
+  let mk vpad command line output =
+    { vpad; hpad;command; line; output = List.rev output }
+  in
+  let rec aux vpad command line output acc = function
+    | []                  -> List.rev (mk vpad command line output :: acc)
+    | `Ellipsis as o :: t -> aux vpad command line (o :: output) acc t
+    | `Output _ as o :: t -> aux vpad command line (o :: output) acc t
     | `Command cmd   :: t ->
       let line' = line + List.length command + List.length output in
-      aux cmd line' [] (mk command line output :: acc) t
+      let vpad', output = vpad_of_lines output in
+      aux vpad' cmd line' [] (mk vpad command line output :: acc) t
   in
   match lines with
-  | `Command cmd :: t -> pad, aux cmd line [] [] t
+  | `Command cmd :: t -> aux vpad cmd (line+vpad) [] [] t
   | _ -> Fmt.failwith "invalid toplevel block: %a" Fmt.(Dump.list string) t

--- a/lib/toplevel.mli
+++ b/lib/toplevel.mli
@@ -18,6 +18,8 @@
 
 (** The type for top-level phrases. *)
 type t = {
+  vpad   : int;
+  hpad   : int;
   line   : int;
   command: string list;
   output : Output.t list;
@@ -29,20 +31,20 @@ val dump: t Fmt.t
 (** [dump] is the printer for dumping toplevel phrases. Useful for
    debugging. *)
 
-val pp: ?pad:int -> t Fmt.t
+val pp: t Fmt.t
 (** [pp] is the pretty-printer for top-level phrases. [pad] is the
    size of the optionnalwhitespace left padding (by default is is
    0). *)
 
-val pp_command: ?pad:int -> t Fmt.t
+val pp_command: t Fmt.t
 (** [pp_command] is the pretty-printer for toplevel commands. *)
 
 (** {2 Parser} *)
 
-val of_lines: file:string -> line:int -> string list -> int * t list
+val of_lines: file:string -> line:int -> string list -> t list
 (** [of_lines ~file ~line lines] is the list of toplevel blocks from
-   file [file] starting at line [line]. Return the whitespace padding
-   as well.*)
+   file [file] starting at line [line]. Return the vertical and
+   horizontal whitespace padding as well.*)
 
 (** {2 Accessors} *)
 

--- a/test/jbuild
+++ b/test/jbuild
@@ -21,6 +21,13 @@
 
 (alias
  ((name runtest)
+  (deps (spaces.md (package mdx)))
+  (action (progn
+           (run mdx test ${<})
+           (diff? ${<} ${<}.corrected)))))
+
+(alias
+ ((name runtest)
   (deps (errors.md (package mdx)))
   (action (progn
            (run mdx test ${<})

--- a/test/spaces.md
+++ b/test/spaces.md
@@ -1,0 +1,48 @@
+```ocaml
+
+
+let x =
+
+  5
+
+```
+
+```ocaml
+
+# let x = 1
+
+  in x
+- : int = 1
+
+
+# 3
+- : int = 3
+
+
+# Printf.printf "foo\n\nbar\n"
+foo
+
+bar
+- : unit = ()
+```
+
+```sh
+$ mdx pp spaces.md
+#2 "spaces.md"
+
+
+let x =
+
+  5
+
+;;
+#12 "spaces.md"
+  let x = 1
+  
+  in x
+#18 "spaces.md"
+  3
+#22 "spaces.md"
+  Printf.printf "foo\n\nbar\n"
+;;
+```


### PR DESCRIPTION
- fix selection of raw/toplevel blocks when it starts by an emptyline
- allow to have vertical padding between commands in toplevel blocks