### PR TITLE
Support for 4.02.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: c
 env:
   # Check build and unit tests
   # NOTE: testing needs OPAMBUILDTEST=true so that test deps are installed
+  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.02.3
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.06.1
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.07.0
 before_install:

--- a/bin/test/dune
+++ b/bin/test/dune
@@ -4,4 +4,5 @@
  (package     mdx)
  (modes       byte)  ;; no native code toplevel libs yet
  (link_flags  -linkall)
+ (preprocess (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
  (libraries   cli mdx.top))

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -15,11 +15,11 @@
  *)
 
 open Mdx
+open Compat
+open Result
 
 let src = Logs.Src.create "cram.test"
 module Log = (val Logs.src_log src : Logs.LOG)
-module Result = Mdx.Migrate_ast.Result
-module String = Mdx.Migrate_ast.String
 
 let (/) = Filename.concat
 
@@ -130,10 +130,10 @@ let err_eval ~cmd lines =
 let eval_raw t ?root c ~line lines =
   let test = Toplevel.{vpad=0; hpad=0; line; command = lines; output = [] } in
   match eval_test t ?root c test with
-  | Result.Ok _    -> ()
-  | Result.Error e -> err_eval ~cmd:lines e
+  | Ok _    -> ()
+  | Error e -> err_eval ~cmd:lines e
 
-let lines = function Result.Ok x | Result.Error x -> x
+let lines = function Ok x | Error x -> x
 
 let split_lines lines =
   let aux acc s =
@@ -324,8 +324,8 @@ let run ()
                    Block.pp ppf t;
                    List.iter (fun test ->
                        match eval_test t ?root c test with
-                       | Result.Ok _    -> ()
-                       | Result.Error e ->
+                       | Ok _    -> ()
+                       | Error e ->
                          let output = List.map (fun l -> `Output l) e in
                          if Output.equal test.output output then ()
                          else err_eval ~cmd:test.command e

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -18,6 +18,8 @@ open Mdx
 
 let src = Logs.Src.create "cram.test"
 module Log = (val Logs.src_log src : Logs.LOG)
+module Result = Mdx.Migrate_ast.Result
+module String = Mdx.Migrate_ast.String
 
 let (/) = Filename.concat
 
@@ -128,10 +130,10 @@ let err_eval ~cmd lines =
 let eval_raw t ?root c ~line lines =
   let test = Toplevel.{vpad=0; hpad=0; line; command = lines; output = [] } in
   match eval_test t ?root c test with
-  | Ok _    -> ()
-  | Error e -> err_eval ~cmd:lines e
+  | Result.Ok _    -> ()
+  | Result.Error e -> err_eval ~cmd:lines e
 
-let lines = function Ok x | Error x -> x
+let lines = function Result.Ok x | Result.Error x -> x
 
 let split_lines lines =
   let aux acc s =
@@ -322,8 +324,8 @@ let run ()
                    Block.pp ppf t;
                    List.iter (fun test ->
                        match eval_test t ?root c test with
-                       | Ok _    -> ()
-                       | Error e ->
+                       | Result.Ok _    -> ()
+                       | Result.Error e ->
                          let output = List.map (fun l -> `Output l) e in
                          if Output.equal test.output output then ()
                          else err_eval ~cmd:test.command e

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -18,11 +18,13 @@ open Astring
 
 type section = int * string
 
+type cram_value = { pad: int; tests: Cram.t list }
+
 type value =
   | Raw
   | OCaml
   | Error of string list
-  | Cram of { pad: int; tests: Cram.t list }
+  | Cram of cram_value
   | Toplevel of Toplevel.t list
 
 type t = {
@@ -147,7 +149,7 @@ let check_labels t =
         :: acc
     ) [] t.labels
   |> function
-  | [] -> Ok ()
+  | [] -> Result.Ok ()
   | es -> Result.Error es
 
 let get_label t label =

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -16,12 +16,14 @@
 
 (** Code blocks. *)
 
+type cram_value = { pad: int; tests: Cram.t list }
+
 (** The type for block values. *)
 type value =
   | Raw
   | OCaml
   | Error of string list
-  | Cram of { pad: int; tests: Cram.t list }
+  | Cram of cram_value
   | Toplevel of Toplevel.t list
 
 type section = int * string

--- a/lib/compat.ml
+++ b/lib/compat.ml
@@ -17,11 +17,11 @@
 module String = struct
   include String
 
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 3
+#if OCAML_MAJOR = 4 && OCAML_MINOR < 3
     let equal x y = String.compare x y = 0
 #endif
 
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 4
+#if OCAML_MAJOR = 4 && OCAML_MINOR < 4
   let split_on_char sep s =
     let r = ref [] in
     let j = ref (String.length s) in
@@ -38,7 +38,7 @@ end
 module Filename = struct
   include Filename
 
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 4
+#if OCAML_MAJOR = 4 && OCAML_MINOR < 4
   let is_dir_sep s i = s.[i] = '/' (* Unix only *)
 
   let extension_len name =
@@ -63,7 +63,7 @@ end
 module List = struct
   include List
 
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 6
+#if OCAML_MAJOR = 4 && OCAML_MINOR < 6
   let rec init_aux i n f =
     if i >= n then []
     else (f i) :: init_aux (i+1) n f
@@ -71,7 +71,7 @@ module List = struct
   let init n f = init_aux 0 n f
 #endif
 
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 5
+#if OCAML_MAJOR = 4 && OCAML_MINOR < 5
   let rec find_opt p = function
     | [] -> None
     | x :: l -> if p x then Some x else find_opt p l
@@ -81,7 +81,7 @@ end
 module Warnings = struct
   include Warnings
 
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 3
+#if OCAML_MAJOR = 4 && OCAML_MINOR < 3
   (* Can't be overriden *)
   let reset_fatal () = ()
 #endif
@@ -90,7 +90,7 @@ end
 module Env = struct
   include Env
 
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 3
+#if OCAML_MAJOR = 4 && OCAML_MINOR < 3
   (* Can't be overriden *)
   let without_cmis f x = f x
 #endif

--- a/lib/compat.ml
+++ b/lib/compat.ml
@@ -1,0 +1,97 @@
+(*
+ * Copyright (c) 2018 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+module String = struct
+  include String
+
+#if OCAML_MAJOR >= 4 && OCAML_MINOR < 3
+    let equal x y = String.compare x y = 0
+#endif
+
+#if OCAML_MAJOR >= 4 && OCAML_MINOR < 4
+  let split_on_char sep s =
+    let r = ref [] in
+    let j = ref (String.length s) in
+    for i = String.length s - 1 downto 0 do
+      if String.unsafe_get s i = sep then begin
+          r := String.sub s (i + 1) (!j - i - 1) :: !r;
+          j := i
+        end
+    done;
+    String.sub s 0 !j :: !r
+#endif
+end
+
+module Filename = struct
+  include Filename
+
+#if OCAML_MAJOR >= 4 && OCAML_MINOR < 4
+  let is_dir_sep s i = s.[i] = '/' (* Unix only *)
+
+  let extension_len name =
+    let rec check i0 i =
+      if i < 0 || is_dir_sep name i then 0
+      else if name.[i] = '.' then check i0 (i - 1)
+      else String.length name - i0
+    in
+    let rec search_dot i =
+      if i < 0 || is_dir_sep name i then 0
+      else if name.[i] = '.' then check i (i - 1)
+      else search_dot (i - 1)
+    in
+    search_dot (String.length name - 1)
+
+  let extension name =
+    let l = extension_len name in
+    if l = 0 then "" else String.sub name (String.length name - l) l
+#endif
+end
+
+module List = struct
+  include List
+
+#if OCAML_MAJOR >= 4 && OCAML_MINOR < 6
+  let rec init_aux i n f =
+    if i >= n then []
+    else (f i) :: init_aux (i+1) n f
+
+  let init n f = init_aux 0 n f
+#endif
+
+#if OCAML_MAJOR >= 4 && OCAML_MINOR < 5
+  let rec find_opt p = function
+    | [] -> None
+    | x :: l -> if p x then Some x else find_opt p l
+#endif
+end
+
+module Warnings = struct
+  include Warnings
+
+#if OCAML_MAJOR >= 4 && OCAML_MINOR < 3
+  (* Can't be overriden *)
+  let reset_fatal () = ()
+#endif
+end
+
+module Env = struct
+  include Env
+
+#if OCAML_MAJOR >= 4 && OCAML_MINOR < 3
+  (* Can't be overriden *)
+  let without_cmis f x = f x
+#endif
+end

--- a/lib/compat.ml
+++ b/lib/compat.ml
@@ -75,6 +75,15 @@ module List = struct
   let rec find_opt p = function
     | [] -> None
     | x :: l -> if p x then Some x else find_opt p l
+
+  let rec compare_length_with l n =
+    match l with
+    | [] ->
+       if n = 0 then 0 else
+         if n > 0 then -1 else 1
+    | _ :: l ->
+       if n <= 0 then 1 else
+         compare_length_with l (n-1)
 #endif
 end
 

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name        mdx)
  (public_name mdx)
  (preprocess (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
- (libraries   astring fmt logs ocaml-migrate-parsetree re))
+ (libraries   astring fmt logs ocaml-migrate-parsetree re result))
 
 (ocamllex lexer)
 (ocamllex lexer_cram)

--- a/lib/lexer_top.mll
+++ b/lib/lexer_top.mll
@@ -13,7 +13,7 @@ rule token = parse
 and phrase acc buf = parse
   | ("\n"* as nl) "\n  "
       { Lexing.new_line lexbuf;
-        let nl = List.init (String.length nl) (fun _ -> "") in
+        let nl = Migrate_ast.List.init (String.length nl) (fun _ -> "") in
         phrase (nl @ Buffer.contents buf :: acc) (Buffer.create 8) lexbuf }
   | eol
       { Lexing.new_line lexbuf;

--- a/lib/lexer_top.mll
+++ b/lib/lexer_top.mll
@@ -13,7 +13,7 @@ rule token = parse
 and phrase acc buf = parse
   | ("\n"* as nl) "\n  "
       { Lexing.new_line lexbuf;
-        let nl = Migrate_ast.List.init (String.length nl) (fun _ -> "") in
+        let nl = Compat.List.init (String.length nl) (fun _ -> "") in
         phrase (nl @ Buffer.contents buf :: acc) (Buffer.create 8) lexbuf }
   | eol
       { Lexing.new_line lexbuf;

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -22,6 +22,7 @@ module Cram = Cram
 module Toplevel = Toplevel
 module Block = Block
 module Migrate_ast = Migrate_ast
+module Compat = Compat
 
 type line =
   | Section of (int * string)

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -28,6 +28,7 @@ module Cram = Cram
 module Toplevel = Toplevel
 module Block = Block
 module Migrate_ast = Migrate_ast
+module Compat = Compat
 
 (** {2 Lines} *)
 

--- a/lib/migrate_ast.ml
+++ b/lib/migrate_ast.ml
@@ -80,10 +80,10 @@ module Printast = struct
     match x with
     | Pdir_none -> Pdir_none
     | Pdir_string s -> Pdir_string s
-#if OCAML_MAJOR >= 4 && OCAML_MINOR > 2
-    | Pdir_int (s, c) -> Pdir_int (s, c)
-#else
+#if OCAML_MAJOR = 4 && OCAML_MINOR <= 2
     | Pdir_int (s, _) -> Pdir_int (int_of_string s)
+#else
+    | Pdir_int (s, c) -> Pdir_int (s, c)
 #endif
     | Pdir_ident i -> Pdir_ident i
     | Pdir_bool b -> Pdir_bool b
@@ -107,7 +107,7 @@ module Printtyp = struct
 
   let wrap_printing_env e f =
     wrap_printing_env
-#if OCAML_MAJOR >= 4 && OCAML_MINOR >= 7
+#if (OCAML_MAJOR = 4 && OCAML_MINOR >= 7) || OCAML_MAJOR > 4
       ~error:false
 #endif
       e f

--- a/lib/migrate_ast.ml
+++ b/lib/migrate_ast.ml
@@ -24,6 +24,8 @@
  * DEALINGS IN THE SOFTWARE.
  *)
 
+open Compat
+
 (* original modules *)
 module Asttypes_ = Asttypes
 module Parsetree_ = Parsetree
@@ -119,27 +121,6 @@ module Pparse = struct
     |> to_406.copy_structure
 end
 
-module String = struct
-  include String
-
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 3
-    let equal x y = String.compare x y = 0
-#endif
-
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 4
-  let split_on_char sep s =
-    let r = ref [] in
-    let j = ref (String.length s) in
-    for i = String.length s - 1 downto 0 do
-      if String.unsafe_get s i = sep then begin
-          r := String.sub s (i + 1) (!j - i - 1) :: !r;
-          j := i
-        end
-    done;
-    String.sub s 0 !j :: !r
-#endif
-end
-
 module Position = struct
   open Lexing
 
@@ -195,73 +176,4 @@ module Location = struct
   let width x = Position.distance x.loc_start x.loc_end
 
   let compare_width_decreasing l1 l2 = (width l2) - (width l1)
-end
-
-module Result = struct
-#if OCAML_MAJOR >= 4 && OCAML_MINOR > 2
-  include Result
-#else
-  type ('a, 'b) result = Ok of 'a | Error of 'b
-#endif
-end
-
-module Filename = struct
-  include Filename
-
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 4
-  let is_dir_sep s i = s.[i] = '/' (* Unix only *)
-
-  let extension_len name =
-    let rec check i0 i =
-      if i < 0 || is_dir_sep name i then 0
-      else if name.[i] = '.' then check i0 (i - 1)
-      else String.length name - i0
-    in
-    let rec search_dot i =
-      if i < 0 || is_dir_sep name i then 0
-      else if name.[i] = '.' then check i (i - 1)
-      else search_dot (i - 1)
-    in
-    search_dot (String.length name - 1)
-
-  let extension name =
-    let l = extension_len name in
-    if l = 0 then "" else String.sub name (String.length name - l) l
-#endif
-end
-
-module List = struct
-  include List
-
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 6
-  let rec init_aux i n f =
-    if i >= n then []
-    else (f i) :: init_aux (i+1) n f
-
-  let init n f = init_aux 0 n f
-#endif
-
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 5
-  let rec find_opt p = function
-    | [] -> None
-    | x :: l -> if p x then Some x else find_opt p l
-#endif
-end
-
-module Warnings = struct
-  include Warnings
-
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 3
-  (* Can't be overriden *)
-  let reset_fatal () = ()
-#endif
-end
-
-module Env = struct
-  include Env
-
-#if OCAML_MAJOR >= 4 && OCAML_MINOR < 3
-  (* Can't be overriden *)
-  let without_cmis f x = f x
-#endif
 end

--- a/lib/output.ml
+++ b/lib/output.ml
@@ -15,6 +15,7 @@
  *)
 
 open Misc
+open Compat
 
 type t = [`Output of string | `Ellipsis]
 

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -16,6 +16,7 @@
  *)
 
 open Mdx.Migrate_ast
+open Mdx.Compat
 
 module Toploop = struct
   include Toploop
@@ -103,8 +104,6 @@ module Phrase = struct
 
   open Lexing
   open Parsetree
-
-  module Result = Mdx.Migrate_ast.Result
 
   type t = {
     doc      : Lexbuf.t;

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -104,11 +104,13 @@ module Phrase = struct
   open Lexing
   open Parsetree
 
+  module Result = Mdx.Migrate_ast.Result
+
   type t = {
     doc      : Lexbuf.t;
     startpos : position;
     endpos   : position;
-    parsed   : (toplevel_phrase, exn) result;
+    parsed   : (toplevel_phrase, exn) Result.result;
   }
 
   let result t = t.parsed
@@ -119,13 +121,18 @@ module Phrase = struct
     let lexbuf = Lexing.from_string contents in
     let startpos = lexbuf.Lexing.lex_start_p in
     let parsed = match Parse.toplevel_phrase lexbuf with
-      | phrase -> Ok phrase
+      | phrase -> Result.Ok phrase
       | exception exn ->
         let exn = match Location.error_of_exn exn with
           | None -> raise exn
+#if OCAML_MAJOR >= 4 && OCAML_MINOR > 2
           | Some `Already_displayed -> raise exn
           | Some (`Ok error) ->
             Location.Error (Lexbuf.shift_location_error startpos error)
+#else
+          | Some error ->
+            Location.Error (Lexbuf.shift_location_error startpos error)
+#endif
         in
         if lexbuf.Lexing.lex_last_action <> Lexbuf.semisemi_action then begin
           let rec aux () = match Lexer.token lexbuf with
@@ -171,7 +178,7 @@ module Rewrite = struct
     typ    : Longident.t;
     witness: Longident.t;
     runner : Longident.t;
-    rewrite: Warnings.loc -> expression -> expression;
+    rewrite: Location.t -> expression -> expression;
     mutable preload: string option;
   }
 
@@ -230,7 +237,12 @@ module Rewrite = struct
     let rec aux = function
       | []   -> pstr_item
       | h::t ->
-        let ty = normalize_type_path env (Env.lookup_type h.typ env) in
+#if OCAML_MAJOR >= 4 && OCAML_MINOR < 4
+        let looked_up_path = Env.lookup_type h.typ env |> fst in
+#else
+        let looked_up_path = Env.lookup_type h.typ env in
+#endif
+        let ty = normalize_type_path env looked_up_path in
         if Path.same ty (normalize_type_path env path) then (
           let loc = pstr_item.Parsetree.pstr_loc in
           { Parsetree.pstr_desc = Parsetree.Pstr_eval (h.rewrite loc e, []);
@@ -417,16 +429,19 @@ let eval t cmd =
               | None   -> []
             ) phrases
           |> List.concat
-          |> fun x -> if !errors then Error x else Ok x
+          |> fun x -> if !errors then Result.Error x else Result.Ok x
         ))
 
 
 let all_show_funs = ref []
 
+#if OCAML_MAJOR >= 4 && OCAML_MINOR >= 3
 let section_env = "Environment queries"
+#endif
 
 let std_out = lazy (Format.formatter_of_out_channel stdout)
 
+#if OCAML_MAJOR >= 4 && OCAML_MINOR >= 3
 let show_prim to_sig ppf lid =
   let env = !Toploop.toplevel_env in
   let loc = Location.none in
@@ -447,20 +462,25 @@ let show_prim to_sig ppf lid =
   with
   | Not_found -> Format.fprintf ppf "@[Unknown element.@]@."
   | Exit -> ()
+#endif
 
 let reg_show_prim name to_sig doc =
   let lazy ppf = std_out in
   all_show_funs := to_sig :: !all_show_funs;
+#if OCAML_MAJOR >= 4 && OCAML_MINOR >= 3
   Toploop.add_directive
     name
-    (Directive_ident (show_prim to_sig ppf))
+    (Toploop.Directive_ident (show_prim to_sig ppf))
     { section = section_env; doc }
+#else
+  ignore (name, doc, ppf)
+#endif
 
 let show_val () =
   reg_show_prim "show_val"
     (fun env loc id lid ->
        let _path, desc = Typetexp.find_value env loc lid in
-       [ Sig_value (id, desc) ]
+       [ Types.Sig_value (id, desc) ]
     )
     "Print the signature of the corresponding value."
 
@@ -485,7 +505,11 @@ let show_exception () =
        let ext =
          { ext_type_path = Predef.path_exn;
            ext_type_params = [];
+#if OCAML_MAJOR >= 4 && OCAML_MINOR < 3
+           ext_args = desc.cstr_args;
+#else
            ext_args = Cstr_tuple desc.cstr_args;
+#endif
            ext_ret_type = ret_type;
            ext_private = Asttypes_.Public;
            Types.ext_loc = desc.cstr_loc;
@@ -520,7 +544,11 @@ let show_module () =
            Sig_module (id, {md with md_type = trim_signature md.md_type},
                        Trec_not) :: acc in
          match md.md_type with
+#if OCAML_MAJOR >= 4 && OCAML_MINOR > 3
          | Mty_alias(_, path) -> accum_aliases path acc
+#else
+         | Mty_alias path -> accum_aliases path acc
+#endif
          | Mty_ident _ | Mty_signature _ | Mty_functor _ ->
            List.rev acc
        in
@@ -553,35 +581,50 @@ let show_class_type () =
     )
     "Print the signature of the corresponding class type."
 
-let show env loc id lid =
-  let sg =
-    List.fold_left
-      (fun sg f -> try (f env loc id lid) @ sg with _ -> sg)
-      [] !all_show_funs
-  in
-  if sg = [] then raise Not_found else sg
-
 let show () =
+#if OCAML_MAJOR >= 4 && OCAML_MINOR >= 3
   let lazy pp = std_out in
-  Toploop.add_directive "show" (Directive_ident (show_prim show pp))
+  let show env loc id lid =
+    let sg =
+      List.fold_left
+        (fun sg f -> try (f env loc id lid) @ sg with _ -> sg)
+        [] !all_show_funs
+    in
+    if sg = [] then raise Not_found else sg
+  in
+  Toploop.add_directive "show" (Toploop.Directive_ident (show_prim show pp))
     {
       section = section_env;
       doc = "Print the signatures of components \
              from any of the categories below.";
     }
+#else
+  ()
+#endif
 
 let verbose t =
+#if OCAML_MAJOR >= 4 && OCAML_MINOR >= 3
   Toploop.add_directive "verbose"
     (Toploop.Directive_bool (fun x -> t.verbose <- x))
     { section = section_env ; doc = "Be verbose" }
+#else
+  ignore t
+#endif
 
-let silent t = Toploop.add_directive "silent"
+let silent t =
+#if OCAML_MAJOR >= 4 && OCAML_MINOR >= 3
+  Toploop.add_directive "silent"
     (Toploop.Directive_bool (fun x -> t.silent <- x))
     { section = section_env; doc = "Be silent" }
+#else
+  ignore t
+#endif
 
 module Linked = struct
   include (Topdirs : sig end)
+#if OCAML_MAJOR >= 4 && OCAML_MINOR >= 3
   include (Ephemeron : sig end)
+#endif
   include (Uchar : sig end)
   include (Condition : sig end)
 end
@@ -662,7 +705,9 @@ let rec save_summary acc s =
       in
       save_summary acc summary
   | Env_empty -> acc
+#if OCAML_MAJOR >= 4 && OCAML_MINOR >= 4
   | Env_constraints (summary, _)
+#endif
     | Env_cltype (summary, _, _)
     | Env_modtype (summary, _, _)
     | Env_type (summary, _, _)
@@ -671,7 +716,10 @@ let rec save_summary acc s =
                 _,
                 #endif
                 _)
-    | Env_copy_types (summary, _) -> save_summary acc summary
+#if OCAML_MAJOR >= 4 && OCAML_MINOR >= 6
+    | Env_copy_types (summary, _)
+#endif
+    -> save_summary acc summary
 
 let default_env = ref (Compmisc.initial_env ())
 let first_call = ref true

--- a/lib/top/mdx_top.mli
+++ b/lib/top/mdx_top.mli
@@ -23,7 +23,10 @@ type t
 val init: verbose:bool -> silent:bool -> verbose_findlib:bool -> unit -> t
 (** [init ()] is a new configuration value. *)
 
-val eval: t -> string list -> (string list, string list) result
+val eval:
+  t
+  -> string list
+  -> (string list, string list) Mdx.Migrate_ast.Result.result
 (** [eval t p] evaluates the toplevel phrase [p] (possibly spawning on
     mulitple lines) with the configuration value [t]. *)
 

--- a/lib/top/mdx_top.mli
+++ b/lib/top/mdx_top.mli
@@ -15,6 +15,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Result
+
 (** Toplevel logic for [mdx]. *)
 
 type t
@@ -23,10 +25,7 @@ type t
 val init: verbose:bool -> silent:bool -> verbose_findlib:bool -> unit -> t
 (** [init ()] is a new configuration value. *)
 
-val eval:
-  t
-  -> string list
-  -> (string list, string list) Result.result
+val eval: t -> string list -> (string list, string list) result
 (** [eval t p] evaluates the toplevel phrase [p] (possibly spawning on
     mulitple lines) with the configuration value [t]. *)
 

--- a/lib/top/mdx_top.mli
+++ b/lib/top/mdx_top.mli
@@ -26,7 +26,7 @@ val init: verbose:bool -> silent:bool -> verbose_findlib:bool -> unit -> t
 val eval:
   t
   -> string list
-  -> (string list, string list) Mdx.Migrate_ast.Result.result
+  -> (string list, string list) Result.result
 (** [eval t p] evaluates the toplevel phrase [p] (possibly spawning on
     mulitple lines) with the configuration value [t]. *)
 

--- a/lib/top/part.ml
+++ b/lib/top/part.ml
@@ -15,6 +15,7 @@
  *)
 
 open Mdx.Migrate_ast
+open Mdx.Compat
 
 module Part = struct
 

--- a/lib/top/part.ml
+++ b/lib/top/part.ml
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Mdx.Migrate_ast
+
 module Part = struct
 
   type t =

--- a/mdx.opam
+++ b/mdx.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.02.3"}
   "dune" {build}
   "fmt"
   "cppo"

--- a/mdx.opam
+++ b/mdx.opam
@@ -22,6 +22,7 @@ depends: [
   "logs"
   "cmdliner"
   "re" {>= "1.7.2"}
+  "result"
   "ocaml-migrate-parsetree" {>= "1.0.6"}
   "lwt" {with-test}
   "conf-pandoc" {with-test}

--- a/test/padding.md
+++ b/test/padding.md
@@ -11,7 +11,6 @@ Arbitrary padding is allowed, as long as it is consistent inside a code block.
 ```
 
 ```sh
-$ ocaml -warn-help | egrep '\b9\b'
+$ ocaml -warn-help | egrep '\b9 Missing\b'
   9 Missing fields in a record pattern.
-  R Alias for warning 9.
 ```


### PR DESCRIPTION
4.02.3 support for PR #85 

I tried to minimize the impact on `mdx_top.ml` but there is a lot of differences between 4.02 and 4.06/07.

Regressions:

# 4.02.3

```
--- test/padding.md	2018-11-28 09:16:32.886114184 +0700
+++ test/padding.md.corrected	2018-11-28 09:19:40.622040315 +0700
@@ -13,5 +13,5 @@
 ```sh
 $ ocaml -warn-help | egrep '\b9\b'
   9 Missing fields in a record pattern.
-  R Alias for warning 9.
+  R warning 9
 ```

```
--- test/errors.md	2018-11-28 09:16:32.886114184 +0700
+++ test/errors.md.corrected	2018-11-28 09:19:40.670040350 +0700
@@ -33,7 +33,7 @@
 # let x =
   1 + "42"
 Characters 14-18:
-Error: This expression has type string but an expression was expected of type
+Error: This expression has type bytes but an expression was expected of type
          int
 ```

``` 
--- test/mlt.md	2018-11-28 09:16:32.886114184 +0700
+++ test/mlt.md.corrected	2018-11-28 09:19:40.718040384 +0700
@@ -6,6 +6,6 @@
 val x : int = 3
 # x + "foo";;
 Characters 4-9:
-Error: This expression has type string but an expression was expected of type
+Error: This expression has type bytes but an expression was expected of type
          int
 ```

```
--- test/lines.md	2018-11-28 09:16:32.886114184 +0700
+++ test/lines.md.corrected	2018-11-28 09:19:40.798040441 +0700
@@ -13,7 +13,7 @@
 val f : int -> int = <fun>
 # let f y =
   y^"foo"
-val f : string -> string = <fun>
+val f : bytes -> bytes = <fun>
 ```
 
 ```
--- test/lines.md	2018-11-28 09:16:32.886114184 +0700
+++ test/lines.md.corrected	2018-11-28 09:19:40.798040441 +0700
@@ -24,7 +24,7 @@
   | n ->
   n + "foo"
 Characters 45-50:
-Error: This expression has type string but an expression was expected of type
+Error: This expression has type bytes but an expression was expected of type
          int
 ```