### PR TITLE
Added unset-* label

### DIFF
--- a/lib/block.mli
+++ b/lib/block.mli
@@ -88,8 +88,11 @@ val environment: t -> string
 (** [environment t] is the name given to the environment where [t] tests
     are run. *)
 
-val variables: t -> (string * string) list
-(** [variable t] is the list of environment variable to set and their values *)
+val set_variables: t -> (string * string) list
+(** [set_variable t] is the list of environment variable to set and their values *)
+
+val unset_variables: t -> string list
+(** [unset_variable t] is the list of environment variable to unset *)
 
 val skip: t -> bool
 (** [skip t] is true iff [skip] is in the labels of [t]. *)

--- a/test/dune
+++ b/test/dune
@@ -170,7 +170,14 @@
 
 (alias
  (name   runtest)
- (deps   (:x environment_variable.md) (package mdx))
+ (deps   (:x set_environment_variable.md) (package mdx))
+ (action (progn
+           (run ocaml-mdx test %{x})
+           (diff? %{x} %{x}.corrected))))
+
+(alias
+ (name   runtest)
+ (deps   (:x unset_environment_variable.md) (package mdx))
  (action (progn
            (run ocaml-mdx test %{x})
            (diff? %{x} %{x}.corrected))))

--- a/test/labels.md.expected
+++ b/test/labels.md.expected
@@ -6,6 +6,6 @@ $ ls
 ```
 
 ```sh toto,dir=xxx
->> "toto" is not a valid label or prefix. Valid labels are "dir", "source-tree", "file", "part", "env", "skip", "non-deterministic" and "version" and valid prefixes are "set-".
+>> "toto" is not a valid label or prefix. Valid labels are "dir", "source-tree", "file", "part", "env", "skip", "non-deterministic" and "version" and valid prefixes are "set-" and "unset-".
 $ xxx
 ```

--- a/test/set_environment_variable.md
+++ b/test/set_environment_variable.md
@@ -1,0 +1,40 @@
+Environment variables can be loeaded in ocaml blocks
+
+# OCaml
+
+Environment variables can be loaded in an ocaml block environment.
+
+```ocaml set-FOO=bar,set-BAR=foo
+  # print_endline (Sys.getenv "FOO")
+  bar
+  - : unit = ()
+  # print_endline (Sys.getenv "BAR")
+  foo
+  - : unit = ()
+```
+
+And the variable stays available in subsequent blocks.
+
+```ocaml
+  # print_endline (Sys.getenv "FOO")
+  bar
+  - : unit = ()
+```
+
+# Sh/bash
+
+Environment variables can be loaded in an ocaml block environment.
+
+```sh set-FAR=boo,set-BOO=far
+  $ echo $FAR
+  boo
+  $ echo $BOO
+  far
+```
+
+And the variable stays available in subsequent blocks.
+
+```sh
+  $ echo $BOO
+  far
+```

--- a/test/unset_environment_variable.md
+++ b/test/unset_environment_variable.md
@@ -1,0 +1,13 @@
+Environment variables can be blacklisted in an shell and bash blocks.
+
+```sh
+  $ echo $HOME
+  ...
+```
+
+```sh unset-HOME
+  $ echo $HOME
+  
+```
+
+By default, the variable INSIDE_DUNE is blacklisted, in order to keep the wanted outputs from dune related commands.


### PR DESCRIPTION
Added a unset-* label, allowing to remove an environment variable in a shell block.

It works the same way as set-* expect that it does not need a value:
>  '''sh unset-HOME
>    $ echo $HOME
>
> '''

It's original purpose was to allow shell script using Dune to run normally:
Dune sets a variable INSIDE_DUNE to 1 when running, which implies some modified behaviours.

So in the case of mdx being used by a dune rule, and itself launching dune in an sh block, the variable is defined before running the nested dune.

This is why, after talking about it with @samoht , I added INSIDE_DUNE to the blacklist by default.