### PR TITLE
Replaced some occurence of mdx for ocaml-mdx

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+### 1.3.0 (2019-03-01)
+- Updated readme file with the new features: dune rules, named environment and
+  ocaml versions, Some grammar correction too (@gpetiot, #101, aantron, #102)
+- Better lexer error messages (@avsm, #103)
+- Added cram syntax parsing (@trefis, #106)
+- Renamed mdx to ocaml-mdx to avoid conflicts/for more precision (@clecat, #110, #115)
+- Fix blank spaces causing parsing errors (@gpetiot, #97)
+- Fix empty lines causing a String.sub (@clecat, #107)
+
 ### 1.2.0 (2018-01-03)
 
 - Support end-of-line ellipsis (@dra27, #85)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -24,7 +24,7 @@ let main =
   let exits = Term.default_exits in
   let man = [] in
   Term.(ret (const main $ Cli.setup)),
-  Term.info "mdx" ~version:"%%VERSION%%" ~doc ~exits ~man
+  Term.info "ocaml-mdx" ~version:"%%VERSION%%" ~doc ~exits ~man
 
 let main () = Term.(exit_status @@ eval_choice main cmds)
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -28,4 +28,12 @@ let main =
 
 let main () = Term.(exit_status @@ eval_choice main cmds)
 
+let main () = 
+  if String.compare (Sys.argv).(0) "mdx" == 0
+  then
+    Format.eprintf
+    "\x1b[0;1mWarning\x1b[0m: 'mdx' is deprecated and will one day be removed.
+    Use 'ocaml-mdx' instead\n%!";
+  main ()
+
 let () = main ()

--- a/bin/output.ml
+++ b/bin/output.ml
@@ -89,7 +89,7 @@ let run () file output =
   match t with
   | [] -> 1
   | _  ->
-    let tmp = Filename.temp_file "mdx" "pandoc" in
+    let tmp = Filename.temp_file "ocaml-mdx" "pandoc" in
     let oc = open_out tmp in
     let ppf = Format.formatter_of_out_channel oc in
     List.iter (function

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -81,7 +81,7 @@ let print_rule ~nd ~prelude ~md_file ~ml_files ~dirs ~root options =
 \ (name   %s)\n\
 \ (deps   (:x %s)%s)\n\
 \ (action (progn\n\
-\           (run mdx test %a %s%s%%{x})\n\
+\           (run ocaml-mdx test %a %s%s%%{x})\n\
 \           (diff? %%{x} %%{x}.corrected)\n%a)))\n"
       name
       md_file

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -298,7 +298,7 @@ let run_exn ()
   in
 
   Mdx.run ?syntax file ~f:(fun file_contents items ->
-      let temp_file = Filename.temp_file "mdx" ".output" in
+      let temp_file = Filename.temp_file "ocaml-mdx" ".output" in
       at_exit (fun () -> Sys.remove temp_file);
       let buf = Buffer.create (String.length file_contents + 1024) in
       let ppf = Format.formatter_of_buffer buf in
@@ -388,7 +388,7 @@ let cmd =
         $ Cli.setup $ Cli.non_deterministic $ Cli.not_verbose $ Cli.syntax
         $ Cli.silent $ Cli.verbose_findlib $ Cli.prelude $ Cli.prelude_str
         $ Cli.file $ Cli.section $ Cli.root $ Cli.direction),
-  Term.info "mdx-test" ~version:"%%VERSION%%" ~doc ~exits ~man
+  Term.info "ocaml-mdx-test" ~version:"%%VERSION%%" ~doc ~exits ~man
 
 let main () = Term.(exit_status @@ eval cmd)
 

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let src = Logs.Src.create "mdx"
+let src = Logs.Src.create "ocaml-mdx"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 open Astring

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let src = Logs.Src.create "mdx"
+let src = Logs.Src.create "ocaml-mdx"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 module Output = Output

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -28,7 +28,7 @@ end
 let redirect ~f =
   let stdout_backup = Unix.dup Unix.stdout in
   let stderr_backup = Unix.dup Unix.stdout in
-  let filename = Filename.temp_file "mdx" "stdout" in
+  let filename = Filename.temp_file "ocaml-mdx" "stdout" in
   let fd_out = Unix.openfile filename Unix.[O_WRONLY; O_CREAT; O_TRUNC] 0o600 in
   Unix.dup2 fd_out Unix.stdout;
   Unix.dup2 fd_out Unix.stderr;
@@ -331,7 +331,7 @@ let toplevel_exec_phrase t ppf p = match Phrase.result p with
     in
     let phrase = match phrase with
       | Ptop_dir _ as x -> x
-      | Ptop_def s -> Ptop_def (Pparse.apply_rewriters_str ~tool_name:"mdx" s)
+      | Ptop_def s -> Ptop_def (Pparse.apply_rewriters_str ~tool_name:"ocaml-mdx" s)
     in
     Rewrite.preload t.verbose_findlib ppf;
     let phrase = Rewrite.phrase phrase in

--- a/lib/toplevel.ml
+++ b/lib/toplevel.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let src = Logs.Src.create "mdx"
+let src = Logs.Src.create "ocaml-mdx"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 open Astring

--- a/mdx.opam
+++ b/mdx.opam
@@ -30,10 +30,10 @@ depends: [
 
 synopsis: "Executable code blocks inside markdown files"
 description: """
-`mdx` allows to execute code blocks inside markdown files.
+`ocaml-mdx` allows to execute code blocks inside markdown files.
 There are (currently) two sub-commands, corresponding
-to two modes of operations: pre-processing (`mdx pp`)
-and tests (`mdx test`).
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
 
 The pre-processor mode allows to mix documentation and code,
 and to practice "literate programming" using markdown and OCaml.
@@ -41,5 +41,6 @@ and to practice "literate programming" using markdown and OCaml.
 The test mode allows to ensure that shell scripts and OCaml fragments
 in the documentation always stays up-to-date.
 
-`mdx` is released as a single binary (called `mdx`).
+`ocaml-mdx` is released as two binaries called `ocaml-mdx` and `mdx` which are
+the same, mdx being the deprecated name, kept for now for compatibility.
 """

--- a/test/dune
+++ b/test/dune
@@ -2,161 +2,161 @@
  (name   runtest)
  (deps   (:x section.md) (:y section.md.expected) (package mdx))
  (action (progn
-           (run mdx test -s Testing %{x})
+           (run ocaml-mdx test -s Testing %{x})
            (diff? %{y} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x labels.md) (:y labels.md.expected) (package mdx))
  (action (progn
-           (run mdx test -s Testing %{x})
+           (run ocaml-mdx test -s Testing %{x})
            (diff? %{y} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x pp.md) section.md (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x ellipsis-updates.md) (:y ellipsis-updates.md.expected) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{y} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x ellipsis.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x envs.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x empty_line.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x empty_lines.md) (:y empty_lines.md.expected) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{y} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x output.md) (:y output.html.expected) (package mdx))
  (action (progn
-           (run mdx output %{x} -o output.html)
+           (run ocaml-mdx output %{x} -o output.html)
            (diff? %{y} output.html))))
 
 (alias
  (name   runtest)
  (deps   (:x spaces.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x cram.t) (package mdx))
  (action (progn
-           (run mdx test --syntax=cram %{x})
+           (run ocaml-mdx test --syntax=cram %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x errors.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x heredoc.md) section.md (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x mlt.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x semisemi.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x exit.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x padding.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x multilines.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x lines.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x lwt.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x non-det.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x code.md) (package mdx))
  (action (progn
-           (run mdx test %{x})
+           (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x dir.md) (package mdx))
  (action (progn
-           (run mdx test --root "../bin" %{x})
+           (run ocaml-mdx test --root "../bin" %{x})
            (diff? %{x} %{x}.corrected))))
 
 (rule (copy dir.md dir2.md))
@@ -165,14 +165,14 @@
  (name   runtest)
  (deps   (:x dir2.md) (:y dir.md.expected) (package mdx))
  (action (progn
-           (run mdx test --root=.. %{x})
+           (run ocaml-mdx test --root=.. %{x})
            (diff? %{y} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x prelude.md) (package mdx))
  (action (progn
-           (run mdx
+           (run ocaml-mdx
                   test
                   --prelude-str "#require \"lwt\""
                   --prelude-str "toto:let x = \"42\""
@@ -183,7 +183,7 @@
  (name   runtest)
  (deps   (:x prelude_file.md) prelude.ml (package mdx))
  (action (progn
-           (run mdx test --prelude prelude.ml %{x})
+           (run ocaml-mdx test --prelude prelude.ml %{x})
            (diff? %{x} %{x}.corrected))))
 
 
@@ -194,7 +194,7 @@
          sync_to_md.ml
          (package mdx))
  (action (progn
-           (run mdx test --direction=to-md %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
            (diff? %{y} %{x}.corrected))))
 
 (alias
@@ -204,7 +204,7 @@
          (:c sync_to_broken_ml.ml) (:d sync_to_ml.mli)
          (package mdx))
  (action (progn
-           (run mdx test --direction=to-ml %{x})
+           (run ocaml-mdx test --direction=to-ml %{x})
            (diff? %{y} %{x}.corrected)
            (diff? %{b} %{a}.corrected)
            (diff? %{c} %{c}.corrected)
@@ -213,7 +213,7 @@
 (rule
  (targets section.ml)
  (deps    (:x section.md) (package mdx))
- (action  (with-stdout-to %{targets} (run mdx pp %{x}))))
+ (action  (with-stdout-to %{targets} (run ocaml-mdx pp %{x}))))
 
 (executable
   (name section)
@@ -231,7 +231,7 @@
 (rule
  (targets dune_rules.inc.gen)
  (deps    (source_tree test-cases) (:x dune_rules.md) (package mdx))
- (action  (with-stdout-to %{targets} (run mdx rule --direction=to-ml %{x}))))
+ (action  (with-stdout-to %{targets} (run ocaml-mdx rule --direction=to-ml %{x}))))
 
 (alias
  (name runtest)

--- a/test/dune_rules.inc
+++ b/test/dune_rules.inc
@@ -5,7 +5,7 @@
          (:y0 dune_rules_2.ml)
          (source_tree foo))
  (action (progn
-           (run mdx test --direction=to-ml %{x})
+           (run ocaml-mdx test --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected))))

--- a/test/lines.md
+++ b/test/lines.md
@@ -49,7 +49,7 @@ Error: This expression has type string but an expression was expected of type
 Let's go recursive:
 
 ```sh
-$ ocamlc -pp "mdx pp" -impl lines.md
+$ ocamlc -pp "ocaml-mdx pp" -impl lines.md
 File "lines.md", line 33, characters 6-11:
 Error: This expression has type string but an expression was expected of type
          int

--- a/test/non-det.md
+++ b/test/non-det.md
@@ -1,4 +1,4 @@
-`mdx` supports non-determinitic code blocks.
+`ocaml-mdx` supports non-determinitic code blocks.
 
 There are two kinds of blocks:
 
@@ -6,7 +6,7 @@ There are two kinds of blocks:
 
 Code blocks with `non-deterministic=output` have their command always
 executed but their output is never checked, unless `--non-deterministic`
-is passed as argument to `mdx`.
+is passed as argument to `ocaml-mdx`.
 
 
 ```sh non-deterministic=output
@@ -33,7 +33,7 @@ $ touch hello-world
 ### Non-deterministic Commands
 
 Code blocks with `non-deterministic=command` are never executed unless
-`--non-deterministic` is passed as argument to `mdx`.
+`--non-deterministic` is passed as argument to `ocaml-mdx`.
 
 ```sh non-deterministic=command
 $ touch toto

--- a/test/pp.md
+++ b/test/pp.md
@@ -1,7 +1,7 @@
 Mdx can be used to compile sections of a markdown file. For instance:
 
 ```sh
-$ ocamlc -pp 'mdx pp -s Hello' -impl section.md
+$ ocamlc -pp 'ocaml-mdx pp -s Hello' -impl section.md
 $ ./a.out
 42
 ```
@@ -10,6 +10,6 @@ OCaml toplevel can also be compiled and executed in the same way:
 
 
 ```sh
-$ ocamlc -pp 'mdx pp -s Toplevel' -impl section.md && ./a.out
+$ ocamlc -pp 'ocaml-mdx pp -s Toplevel' -impl section.md && ./a.out
 42
 ```

--- a/test/prelude.md
+++ b/test/prelude.md
@@ -1,4 +1,4 @@
-`mdx test` can also take a prelude file.
+`ocaml-mdx test` can also take a prelude file.
 
 ```ocaml
 # Lwt.return 4

--- a/test/spaces.md
+++ b/test/spaces.md
@@ -27,7 +27,7 @@ bar
 ```
 
 ```sh
-$ mdx pp spaces.md
+$ ocaml-mdx pp spaces.md
 #2 "spaces.md"
 
 


### PR DESCRIPTION
I left several calls to mdx, thinking the codebase was using argv[1]. Replaced them for ocaml-mdx.