### PR TITLE
Improve ellipsis support, for some value of improve

### DIFF
--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -100,7 +100,7 @@ let run_cram_tests t ?root ppf temp_file pad tests =
       let output =
         let output = List.map (fun x -> `Output x) lines in
         if Output.equal output test.output then test.output
-        else output
+        else Output.merge output test.output
       in
       Cram.pp_command ~pad ppf test;
       List.iter (function

--- a/lib/output.mli
+++ b/lib/output.mli
@@ -24,6 +24,10 @@ val equal: t list -> t list -> bool
 (** [equal x y] is true iff [x] and [y] are equivalent, modulo
    ellipsis. *)
 
+val merge: [`Output of string] list -> t list -> t list
+(** [merge output test] merges any [`Ellipsis] items from [test] into
+   [output]. *)
+
 val pp: ?pad:int -> t Fmt.t
 (** [pp] is the pretty-printer for test outputs. [pad] is the size of
    the optional whitespace left-padding (by default it is 0). *)

--- a/test/dune
+++ b/test/dune
@@ -21,6 +21,13 @@
 
 (alias
  (name   runtest)
+ (deps   (:x ellipsis-updates.md) (:y ellipsis-updates.md.expected) (package mdx))
+ (action (progn
+           (run mdx test %{x})
+           (diff? %{y} %{x}.corrected))))
+
+(alias
+ (name   runtest)
  (deps   (:x ellipsis.md) (package mdx))
  (action (progn
            (run mdx test %{x})

--- a/test/ellipsis-updates.md
+++ b/test/ellipsis-updates.md
@@ -1,0 +1,22 @@
+Ellipsis lines are preserved if possible even when the output changes
+
+```sh
+$ for i in `seq 1 21`; do echo $i; done
+1
+2
+...
+10
+...
+19
+20
+```
+
+```sh
+$ for i in `seq 1 19`; do echo $i; done
+1
+2
+...
+10
+...
+20
+```

--- a/test/ellipsis-updates.md.expected
+++ b/test/ellipsis-updates.md.expected
@@ -1,0 +1,30 @@
+Ellipsis lines are preserved if possible even when the output changes
+
+```sh
+$ for i in `seq 1 21`; do echo $i; done
+1
+2
+...
+10
+...
+19
+20
+21
+```
+
+```sh
+$ for i in `seq 1 19`; do echo $i; done
+1
+2
+...
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+```

--- a/test/ellipsis.md
+++ b/test/ellipsis.md
@@ -24,3 +24,10 @@ foo"
 
 ...
 ```
+
+Lines ending with ellipsis
+
+```sh
+$ echo Hello world
+Hello...
+```


### PR DESCRIPTION
This PR changes two features of ellipsis support.

 1. If the output has changed, mdx tries to preserve ellipsis lines - before, they would all be expanded. A test is included.
 2. If an output line ends with an ellipsis, then only the rest of the line has to match - this allows very limited partial matching of lines (but useful for things like shell error messages where the prefix is portable but the precise text of the message is not)

The second change is obviously not wholly backwards compatible (an existing `Press any key to continue...` line of output will now match `Press any key to continue...!`, for example)