### PR TITLE
Tests may ignore an error if no correction is generated when one was wanted

### DIFF
--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -195,9 +195,9 @@ type file = { first: Mdx_top.Part.file; current: Mdx_top.Part.file }
 
 let files: (string, file) Hashtbl.t = Hashtbl.create 8
 
-let has_changed { first; current } =
+let has_changed ~force_output { first; current } =
   let contents = Mdx_top.Part.contents current in
-  if contents = Mdx_top.Part.contents first
+  if contents = Mdx_top.Part.contents first && force_output = false
   then None
   else Some contents
 
@@ -209,9 +209,9 @@ let read_parts file =
     Hashtbl.add files file f;
     f
 
-let write_parts file parts =
+let write_parts ~force_output file parts =
   let output_file = file ^ ".corrected" in
-  match has_changed parts with
+  match has_changed ~force_output parts with
   | None   -> if Sys.file_exists output_file then Sys.remove output_file
   | Some c ->
     let oc = open_out output_file in
@@ -379,7 +379,7 @@ let run_exn ()
         ) items;
       Format.pp_print_flush ppf ();
       Buffer.contents buf);
-  Hashtbl.iter write_parts files;
+  Hashtbl.iter (write_parts ~force_output) files;
   0
 
 let run ()

--- a/test/dune
+++ b/test/dune
@@ -2,14 +2,14 @@
  (name   runtest)
  (deps   (:x section.md) (:y section.md.expected) (package mdx))
  (action (progn
-           (run ocaml-mdx test -s Testing %{x})
+           (run ocaml-mdx test --force-output -s Testing %{x})
            (diff? %{y} %{x}.corrected))))
 
 (alias
  (name   runtest)
  (deps   (:x labels.md) (:y labels.md.expected) (package mdx))
  (action (progn
-           (run ocaml-mdx test -s Testing %{x})
+           (run ocaml-mdx test --force-output -s Testing %{x})
            (diff? %{y} %{x}.corrected))))
 
 (alias
@@ -23,7 +23,7 @@
  (name   runtest)
  (deps   (:x ellipsis-updates.md) (:y ellipsis-updates.md.expected) (package mdx))
  (action (progn
-           (run ocaml-mdx test %{x})
+           (run ocaml-mdx test --force-output %{x})
            (diff? %{y} %{x}.corrected))))
 
 (alias
@@ -51,7 +51,7 @@
  (name   runtest)
  (deps   (:x empty_lines.md) (:y empty_lines.md.expected) (package mdx))
  (action (progn
-           (run ocaml-mdx test %{x})
+           (run ocaml-mdx test --force-output %{x})
            (diff? %{y} %{x}.corrected))))
 
 (alias
@@ -165,7 +165,7 @@
  (name   runtest)
  (deps   (:x dir2.md) (:y dir.md.expected) (package mdx))
  (action (progn
-           (run ocaml-mdx test --root=.. %{x})
+           (run ocaml-mdx test --force-output --root=.. %{x})
            (diff? %{y} %{x}.corrected))))
 
 (alias
@@ -208,7 +208,7 @@
          sync_to_md.ml
          (package mdx))
  (action (progn
-           (run ocaml-mdx test --direction=to-md %{x})
+           (run ocaml-mdx test --force-output --direction=to-md %{x})
            (diff? %{y} %{x}.corrected))))
 
 (alias
@@ -218,7 +218,7 @@
          (:c sync_to_broken_ml.ml) (:d sync_to_ml.mli)
          (package mdx))
  (action (progn
-           (run ocaml-mdx test --direction=to-ml %{x})
+           (run ocaml-mdx test --force-output --direction=to-ml %{x})
            (diff? %{y} %{x}.corrected)
            (diff? %{b} %{a}.corrected)
            (diff? %{c} %{c}.corrected)


### PR DESCRIPTION
Currently, if a test wants mdx to generate a `.corrected` file but mdx does not generate the file, `dune runtest` does not raise any error.
This is because we use `diff?` which doesn't need both files to exist.
One solution for now is to use force-output in the tests expecting a correction.
I also updated force-output so it also forces the corrections of .ml files in the case of an to-ml direction.