### PR TITLE
Added environment variable support in code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,27 @@ The version number can be of the following forms:
 - `X.Y`
 - `X.Y.Z`
 
+#### Environment variables declaration
+
+Environment variables can be declared at the beginning of a block:
+
+```ocaml set-FOO=bar,set-BAR=foo
+  # print_endline (Sys.getenv "FOO")
+  bar
+  - : unit = ()
+  # print_endline (Sys.getenv "BAR")
+  foo
+  - : unit = ()
+```
+
+Those variables are then available in the subsequent blocks
+
+```ocaml
+  # print_endline (Sys.getenv "FOO")
+  bar
+  - : unit = ()
+```
+
 ### Sections
 
 It is possible to test or execute only a subset of the file using

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -306,7 +306,8 @@ let run_exn ()
           | Section _
           | Text _ as t -> Mdx.pp_line ?syntax ppf t
           | Block t ->
-            Mdx_top.in_env (Block.environment t)
+            List.iter (fun (k, v) -> Unix.putenv k v) (Block.variables t);
+              Mdx_top.in_env (Block.environment t)
               (fun () ->
                  let active = active t && (not (Block.skip t)) in
                  match active, non_deterministic, Block.mode t, Block.value t with

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -88,6 +88,9 @@ val environment: t -> string
 (** [environment t] is the name given to the environment where [t] tests
     are run. *)
 
+val variables: t -> (string * string) list
+(** [variable t] is the list of environment variable to set and their values *)
+
 val skip: t -> bool
 (** [skip t] is true iff [skip] is in the labels of [t]. *)
 

--- a/test/dune
+++ b/test/dune
@@ -170,6 +170,13 @@
 
 (alias
  (name   runtest)
+ (deps   (:x environment_variable.md) (package mdx))
+ (action (progn
+           (run ocaml-mdx test %{x})
+           (diff? %{x} %{x}.corrected))))
+
+(alias
+ (name   runtest)
  (deps   (:x prelude.md) (package mdx))
  (action (progn
            (run ocaml-mdx

--- a/test/environment_variable.md
+++ b/test/environment_variable.md
@@ -1,0 +1,18 @@
+Environment variable can also loaded in an environment
+
+```ocaml set-FOO=bar,set-BAR=foo
+  # print_endline (Sys.getenv "FOO")
+  bar
+  - : unit = ()
+  # print_endline (Sys.getenv "BAR")
+  foo
+  - : unit = ()
+```
+
+And the variable stays available in subsequent blocks
+
+```ocaml
+  # print_endline (Sys.getenv "FOO")
+  bar
+  - : unit = ()
+```

--- a/test/labels.md.expected
+++ b/test/labels.md.expected
@@ -6,6 +6,6 @@ $ ls
 ```
 
 ```sh toto,dir=xxx
->> "toto" is not a valid label. Valid labels are are "dir", "source-tree", "file", "part", "env", "skip", "non-deterministic" and "version".
+>> "toto" is not a valid label or prefix. Valid labels are "dir", "source-tree", "file", "part", "env", "skip", "non-deterministic" and "version" and valid prefixes are "set-".
 $ xxx
 ```


### PR DESCRIPTION
As requested in [this](https://github.com/realworldocaml/mdx/issues/113) issue, it is now possible to create environment variable in a block