### PR TITLE
Solved bug occuring when a top-level command outputs an empty line

### DIFF
--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -363,7 +363,7 @@ let trim_line str =
   if len = 0 then str else
     let trim_from = if str.[0] = '\n' then 1 else 0 in
     let trim_to = if str.[len - 1] = '\n' then len - 1 else len in
-    String.sub str trim_from (trim_to - trim_from)
+    if trim_to - trim_from <= 0 then "" else String.sub str trim_from (trim_to - trim_from)
 
 let rtrim l = List.rev (ltrim (List.rev l))
 let trim l = ltrim (rtrim (List.map trim_line l))

--- a/test/dune
+++ b/test/dune
@@ -42,6 +42,13 @@
 
 (alias
  (name   runtest)
+ (deps   (:x empty_line.md) (package mdx))
+ (action (progn
+           (run mdx test %{x})
+           (diff? %{x} %{x}.corrected))))
+
+(alias
+ (name   runtest)
  (deps   (:x empty_lines.md) (:y empty_lines.md.expected) (package mdx))
  (action (progn
            (run mdx test %{x})

--- a/test/empty_line.md
+++ b/test/empty_line.md
@@ -1,0 +1,8 @@
+Testing empty line output
+
+```ocaml
+# print_newline ()
+- : unit = ()
+# print_endline ""
+- : unit = ()
+```


### PR DESCRIPTION
Short commit solving a bug occurring when a top-level command generates an empty line output, which throws an `Invalid_argument("String.sub / Bytes.sub") error`.
e.g:
```ocaml
# print_newline ();;
```
Add an additional test checking if the error does not occurs anymore.

Fix issue [#98](https://github.com/realworldocaml/mdx/issues/98)

#### Details:
In file mdx_top.ml, function trim_line, line 361 to 366:
When the string str is "\n",
 * len = 1
 * str.[0] = '\n', therefore trim_from is set to 1
 * str.[len - 1] = str.[0] = '\n', therefore trim_to is set to len - 1 = 0

Then String.sub is called with 0 and 0 - 1 = -1, which raises the error