### PR TITLE
improve lexer error with a malformed toplevel line

### DIFF
--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -255,7 +255,7 @@ let update_file_or_block ?root ppf md_file ml_file block direction =
   | `To_ml ->
      update_file_with_block ppf block ml_file (Block.part block)
 
-let run ()
+let run_exn ()
     non_deterministic not_verbose silent verbose_findlib prelude prelude_str
     file section root direction
   =
@@ -359,6 +359,15 @@ let run ()
   Hashtbl.iter write_parts files;
   0
 
+let run ()
+    non_deterministic not_verbose silent verbose_findlib prelude prelude_str
+    file section root direction
+  =
+    try
+    run_exn () non_deterministic not_verbose silent verbose_findlib prelude prelude_str
+    file section root direction
+    with Failure f -> prerr_endline f; exit 1
+ 
 (**** Cmdliner ****)
 
 open Cmdliner

--- a/lib/lexer_top.mll
+++ b/lib/lexer_top.mll
@@ -9,6 +9,7 @@ rule token = parse
                    `Command c :: token lexbuf }
  | ([^'#' '\n'] [^'\n']* as str) eol
                  { `Output str :: token lexbuf }
+ | _ as c        { failwith (Printf.sprintf "unexpected character '%c'. Did you forget a space after the '#' at the start of the line?" c) }
 
 and phrase acc buf = parse
   | ("\n"* as nl) "\n  "
@@ -24,5 +25,5 @@ and phrase acc buf = parse
 {
 let token lexbuf =
   try token lexbuf
-  with Failure _ -> Misc.err lexbuf "incomplete toplevel"
+  with Failure e -> Misc.err lexbuf "incomplete toplevel entry: %s" e
 }


### PR DESCRIPTION
e.g.: #foo will now output a proper error message

Also catch Failure exceptions exit properly rather than
showing an exception backtrace in mdx