### PR TITLE
Support for 4.08

### DIFF
--- a/lib/compat.ml
+++ b/lib/compat.ml
@@ -96,11 +96,11 @@ module Warnings = struct
 #endif
 end
 
+#if OCAML_MAJOR = 4 && OCAML_MINOR < 4
 module Env = struct
   include Env
 
-#if OCAML_MAJOR = 4 && OCAML_MINOR < 4
   (* Can't be overriden *)
   let without_cmis f x = f x
-#endif
 end
+#endif

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -728,10 +728,10 @@ let init ~verbose:v ~silent:s ~verbose_findlib () =
   Sys.interactive := false;
   (* CR hheuzard: fixme *)
   (* patch_env (); *)
-  (* Topfind.don't_load_deeply [
-   *   "unix"; "findlib.top"; "findlib.internal"; "compiler-libs.toplevel"
-   * ];
-   * Topfind.add_predicates ["byte"; "toploop"]; *)
+  Topfind.don't_load_deeply [
+    "unix"; "findlib.top"; "findlib.internal"; "compiler-libs.toplevel"
+  ];
+  Topfind.add_predicates ["byte"; "toploop"];
   let t = { verbose=v; silent=s; verbose_findlib } in
   show ();
   show_val ();

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -749,11 +749,9 @@ module Part = Part
 
 let envs = Hashtbl.create 8
 
-let is_builtin id =
+let is_predef_or_global id =
 #if OCAML_MAJOR >= 4 && OCAML_MINOR >= 8
-  List.exists
-    (fun (_, builtin) -> Ident.same id builtin)
-    Predef.builtin_idents
+  Ident.is_predef id || Ident.global id
 #else
   Ident.binding_time id < 1000
 #endif
@@ -777,7 +775,7 @@ let rec save_summary acc s =
                 Pident id)
     | Env_extension (summary, id, _) ->
             let acc =
-        if not (is_builtin id)
+        if not (is_predef_or_global id)
         then Ident.unique_toplevel_name id :: acc
         else acc
       in

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -711,7 +711,7 @@ let monkey_patch (type a) (type b) (m: a) (prj: unit -> b) (v : b) =
     with Exit -> ()
   )
 
-let _patch_env () =
+let patch_env () =
   let module M = struct
     module type T = module type of Env
     let field () = Env.without_cmis
@@ -726,8 +726,7 @@ let init ~verbose:v ~silent:s ~verbose_findlib () =
   Compmisc.init_path true;
   Toploop.toplevel_env := Compmisc.initial_env ();
   Sys.interactive := false;
-  (* CR hheuzard: fixme *)
-  (* patch_env (); *)
+  patch_env ();
   Topfind.don't_load_deeply [
     "unix"; "findlib.top"; "findlib.internal"; "compiler-libs.toplevel"
   ];

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -722,14 +722,12 @@ let _patch_env () =
 
 let init ~verbose:v ~silent:s ~verbose_findlib () =
   Clflags.real_paths := false;
-  Clflags.unsafe_string := Toplevel_backend.unsafe_string ();
   Toploop.set_paths ();
   Compmisc.init_path true;
   Toploop.toplevel_env := Compmisc.initial_env ();
   Sys.interactive := false;
   (* CR hheuzard: fixme *)
   (* patch_env (); *)
-  Toplevel_backend.init ~native:false (module Topdirs);
   (* Topfind.don't_load_deeply [
    *   "unix"; "findlib.top"; "findlib.internal"; "compiler-libs.toplevel"
    * ];

--- a/lib/top/part.ml
+++ b/lib/top/part.ml
@@ -196,19 +196,29 @@ module Phrase = struct
     in
     aux [] "" [] phrases
 
+  let handle_syntax_error e =
+#if OCAML_MAJOR >= 4 && OCAML_MINOR >= 8
+      (* The function is now Parse.prepare_error, but it is not
+         exposed; luckily enough, it is register to print the
+         exception. *)
+      Fmt.failwith "Cannot parse: %s" (Printexc.to_string (Syntaxerr.Error e))
+#else
+      Fmt.failwith "Cannot parse: %a" Syntaxerr.report_error e
+#endif
+
   let read_impl doc =
     try
       let strs = Parse.implementation doc.Lexbuf.lexbuf in
       List.map (fun x -> x, kind_impl x) strs
     with Syntaxerr.Error e ->
-      Fmt.failwith "Cannot parse: %a" Syntaxerr.report_error e
+      handle_syntax_error e
 
   let read_intf doc =
     try
       let strs = Parse.interface doc.Lexbuf.lexbuf in
       List.map (fun x -> x, kind_intf x) strs
     with Syntaxerr.Error e ->
-      Fmt.failwith "Cannot parse: %a" Syntaxerr.report_error e
+      handle_syntax_error e
 
 end
 


### PR DESCRIPTION
(Joint work with @hhugo)

This is clearly a work-in-progress, but it sounds useful to
share it, at least to avoid duplication.

This versions allows to build with 4.08, but tests fails.
There are (at least) two pain points:

- the black magic discussed by @hhugo [here](https://github.com/realworldocaml/mdx/pull/86);
- the conversion of the condition `Ident.binding_time id >= 1000`
  (I thought it meant "is not builtin", but the `is_builtin` function
  I added is apparently not correct).