### PR TITLE
Specify and load required packages

### DIFF
--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -137,7 +137,12 @@ let eval_test t ?root c test =
   Log.debug (fun l ->
       l "eval_test %a" Fmt.(Dump.list (Fmt.fmt "%S")) (Toplevel.command test));
   let root = root_dir ?root t in
-  with_dir root (fun () -> Mdx_top.eval c (Toplevel.command test))
+  let required_packages = Block.required_packages t in
+  with_dir root (fun () ->
+      match Mdx_top.load_packages c required_packages with
+      | Ok () -> Mdx_top.eval c (Toplevel.command test)
+      | Error name -> Error [Fmt.strf "Package could not be found: %s" name]
+    )
 
 let err_eval ~cmd lines =
     Fmt.epr "Got an error while evaluating:\n---\n%a\n---\n%a\n%!"

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -149,6 +149,7 @@ let labels = [
   `Label "skip"             , [`None];
   `Label "non-deterministic", [`None; `Some "command"; `Some "output"];
   `Label "version"          , [`Any];
+  `Label "require"          , [`Any];
   `Prefix "set-"            , [`Any];
   `Prefix "unset-"          , [`None];
 ]
@@ -287,6 +288,15 @@ let unset_variables t =
     | _ -> Fmt.failwith "invalid env variable operator (no operator allowed)"
   in
   List.map f (get_prefixed_labels t "unset-")
+
+let required_packages t =
+  let f = function
+    | `Eq, "" ->
+      Fmt.failwith "invalid `require` label value: requires a value"
+    | `Eq, pkg -> pkg
+    | _ -> Fmt.failwith "invalid `env` label value"
+  in
+  List.map f (get_labels t "require")
 
 let value t = t.value
 let section t = t.section

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -94,6 +94,9 @@ val set_variables: t -> (string * string) list
 val unset_variables: t -> string list
 (** [unset_variable t] is the list of environment variable to unset *)
 
+val required_packages: t -> string list
+(** [required_packages t] is the names of the required packages *)
+
 val skip: t -> bool
 (** [skip t] is true iff [skip] is in the labels of [t]. *)
 

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -744,6 +744,11 @@ let init ~verbose:v ~silent:s ~verbose_findlib () =
   silent t;
   t
 
+let load_packages _ pkgs =
+  try Result.Ok (Topfind.load_deeply pkgs)
+  with Fl_package_base.No_such_package (name, _) ->
+    Result.Error name
+
 module Part = Part
 
 let envs = Hashtbl.create 8

--- a/lib/top/mdx_top.mli
+++ b/lib/top/mdx_top.mli
@@ -25,6 +25,12 @@ type t
 val init: verbose:bool -> silent:bool -> verbose_findlib:bool -> unit -> t
 (** [init ()] is a new configuration value. *)
 
+val load_packages: t -> string list -> (unit, string) result
+(** [load_packages t pkgs] Load the findlib packages [pkgs] by their name
+    into the toplevel.
+    Returns [Error pkg_name] if a package named [pkg_name] could not be found.
+    Otherwise, returns [Ok ()] *)
+
 val eval: t -> string list -> (string list, string list) result
 (** [eval t p] evaluates the toplevel phrase [p] (possibly spawning on
     mulitple lines) with the configuration value [t]. *)

--- a/test/dune
+++ b/test/dune
@@ -268,3 +268,12 @@
 (alias
  (name runtest)
  (action (diff dune_rules.inc dune_rules.inc.gen)))
+
+(alias
+ (name   runtest)
+ (deps   (:x require/require.md)
+         (package example_lib))
+ (action (progn
+           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (diff? %{x} %{x}.corrected)
+)))

--- a/test/labels.md.expected
+++ b/test/labels.md.expected
@@ -6,6 +6,6 @@ $ ls
 ```
 
 ```sh toto,dir=xxx
->> "toto" is not a valid label or prefix. Valid labels are "dir", "source-tree", "file", "part", "env", "skip", "non-deterministic" and "version" and valid prefixes are "set-" and "unset-".
+>> "toto" is not a valid label or prefix. Valid labels are "dir", "source-tree", "file", "part", "env", "skip", "non-deterministic", "version" and "require" and valid prefixes are "set-" and "unset-".
 $ xxx
 ```

--- a/test/require/example_lib/dune
+++ b/test/require/example_lib/dune
@@ -1,0 +1,3 @@
+(library
+ (name example_lib)
+ (public_name example_lib))

--- a/test/require/example_lib/example_lib.ml
+++ b/test/require/example_lib/example_lib.ml
@@ -1,0 +1,1 @@
+let hello () = print_endline "Hello world!"

--- a/test/require/lib_b/dune
+++ b/test/require/lib_b/dune
@@ -1,0 +1,4 @@
+(library
+ (name lib_b)
+ (public_name example_lib.b)
+ (libraries example_lib))

--- a/test/require/lib_b/lib_b.ml
+++ b/test/require/lib_b/lib_b.ml
@@ -1,0 +1,1 @@
+let hello () = Example_lib.hello ()

--- a/test/require/require.md
+++ b/test/require/require.md
@@ -1,0 +1,15 @@
+# Using local library
+
+```ocaml require=example_lib
+# Example_lib.hello ()
+Hello world!
+- : unit = ()
+```
+
+# Sub library
+
+```ocaml require=example_lib.b
+# Lib_b.hello ()
+Hello world!
+- : unit = ()
+```


### PR DESCRIPTION
Fixes https://github.com/realworldocaml/mdx/issues/105

This PR adds the `require` label:

```
```ocaml require=lib1,lib2
```

This will load `lib1` and `lib2` into the toplevel before executing the block. Using `findlib`.

Like with https://github.com/realworldocaml/mdx/pull/127, local libraries must be installable (have a `public_name`).

To work properly, the dune rule must be updated when the list of packages changes (eg. with `ocaml-mdx rule`).