### PR TITLE
Update tests for 4.08

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.05.0
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.06.1
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.07.1
+  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.08.0
 before_install:
   # Download and use opam2
   - wget -O ${HOME}/opam https://github.com/ocaml/opam/releases/download/2.0.4/opam-2.0.4-x86_64-linux

--- a/test/envs.md
+++ b/test/envs.md
@@ -60,7 +60,7 @@ type t2 = t1
 type t2 = t1
 ```
 
-```ocaml env=e2
+```ocaml version<4.08 env=e2
 # let x = 2;;
 val x : int = 2
 # type t2 = int;;
@@ -70,9 +70,18 @@ Characters 10-12:
 Error: Unbound type constructor t1
 ```
 
+```ocaml version>=4.08 env=e2
+# let x = 2;;
+val x : t2 = 2
+# type t2 = int;;
+type t2 = t1
+# type t3 = t1;;
+type t3 = t2
+```
+
 ```ocaml
 # type t2 = t1;;
-type t2 = t1
+type t2 = t3
 # let (y : t1) = 4;;
 val y : t2 = 4
 ```
@@ -95,7 +104,7 @@ val y : t3 = 2
 - : unit = ()
 ```
 
-```ocaml env=e2
+```ocaml version<4.08 env=e2
 # let (z : t2) = 32;;
 val z : t2 = 32
 # print_int z;;
@@ -106,5 +115,19 @@ Characters 9-11:
 Error: Unbound type constructor t3
 # print_int d;;
 Characters 10-11:
+Error: Unbound value d
+```
+
+```ocaml version>=4.08 env=e2
+# let (z : t3) = 32;;
+val z : t3 = 32
+# print_int z;;
+32
+- : unit = ()
+# let (d : t4) = 32;;
+Line 1, characters 10-12:
+Error: Unbound type constructor t4
+# print_int d;;
+Line 1, characters 11-12:
 Error: Unbound value d
 ```

--- a/test/envs.md
+++ b/test/envs.md
@@ -60,7 +60,7 @@ type t2 = t1
 type t2 = t1
 ```
 
-```ocaml version<4.08 env=e2
+```ocaml version<4.08,env=e2
 # let x = 2;;
 val x : int = 2
 # type t2 = int;;
@@ -70,18 +70,19 @@ Characters 10-12:
 Error: Unbound type constructor t1
 ```
 
-```ocaml version>=4.08 env=e2
+```ocaml version>=4.08,env=e2
 # let x = 2;;
-val x : t2 = 2
+val x : int = 2
 # type t2 = int;;
-type t2 = t1
+type t2 = int
 # type t3 = t1;;
-type t3 = t2
+Line 1, characters 11-13:
+Error: Unbound type constructor t1
 ```
 
 ```ocaml
 # type t2 = t1;;
-type t2 = t3
+type t2 = t1
 # let (y : t1) = 4;;
 val y : t2 = 4
 ```
@@ -104,7 +105,7 @@ val y : t3 = 2
 - : unit = ()
 ```
 
-```ocaml version<4.08 env=e2
+```ocaml version<4.08,env=e2
 # let (z : t2) = 32;;
 val z : t2 = 32
 # print_int z;;
@@ -118,12 +119,13 @@ Characters 10-11:
 Error: Unbound value d
 ```
 
-```ocaml version>=4.08 env=e2
+```ocaml version>=4.08,env=e2
 # let (z : t3) = 32;;
-val z : t3 = 32
+Line 1, characters 10-12:
+Error: Unbound type constructor t3
 # print_int z;;
-32
-- : unit = ()
+Line 1, characters 11-12:
+Error: Unbound value z
 # let (d : t4) = 32;;
 Line 1, characters 10-12:
 Error: Unbound type constructor t4

--- a/test/errors.md
+++ b/test/errors.md
@@ -1,6 +1,6 @@
 Errors should be well localized:
 
-```ocaml
+```ocaml version<4.08
 # class ['a] stack init = object
     val mutable v = init
 
@@ -37,10 +37,26 @@ Error: This expression has type bytes but an expression was expected of type
          int
 ```
 
-```ocaml version>=4.06
+```ocaml version=4.06
 # let x =
   1 + "42"
 Characters 14-18:
+Error: This expression has type string but an expression was expected of type
+         int
+```
+
+```ocaml version=4.07
+# let x =
+  1 + "42"
+Characters 14-18:
+Error: This expression has type string but an expression was expected of type
+         int
+```
+
+```ocaml version>=4.08
+# let x =
+  1 + "42"
+Line 2, characters 7-11:
 Error: This expression has type string but an expression was expected of type
          int
 ```

--- a/test/lines.md
+++ b/test/lines.md
@@ -68,9 +68,19 @@ Error: This expression has type string but an expression was expected of type
 
 Let's go recursive:
 
-```sh
+```sh version<4.08
 $ ocamlc -pp "ocaml-mdx pp" -impl lines.md
 File "lines.md", line 33, characters 6-11:
+Error: This expression has type string but an expression was expected of type
+         int
+[2]
+```
+
+```sh version>=4.08
+$ ocamlc -pp "ocaml-mdx pp" -impl lines.md
+File "lines.md", line 33, characters 6-11:
+33 |   n + "foo"
+           ^^^^^
 Error: This expression has type string but an expression was expected of type
          int
 [2]

--- a/test/lines.md
+++ b/test/lines.md
@@ -36,12 +36,32 @@ Error: This expression has type bytes but an expression was expected of type
          int
 ```
 
-```ocaml version>=4.06
+```ocaml version=4.06
 # let f x = function
   | 0 -> 1
   | n ->
   n + "foo"
 Characters 45-50:
+Error: This expression has type string but an expression was expected of type
+         int
+```
+
+```ocaml version=4.07
+# let f x = function
+  | 0 -> 1
+  | n ->
+  n + "foo"
+Characters 45-50:
+Error: This expression has type string but an expression was expected of type
+         int
+```
+
+```ocaml version>=4.08
+# let f x = function
+  | 0 -> 1
+  | n ->
+  n + "foo"
+Line 4, characters 7-12:
 Error: This expression has type string but an expression was expected of type
          int
 ```

--- a/test/mlt.md
+++ b/test/mlt.md
@@ -10,12 +10,32 @@ Error: This expression has type bytes but an expression was expected of type
          int
 ```
 
-```ocaml version>=4.06
+```ocaml version=4.06
 # #require "fmt";;
 # let x = 3;;
 val x : int = 3
 # x + "foo";;
 Characters 4-9:
+Error: This expression has type string but an expression was expected of type
+         int
+```
+
+```ocaml version=4.07
+# #require "fmt";;
+# let x = 3;;
+val x : int = 3
+# x + "foo";;
+Characters 4-9:
+Error: This expression has type string but an expression was expected of type
+         int
+```
+
+```ocaml version>=4.08
+# #require "fmt";;
+# let x = 3;;
+val x : int = 3
+# x + "foo";;
+Line 1, characters 5-10:
 Error: This expression has type string but an expression was expected of type
          int
 ```

--- a/test/prelude.md
+++ b/test/prelude.md
@@ -14,8 +14,14 @@ It's possible to load a prelude only in a specific environment using
 - : unit = ()
 ```
 
-```ocaml
+```ocaml version<4.08
 # print_endline x
 Characters 14-15:
+Error: Unbound value x
+```
+
+```ocaml version>=4.08
+# print_endline x
+Line 1, characters 15-16:
 Error: Unbound value x
 ```


### PR DESCRIPTION
Fix #126, I don't know what changed with `Env_module` and `Env_open` in Toplevel/Env with 4.08, didn't find much info in the last commits.

The mdx tests are almost all fixed, there is still an issue with test/lines.md because `sh` blocks don't accept the `version` tag.

Improvements (TODO) :
- allow syntax like `version>=4.06&&<4.08` (not in this PR)
- the `version` tag should be checked for `sh` blocks (in this PR)