### PR TITLE
mdx does not use the cppo library, just the binary

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name        mdx)
  (public_name mdx)
  (preprocess (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
- (libraries   astring cppo fmt logs ocaml-migrate-parsetree re))
+ (libraries   astring fmt logs ocaml-migrate-parsetree re))
 
 (ocamllex lexer)
 (ocamllex lexer_cram)


### PR DESCRIPTION
Remove the dependency here, as it breaks embedding the mdx
code in a duniverse when there is a cppo override present
in the source tree.