### PR TITLE
[RFC] Add the --require option

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -88,6 +88,10 @@ let force_output =
   let doc = "Force generation of corrected file (even if there was no diff)" in
   Arg.(value & flag & info ["force-output"] ~doc)
 
+let required_packages =
+  let doc = "Packages to load before executing tests, separated by a comma ($(b,,))." in
+  Arg.(value & opt (list string) [] & info ["require"] ~doc ~docv:"PACKAGES")
+
 let setup_log style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Logs.set_level level;

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -21,7 +21,7 @@ let (/) x y = match x with
   | "." -> y
   | _   -> Filename.concat x y
 
-let run () _ _ _ _ _ _ _ _ _ _ =
+let run () _ _ _ _ _ _ _ _ _ _ _ =
   let base = Filename.basename Sys.argv.(0) in
   let dir = Filename.dirname Sys.argv.(0) in
   let cmd = match base with
@@ -41,5 +41,6 @@ let cmd: int Term.t * Term.info =
   Term.(pure run
         $ Cli.setup $ Cli.non_deterministic $ Cli.not_verbose $ Cli.syntax
         $ Cli.silent $ Cli.verbose_findlib $ Cli.prelude $ Cli.prelude_str
-        $ Cli.file $ Cli.section $ Cli.root $ Cli.direction $ Cli.force_output),
+        $ Cli.file $ Cli.section $ Cli.root $ Cli.direction $ Cli.force_output
+        $ Cli.required_packages),
   Term.info "test" ~doc

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -720,7 +720,7 @@ let patch_env () =
   end
   in ()
 
-let init ~verbose:v ~silent:s ~verbose_findlib () =
+let init ~verbose:v ~silent:s ~verbose_findlib ~required_packages () =
   Clflags.real_paths := false;
   Toploop.set_paths ();
   Compmisc.init_path true;
@@ -731,6 +731,7 @@ let init ~verbose:v ~silent:s ~verbose_findlib () =
     "unix"; "findlib.top"; "findlib.internal"; "compiler-libs.toplevel"
   ];
   Topfind.add_predicates ["byte"; "toploop"];
+  Topfind.load_deeply required_packages;
   let t = { verbose=v; silent=s; verbose_findlib } in
   show ();
   show_val ();

--- a/lib/top/mdx_top.mli
+++ b/lib/top/mdx_top.mli
@@ -22,7 +22,8 @@ open Result
 type t
 (** The type for configuration values. *)
 
-val init: verbose:bool -> silent:bool -> verbose_findlib:bool -> unit -> t
+val init: verbose:bool -> silent:bool -> verbose_findlib:bool ->
+  required_packages:string list -> unit -> t
 (** [init ()] is a new configuration value. *)
 
 val eval: t -> string list -> (string list, string list) result

--- a/test/dune
+++ b/test/dune
@@ -243,3 +243,11 @@
 (alias
  (name runtest)
  (action (diff dune_rules.inc dune_rules.inc.gen)))
+
+(alias
+ (name   runtest)
+ (deps   (package example_lib) (:x require/require.md))
+ (action (progn
+           (run ocaml-mdx test --require example_lib --direction=infer-timestamp %{x})
+           (diff? %{x} %{x}.corrected)
+)))

--- a/test/require/dune
+++ b/test/require/dune
@@ -1,0 +1,3 @@
+(library
+ (name example_lib)
+ (public_name example_lib))

--- a/test/require/example_lib.ml
+++ b/test/require/example_lib.ml
@@ -1,0 +1,1 @@
+let hello () = print_endline "Hello world!"

--- a/test/require/require.md
+++ b/test/require/require.md
@@ -1,0 +1,7 @@
+# Using local library
+
+```ocaml
+# Example_lib.hello ()
+Hello world!
+- : unit = ()
+```


### PR DESCRIPTION
This option loads a list of packages into the toplevel, like the `-require` option of utop.

To fix https://github.com/realworldocaml/mdx/issues/105

The dune rule can then be rewritten as:

```dune
(alias
 (name   runtest)
 (deps   (package a) (:x README.mdx))
 (action (progn
           (run ocaml-mdx-test --require a --direction=infer-timestamp %{x})
           (diff? %{x} %{x}.corrected))))
```

However, the user has to specify the required packages, for example, in the mdx file (TODO).

Also, this only works with installable packages. So it not possible to write examples that requires private libraries but will be a pain in some cases (like rwo).

What do you think?