### PR TITLE
Correction of tests on ellipsis/cram

### DIFF
--- a/test/cram.t
+++ b/test/cram.t
@@ -10,7 +10,7 @@ Long lines can be replaced by ellipsis:
   ...
   10
 
-  $ echo "foo\"\n\nbar"
+  $ echo -e "foo\"\n\nbar"
   foo"
   
   ...

--- a/test/cram.t
+++ b/test/cram.t
@@ -10,7 +10,7 @@ Long lines can be replaced by ellipsis:
   ...
   10
 
-  $ echo -e "foo\"\n\nbar"
+  $ printf "foo\"\n\nbar"
   foo"
   
   ...

--- a/test/ellipsis.md
+++ b/test/ellipsis.md
@@ -19,7 +19,7 @@ $ for i in `seq 1 10`; do echo $i; done
 ```
 
 ```sh
-$ echo "foo\"\n\nbar"
+$ echo -e "foo\"\n\nbar"
 foo"
 
 ...

--- a/test/ellipsis.md
+++ b/test/ellipsis.md
@@ -19,7 +19,7 @@ $ for i in `seq 1 10`; do echo $i; done
 ```
 
 ```sh
-$ echo -e "foo\"\n\nbar"
+$ printf "foo\"\n\nbar"
 foo"
 
 ...


### PR DESCRIPTION
Tests are not passing on my computer:
Indeed, the new tests using "echo" does not specify the flag -e which, AFAIK, are needed for the command to interpret most of the backslash escapes.

Did the tests pass on your computer @trefis ? I thought the "-e" option was common to every implementation of echo