### PR TITLE
Reintroduce craml syntax

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -4,6 +4,22 @@ let non_deterministic =
   let doc = "Run non-deterministic tests." in
   Arg.(value & flag & info ["non-deterministic"; "n"] ~doc)
 
+let syntax =
+  let parse = function
+    | "normal" -> `Ok Mdx.Normal
+    | "cram" -> `Ok Mdx.Cram
+    | s -> `Error (Format.sprintf "unrecognized syntax %S" s)
+  in
+  let print fmt syn =
+    Format.fprintf fmt "%s"
+      (match syn with
+       | Mdx.Normal -> "normal"
+       | Mdx.Cram -> "cram")
+  in
+  let syntax = parse, print in
+  let doc = "Which syntax to use. Either 'normal' or 'cram'." in
+  Arg.(value & opt (some syntax) None & info ["syntax"] ~doc ~docv:"SYNTAX")
+
 let file =
   let doc = "The file to use." in
   Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:"FILE")

--- a/bin/dune
+++ b/bin/dune
@@ -1,7 +1,7 @@
 (library
  (name      cli)
  (modules   cli)
- (libraries cmdliner fmt.cli logs.fmt fmt.tty logs.cli))
+ (libraries cmdliner fmt.cli logs.fmt fmt.tty logs.cli mdx))
 
 (executable
  (name        main)

--- a/bin/output.ml
+++ b/bin/output.ml
@@ -85,7 +85,7 @@ let pp_block ppf (b:Mdx.Block.t) =
     pp_attrs () pp_lang () pp_code
 
 let run () file output =
-  let t = Mdx.parse_file file in
+  let t = Mdx.parse_file Normal file in
   match t with
   | [] -> 1
   | _  ->

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -18,7 +18,7 @@ let src = Logs.Src.create "cram.pp"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let run () file section =
-  let t = Mdx.parse_file file in
+  let t = Mdx.parse_file Normal file in
   let t = match section with
     | None   -> t
     | Some s ->

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -38,7 +38,7 @@ open Cmdliner
 let cmd: int Term.t * Term.info =
   let doc = "Test markdown files." in
   Term.(pure run
-        $ Cli.setup $ Cli.non_deterministic $ Cli.not_verbose
+        $ Cli.setup $ Cli.non_deterministic $ Cli.not_verbose $ Cli.syntax
         $ Cli.silent $ Cli.verbose_findlib $ Cli.prelude $ Cli.prelude_str
         $ Cli.file $ Cli.section $ Cli.root $ Cli.direction),
   Term.info "test" ~doc

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -93,8 +93,13 @@ let root_dir ?root t =
   | Some r, Some d -> Some (r / d)
   | Some d, None   -> Some d
 
-let run_cram_tests t ?root ppf temp_file pad tests =
-  Block.pp_header ppf t;
+let run_cram_tests ?syntax t ?root ppf temp_file pad tests =
+  Block.pp_header ?syntax ppf t;
+  let pad =
+    match syntax with
+    | Some Cram -> pad + 2
+    | _ -> pad
+  in
   List.iter (fun test ->
       let root = root_dir ?root t in
       let n = run_test ?root temp_file test in
@@ -113,7 +118,7 @@ let run_cram_tests t ?root ppf temp_file pad tests =
         ) output;
       Cram.pp_exit_code ~pad ppf n;
     ) tests;
-  Block.pp_footer ppf ()
+  Block.pp_footer ?syntax ppf ()
 
 let eval_test t ?root c test =
   Log.debug (fun l ->
@@ -299,28 +304,29 @@ let run_exn ()
       let ppf = Format.formatter_of_buffer buf in
       List.iter (function
           | Section _
-          | Text _ as t -> Mdx.pp_line ppf t
+          | Text _ as t -> Mdx.pp_line ?syntax ppf t
           | Block t ->
             Mdx_top.in_env (Block.environment t)
               (fun () ->
                  let active = active t && (not (Block.skip t)) in
                  match active, non_deterministic, Block.mode t, Block.value t with
                  (* Print errors *)
-                 | _, _, _, Error _ -> Block.pp ppf t
+                 | _, _, _, Error _ -> Block.pp ?syntax ppf t
                  (* Skip raw blocks. *)
-                 | true, _, _, Raw -> Block.pp ppf t
+                 | true, _, _, Raw -> Block.pp ?syntax ppf t
                  (* The command is not active, skip it. *)
-                 | false, _, _, _ -> Block.pp ppf t
+                 | false, _, _, _ -> Block.pp ?syntax ppf t
                  (* the command is active but non-deterministic so skip everything *)
-                 | true, false, `Non_det `Command, _ -> Block.pp ppf t
+                 | true, false, `Non_det `Command, _ -> Block.pp ?syntax ppf t
                  (* the command is active but it's output is
                     non-deterministic; run it but keep the old output. *)
                  | true, false, `Non_det `Output, Cram { tests; _ } ->
-                   Block.pp ppf t;
+                   Block.pp ?syntax ppf t;
                    List.iter (fun t ->
                        let _: int = run_test ?root temp_file t in ()
                      ) tests
                  | true, false, `Non_det `Output, Toplevel tests ->
+                   assert (syntax <> Some Cram);
                    Block.pp ppf t;
                    List.iter (fun test ->
                        match eval_test t ?root c test with
@@ -332,6 +338,7 @@ let run_exn ()
                      ) tests
                  (* Run raw OCaml code *)
                  | true, _, _, OCaml ->
+                   assert (syntax <> Some Cram);
                    let version_enabled = Block.version_enabled t in
                    (match Block.file t with
                     | Some ml_file when version_enabled ->
@@ -342,9 +349,10 @@ let run_exn ()
                     | _ -> Block.pp ppf t )
                  (* Cram tests. *)
                  | true, _, _, Cram { tests; pad } ->
-                   run_cram_tests t ?root ppf temp_file pad tests
+                   run_cram_tests ?syntax t ?root ppf temp_file pad tests
                  (* Top-level tests. *)
                  | true, _, _, Toplevel tests ->
+                   assert (syntax <> Some Cram);
                    let version_enabled = Block.version_enabled t in
                    match Block.file t with
                    | Some ml_file when version_enabled ->

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -256,8 +256,8 @@ let update_file_or_block ?root ppf md_file ml_file block direction =
      update_file_with_block ppf block ml_file (Block.part block)
 
 let run_exn ()
-    non_deterministic not_verbose silent verbose_findlib prelude prelude_str
-    file section root direction
+    non_deterministic not_verbose syntax silent verbose_findlib prelude
+    prelude_str file section root direction
   =
   let c =
     Mdx_top.init ~verbose:(not not_verbose) ~silent ~verbose_findlib ()
@@ -292,7 +292,7 @@ let run_exn ()
     | _ -> Fmt.failwith "only one of --prelude or --prelude-str shoud be used"
   in
 
-  Mdx.run file ~f:(fun file_contents items ->
+  Mdx.run ?syntax file ~f:(fun file_contents items ->
       let temp_file = Filename.temp_file "mdx" ".output" in
       at_exit (fun () -> Sys.remove temp_file);
       let buf = Buffer.create (String.length file_contents + 1024) in
@@ -360,12 +360,12 @@ let run_exn ()
   0
 
 let run ()
-    non_deterministic not_verbose silent verbose_findlib prelude prelude_str
-    file section root direction
+    non_deterministic not_verbose syntax silent verbose_findlib prelude
+    prelude_str file section root direction
   =
     try
-    run_exn () non_deterministic not_verbose silent verbose_findlib prelude prelude_str
-    file section root direction
+    run_exn () non_deterministic not_verbose syntax silent verbose_findlib
+      prelude prelude_str file section root direction
     with Failure f -> prerr_endline f; exit 1
  
 (**** Cmdliner ****)
@@ -377,7 +377,7 @@ let cmd =
   let man = [] in
   let doc = "Test markdown files." in
   Term.(pure run
-        $ Cli.setup $ Cli.non_deterministic $ Cli.not_verbose
+        $ Cli.setup $ Cli.non_deterministic $ Cli.not_verbose $ Cli.syntax
         $ Cli.silent $ Cli.verbose_findlib $ Cli.prelude $ Cli.prelude_str
         $ Cli.file $ Cli.section $ Cli.root $ Cli.direction),
   Term.info "mdx-test" ~version:"%%VERSION%%" ~doc ~exits ~man

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -92,10 +92,9 @@ let pp_lines syntax =
   Fmt.(list ~sep:(unit "\n") pp)
 let pp_contents ?syntax ppf t = Fmt.pf ppf "%a\n" (pp_lines syntax) t.contents
 let pp_footer ?syntax ppf () =
-  Fmt.string ppf
-    (match syntax with
-     | Some Syntax.Cram -> "\n"
-     | _ -> "```\n")
+  match syntax with
+  | Some Syntax.Cram -> ()
+  | _ -> Fmt.string ppf "```\n"
 
 let pp_cmp ppf = function
   | `Eq -> Fmt.pf ppf "="

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -83,9 +83,19 @@ let dump ppf { file; line; section; labels; header; contents; value } =
     Fmt.(Dump.list dump_string) contents
     dump_value value
 
-let pp_lines pp = Fmt.(list ~sep:(unit "\n") pp)
-let pp_contents ppf t = Fmt.pf ppf "%a\n" (pp_lines Fmt.string) t.contents
-let pp_footer ppf () = Fmt.string ppf "```\n"
+let pp_lines syntax =
+  let pp =
+    match syntax with
+    | Some Syntax.Cram -> Fmt.fmt "  %s"
+    | _ -> Fmt.string
+  in
+  Fmt.(list ~sep:(unit "\n") pp)
+let pp_contents ?syntax ppf t = Fmt.pf ppf "%a\n" (pp_lines syntax) t.contents
+let pp_footer ?syntax ppf () =
+  Fmt.string ppf
+    (match syntax with
+     | Some Syntax.Cram -> "\n"
+     | _ -> "```\n")
 
 let pp_cmp ppf = function
   | `Eq -> Fmt.pf ppf "="
@@ -103,19 +113,33 @@ let pp_labels ppf = function
   | [] -> ()
   | l  -> Fmt.pf ppf " %a" Fmt.(list ~sep:(unit ",") pp_label) l
 
-let pp_header ppf t =
-  Fmt.pf ppf "```%a%a\n" Fmt.(option string) t.header pp_labels t.labels
+let pp_header ?syntax ppf t =
+  match syntax with
+  | Some Syntax.Cram ->
+    assert (t.header = Syntax.cram_default_header);
+    begin match t.labels with
+    | [] -> ()
+    | ["non-deterministic", Some (`Eq, choice)] ->
+      Fmt.pf ppf "<-- non-deterministic %s\n" choice
+    | _ ->
+      let err =
+        Fmt.strf "Block.pp_header: [ %a ]" pp_labels t.labels
+      in
+      invalid_arg err
+    end
+  | _ ->
+    Fmt.pf ppf "```%a%a\n" Fmt.(option string) t.header pp_labels t.labels
 
 let pp_error ppf b =
   match b.value with
   | Error e -> List.iter (fun e -> Fmt.pf ppf ">> @[<h>%a@]@." Fmt.words e) e
   | _ -> ()
 
-let pp ppf b =
-  pp_header ppf b;
+let pp ?syntax ppf b =
+  pp_header ?syntax ppf b;
   pp_error ppf b;
-  pp_contents ppf b;
-  pp_footer ppf ()
+  pp_contents ?syntax ppf b;
+  pp_footer ?syntax ppf ()
 
 let labels = [
   "dir"              , [`Any];

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -49,16 +49,16 @@ val empty: t
 val dump: t Fmt.t
 (** [dump] is the printer for dumping code blocks. Useful for debugging. *)
 
-val pp_header: t Fmt.t
+val pp_header: ?syntax:Syntax.t -> t Fmt.t
 (** [pp_header] pretty-prints block headers. *)
 
-val pp_contents: t Fmt.t
+val pp_contents: ?syntax:Syntax.t -> t Fmt.t
 (** [pp_contents] pretty-prints block contents. *)
 
-val pp_footer: unit Fmt.t
+val pp_footer: ?syntax:Syntax.t -> unit Fmt.t
 (** [pp_footer] pretty-prints block footer. *)
 
-val pp: t Fmt.t
+val pp: ?syntax:Syntax.t -> t Fmt.t
 (** [pp] pretty-prints blocks. *)
 
 val pp_line_directive: (string * int) Fmt.t

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -78,7 +78,12 @@ and cram_block = parse
   | "  " ([^'\n'] * as str) eol { str :: cram_block lexbuf }
 
 {
-let token lexbuf =
-  try text None lexbuf
+type syntax = Normal | Cram
+
+let token syntax lexbuf =
+  try
+    match syntax with
+    | Normal -> text      None lexbuf
+    | Cram   -> cram_text None lexbuf
   with Failure _ -> Misc.err lexbuf "incomplete code block"
 }

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -6,6 +6,8 @@ let line_ref = ref 1
 let newline lexbuf =
   Lexing.new_line lexbuf;
   incr line_ref
+
+let cram_header = Some "sh" (* FIXME: bash? *)
 }
 
 let eol = '\n' | eof
@@ -36,6 +38,45 @@ rule text section = parse
 and block = parse
   | eof | "```" ws* eol    { [] }
   | ([^'\n'] * as str) eol { str :: block lexbuf }
+
+
+and cram_text section = parse
+  | eof { [] }
+  | ("#"+ as n) " " ([^'\n']* as str) eol
+      { let section = (String.length n, str) in
+        newline lexbuf;
+        `Section section :: cram_text (Some section) lexbuf }
+  | "  " ([^'\n']* as first_line) eol
+      { let header = cram_header in
+        let contents = first_line :: cram_block lexbuf in
+        let labels = [] in
+        let value = Block.Raw in
+        let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
+        let line = !line_ref in
+        List.iter (fun _ -> newline lexbuf) contents;
+        newline lexbuf;
+        `Block { Block.file; line; section; header; contents; labels; value }
+        :: cram_text section lexbuf }
+  | "<-- non-deterministic" ws* (("command"|"output") as choice) eol
+      { let header = cram_header in
+        let contents = cram_block lexbuf in
+        let labels = ["non-deterministic", Some (`Eq, choice)] in
+        let value = Block.Raw in
+        let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
+        newline lexbuf;
+        let line = !line_ref in
+        List.iter (fun _ -> newline lexbuf) contents;
+        newline lexbuf;
+        `Block { Block.file; line; section; header; contents; labels; value }
+        :: cram_text section lexbuf }
+  | ([^'\n']* as str) eol
+      { newline lexbuf;
+        `Text str :: cram_text section lexbuf }
+
+and cram_block = parse
+  | eof | eol                   { [] }
+  | "  " ([^'\n'] * as str) eol { str :: cram_block lexbuf }
+
 {
 let token lexbuf =
   try text None lexbuf

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -38,12 +38,13 @@ let dump_line ppf (l: line) = match l with
 
 let dump = Fmt.Dump.list dump_line
 
-let pp_line ppf (l: line) = match l with
-  | Block b        -> Fmt.pf ppf "%a\n" Block.pp b
+let pp_line ?syntax ppf (l: line) = match l with
+  | Block b        -> Fmt.pf ppf "%a\n" (Block.pp ?syntax) b
   | Section (d, s) -> Fmt.pf ppf "%s %s\n" (String.make d '#') s
   | Text s         -> Fmt.pf ppf "%s\n" s
 
-let pp ppf t = Fmt.pf ppf "%a\n" Fmt.(list ~sep:(unit "\n") pp_line) t
+let pp ?syntax ppf t =
+  Fmt.pf ppf "%a\n" Fmt.(list ~sep:(unit "\n") (pp_line ?syntax)) t
 
 let to_string = Fmt.to_to_string pp
 
@@ -69,7 +70,7 @@ let parse l =
       | `Block b   -> Block b
     ) l
 
-type syntax = Lexer.syntax =
+type syntax = Syntax.t =
   | Normal
   | Cram
 

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -83,9 +83,9 @@ let eval = function
     let t' = Block.eval t in
     if t == t' then x else Block t'
 
-let run ~f n =
+let run ?(syntax=Normal) ~f n =
   Misc.run_expect_test n ~f:(fun c l ->
-      let items = parse_lexbuf Normal l in
+      let items = parse_lexbuf syntax l in
       let items = List.map eval items in
       Log.debug (fun l -> l "run @[%a@]" dump items);
       f c items

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -69,9 +69,13 @@ let parse l =
       | `Block b   -> Block b
     ) l
 
-let parse_lexbuf l = parse (Lexer.token l)
-let parse_file f = parse (Lexer.token (snd (Misc.init f)))
-let of_string s = parse_lexbuf (Lexing.from_string s)
+type syntax = Lexer.syntax =
+  | Normal
+  | Cram
+
+let parse_lexbuf syntax l = parse (Lexer.token syntax l)
+let parse_file syntax f = parse (Lexer.token syntax (snd (Misc.init f)))
+let of_string syntax s = parse_lexbuf syntax (Lexing.from_string s)
 
 let eval = function
   | Section _ | Text _ as x -> x
@@ -81,7 +85,7 @@ let eval = function
 
 let run ~f n =
   Misc.run_expect_test n ~f:(fun c l ->
-      let items = parse_lexbuf l in
+      let items = parse_lexbuf Normal l in
       let items = List.map eval items in
       Log.debug (fun l -> l "run @[%a@]" dump items);
       f c items

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -32,31 +32,34 @@ module Compat = Compat
 
 (** {2 Lines} *)
 
-(** The type for the lines of a markdown file. *)
+type syntax = Syntax.t =
+  | Normal
+  | Cram
+
+(** The type for the lines of a markdown or cram file. *)
 type line =
   | Section of (int * string)
   | Text    of string
   | Block   of Block.t
 
-val pp_line: line Fmt.t
-(** [pp_line] is the pretty-printer for markdown lines. *)
+val pp_line: ?syntax:syntax -> line Fmt.t
+(** [pp_line] is the pretty-printer for markdown or cram lines. *)
 
 (** {2 Document} *)
 
 type t = line list
 (** The type for mdx documents. *)
 
-val pp: t Fmt.t
+val pp: ?syntax:syntax -> t Fmt.t
 (** [pp] is the pretty printer for mdx documents. Should be idempotent
    with {!of_string}. *)
-
-type syntax = Normal | Cram
 
 val to_string: t -> string
 (** [to_string t] converts the document [t] to a string. *)
 
 val of_string: syntax -> string -> t
-(** [of_string syn s] is the document [t] such that [to_string t = s]. *)
+(** [of_string syntax s] is the document [t] such that
+    [to_string ~syntax t = s]. *)
 
 val parse_file: syntax -> string ->  t
 (** [parse_file s] is {!of_string} of [s]'s contents. *)

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -50,16 +50,18 @@ val pp: t Fmt.t
 (** [pp] is the pretty printer for mdx documents. Should be idempotent
    with {!of_string}. *)
 
+type syntax = Normal | Cram
+
 val to_string: t -> string
 (** [to_string t] converts the document [t] to a string. *)
 
-val of_string: string -> t
-(** [of_string s] is the document [t] such that [to_string t = s]. *)
+val of_string: syntax -> string -> t
+(** [of_string syn s] is the document [t] such that [to_string t = s]. *)
 
-val parse_file: string ->  t
+val parse_file: syntax -> string ->  t
 (** [parse_file s] is {!of_string} of [s]'s contents. *)
 
-val parse_lexbuf: Lexing.lexbuf -> t
+val parse_lexbuf: syntax -> Lexing.lexbuf -> t
 (** [parse_lexbuf l] is {!of_string} of [l]'s contents. *)
 
 (** {2 Evaluation} *)

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -66,8 +66,8 @@ val parse_lexbuf: syntax -> Lexing.lexbuf -> t
 
 (** {2 Evaluation} *)
 
-val run: f:(string -> t -> string) -> string -> unit
-(** [run ~f n] runs the expect callback [f] over the file named
+val run: ?syntax:syntax -> f:(string -> t -> string) -> string -> unit
+(** [run ?syntax ~f n] runs the expect callback [f] over the file named
    [n]. [f] is called with the raw contents of [n] and its structured
    contents; it returns the new file contents. If the result of [f] is
    different from the initial contents, then [$n.corrected] is created

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -1,0 +1,3 @@
+type t = Normal | Cram
+
+let cram_default_header = Some "sh" (* FIXME: bash? *)

--- a/test/cram.t
+++ b/test/cram.t
@@ -1,0 +1,76 @@
+Test that cram syntax is fully supported.
+
+# Copy of ellipsis.md
+
+Long lines can be replaced by ellipsis:
+
+  $ for i in `seq 1 10`; do echo $i; done
+  1
+  2
+  ...
+  10
+
+  $ echo "foo\"\n\nbar"
+  foo"
+  
+  ...
+
+Lines ending with ellipsis
+
+  $ echo Hello world
+  Hello...
+
+# Copy of exit.md
+
+  $ exit 0
+
+  $ exit 1
+  [1]
+  $ exit 10
+  [10]
+
+# Subset of non-det.md
+
+<-- non-deterministic output
+  $ echo $RANDOM
+  4150
+
+<-- non-deterministic command
+  $ touch toto
+
+# Copy of heredoc.md
+
+Support for heredoc syntax:
+
+  $ cat <<EOF \
+  > hello\
+  > world\
+  > EOF
+  hello
+  world
+  $ echo foo
+  foo
+
+And
+
+  $ cat <<EOF > foo \
+  > hello\
+  > world\
+  > EOF
+  $ cat foo
+  hello
+  world
+  $ echo foo
+  foo
+
+# Subset of multilines.md
+
+Test multi-lines shell commands:
+
+  $ for i in `seq 1 10`; do \
+  >   echo $i; \
+  > done
+  1
+  ...
+  10
+

--- a/test/dune
+++ b/test/dune
@@ -63,6 +63,13 @@
 
 (alias
  (name   runtest)
+ (deps   (:x cram.t) (package mdx))
+ (action (progn
+           (run mdx test --syntax=cram %{x})
+           (diff? %{x} %{x}.corrected))))
+
+(alias
+ (name   runtest)
  (deps   (:x errors.md) (package mdx))
  (action (progn
            (run mdx test %{x})


### PR DESCRIPTION
Enabled by `--syntax=cram`, that seemed cleaner than matching on the file ext.