### PR TITLE
Added an argument allowing to force generation of diff file

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -84,6 +84,10 @@ let direction =
   let docv = "{" ^ docv ^ "}" in
   Arg.(value & opt (enum opt_names) `Infer_timestamp & info names ~doc ~docv)
 
+let force_output =
+  let doc = "Force generation of corrected file (even if there was no diff)" in
+  Arg.(value & flag & info ["force-output"] ~doc)
+
 let setup_log style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Logs.set_level level;

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -143,7 +143,7 @@ let run () md_file section direction prelude prelude_str root =
     print_rule ~md_file ~prelude ~nd ~ml_files ~dirs ~root options;
     file_contents
   in
-  Mdx.run ~force_output:false md_file ~f:on_file;
+  Mdx.run md_file ~f:on_file;
   0
 
 open Cmdliner

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -143,7 +143,7 @@ let run () md_file section direction prelude prelude_str root =
     print_rule ~md_file ~prelude ~nd ~ml_files ~dirs ~root options;
     file_contents
   in
-  Mdx.run false md_file ~f:on_file;
+  Mdx.run ~force_output:false md_file ~f:on_file;
   0
 
 open Cmdliner

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -143,7 +143,7 @@ let run () md_file section direction prelude prelude_str root =
     print_rule ~md_file ~prelude ~nd ~ml_files ~dirs ~root options;
     file_contents
   in
-  Mdx.run md_file ~f:on_file;
+  Mdx.run false md_file ~f:on_file;
   0
 
 open Cmdliner

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -41,5 +41,5 @@ let cmd: int Term.t * Term.info =
   Term.(pure run
         $ Cli.setup $ Cli.non_deterministic $ Cli.not_verbose $ Cli.syntax
         $ Cli.silent $ Cli.verbose_findlib $ Cli.prelude $ Cli.prelude_str
-        $ Cli.file $ Cli.section $ Cli.root $ Cli.direction),
+        $ Cli.file $ Cli.section $ Cli.root $ Cli.direction $ Cli.force_output),
   Term.info "test" ~doc

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -297,7 +297,7 @@ let run_exn ()
     | _ -> Fmt.failwith "only one of --prelude or --prelude-str shoud be used"
   in
 
-  Mdx.run ?syntax force_output file ~f:(fun file_contents items ->
+  Mdx.run ?syntax ~force_output file ~f:(fun file_contents items ->
       let temp_file = Filename.temp_file "ocaml-mdx" ".output" in
       at_exit (fun () -> Sys.remove temp_file);
       let buf = Buffer.create (String.length file_contents + 1024) in

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -262,7 +262,7 @@ let update_file_or_block ?root ppf md_file ml_file block direction =
 
 let run_exn ()
     non_deterministic not_verbose syntax silent verbose_findlib prelude
-    prelude_str file section root direction
+    prelude_str file section root direction force_output
   =
   let c =
     Mdx_top.init ~verbose:(not not_verbose) ~silent ~verbose_findlib ()
@@ -297,7 +297,7 @@ let run_exn ()
     | _ -> Fmt.failwith "only one of --prelude or --prelude-str shoud be used"
   in
 
-  Mdx.run ?syntax file ~f:(fun file_contents items ->
+  Mdx.run ?syntax force_output file ~f:(fun file_contents items ->
       let temp_file = Filename.temp_file "ocaml-mdx" ".output" in
       at_exit (fun () -> Sys.remove temp_file);
       let buf = Buffer.create (String.length file_contents + 1024) in
@@ -387,7 +387,7 @@ let cmd =
   Term.(pure run
         $ Cli.setup $ Cli.non_deterministic $ Cli.not_verbose $ Cli.syntax
         $ Cli.silent $ Cli.verbose_findlib $ Cli.prelude $ Cli.prelude_str
-        $ Cli.file $ Cli.section $ Cli.root $ Cli.direction),
+        $ Cli.file $ Cli.section $ Cli.root $ Cli.direction $ Cli.force_output),
   Term.info "ocaml-mdx-test" ~version:"%%VERSION%%" ~doc ~exits ~man
 
 let main () = Term.(exit_status @@ eval cmd)

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -84,7 +84,7 @@ let eval = function
     let t' = Block.eval t in
     if t == t' then x else Block t'
 
-let run ?(syntax=Normal) ~force_output ~f n =
+let run ?(syntax=Normal) ?(force_output=false) ~f n =
   Misc.run_expect_test ~force_output n ~f:(fun c l ->
       let items = parse_lexbuf syntax l in
       let items = List.map eval items in

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -84,8 +84,8 @@ let eval = function
     let t' = Block.eval t in
     if t == t' then x else Block t'
 
-let run ?(syntax=Normal) ~f n =
-  Misc.run_expect_test n ~f:(fun c l ->
+let run ?(syntax=Normal) force_output ~f n =
+  Misc.run_expect_test force_output n ~f:(fun c l ->
       let items = parse_lexbuf syntax l in
       let items = List.map eval items in
       Log.debug (fun l -> l "run @[%a@]" dump items);

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -84,8 +84,8 @@ let eval = function
     let t' = Block.eval t in
     if t == t' then x else Block t'
 
-let run ?(syntax=Normal) force_output ~f n =
-  Misc.run_expect_test force_output n ~f:(fun c l ->
+let run ?(syntax=Normal) ~force_output ~f n =
+  Misc.run_expect_test ~force_output n ~f:(fun c l ->
       let items = parse_lexbuf syntax l in
       let items = List.map eval items in
       Log.debug (fun l -> l "run @[%a@]" dump items);

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -69,12 +69,12 @@ val parse_lexbuf: syntax -> Lexing.lexbuf -> t
 
 (** {2 Evaluation} *)
 
-val run: ?syntax:syntax -> force_output:bool -> f:(string -> t -> string) -> string -> unit
+val run: ?syntax:syntax -> ?force_output:bool -> f:(string -> t -> string) -> string -> unit
 (** [run ?syntax ~f n] runs the expect callback [f] over the file named
    [n]. [f] is called with the raw contents of [n] and its structured
    contents; it returns the new file contents. If the result of [f] is
-   different from the initial contents, then [$n.corrected] is created
-   with the new contents. *)
+   different from the initial contents of force_output was set to true, then
+   [$n.corrected] is created with the new contents. *)
 
 (** {2 Filtering} *)
 

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -69,7 +69,7 @@ val parse_lexbuf: syntax -> Lexing.lexbuf -> t
 
 (** {2 Evaluation} *)
 
-val run: ?syntax:syntax -> f:(string -> t -> string) -> string -> unit
+val run: ?syntax:syntax -> bool -> f:(string -> t -> string) -> string -> unit
 (** [run ?syntax ~f n] runs the expect callback [f] over the file named
    [n]. [f] is called with the raw contents of [n] and its structured
    contents; it returns the new file contents. If the result of [f] is

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -73,7 +73,7 @@ val run: ?syntax:syntax -> ?force_output:bool -> f:(string -> t -> string) -> st
 (** [run ?syntax ~f n] runs the expect callback [f] over the file named
    [n]. [f] is called with the raw contents of [n] and its structured
    contents; it returns the new file contents. If the result of [f] is
-   different from the initial contents of force_output was set to true, then
+   different from the initial contents or if force_output was set to true, then
    [$n.corrected] is created with the new contents. *)
 
 (** {2 Filtering} *)

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -69,7 +69,7 @@ val parse_lexbuf: syntax -> Lexing.lexbuf -> t
 
 (** {2 Evaluation} *)
 
-val run: ?syntax:syntax -> bool -> f:(string -> t -> string) -> string -> unit
+val run: ?syntax:syntax -> force_output:bool -> f:(string -> t -> string) -> string -> unit
 (** [run ?syntax ~f n] runs the expect callback [f] over the file named
    [n]. [f] is called with the raw contents of [n] and its structured
    contents; it returns the new file contents. If the result of [f] is

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -48,11 +48,11 @@ let init file =
     };
   file_contents, lexbuf
 
-let run_expect_test file ~f =
+let run_expect_test force_output file ~f =
   let file_contents, lexbuf = init file in
   let expected = f file_contents lexbuf in
   let corrected_file = file ^ ".corrected" in
-  if file_contents <> expected then begin
+  if force_output || file_contents <> expected then begin
     let oc = open_out_bin corrected_file in
     output_string oc expected;
     close_out oc;

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -48,7 +48,7 @@ let init file =
     };
   file_contents, lexbuf
 
-let run_expect_test force_output file ~f =
+let run_expect_test ~force_output file ~f =
   let file_contents, lexbuf = init file in
   let expected = f file_contents lexbuf in
   let corrected_file = file ^ ".corrected" in


### PR DESCRIPTION
As said, I added an argument to ocaml-mdx which forces the generation of a corrected file, even without diff.
It allows to really on the file in dune rules (e.g [this example](https://github.com/realworldocaml/mdx/issues/112))