### PR TITLE
Correcting bug preventing promotion of empty ml files

### DIFF
--- a/lib/top/part.ml
+++ b/lib/top/part.ml
@@ -190,7 +190,10 @@ module Phrase = struct
             let body = body doc (List.rev strs) in
             Part.v ~name:part ~body :: parts
           else
-            parts
+            if List.length parts = 0 then
+              [Part.v ~name:"" ~body:""]
+            else
+              parts
         in
         List.rev parts
     in

--- a/test/dune
+++ b/test/dune
@@ -226,6 +226,15 @@
 
 (alias
  (name   runtest)
+ (deps   (:x sync_to_empty_ml.md)
+         (:a sync_to_empty_ml.ml) (:b sync_to_empty_ml.ml.expected)
+         (package mdx))
+ (action (progn
+           (run ocaml-mdx test --force-output --direction=to-ml %{x})
+           (diff? %{b} %{a}.corrected))))
+
+(alias
+ (name   runtest)
  (deps   (:x sync_to_ml_with_correct_md.md)
          (:a sync_to_ml_with_correct_md.ml) (:b sync_to_ml_with_correct_md.ml.expected)
          (package mdx))

--- a/test/sync_to_empty_ml.md
+++ b/test/sync_to_empty_ml.md
@@ -1,0 +1,6 @@
+This test is a reggresion test for [PR 137](https://github.com/realworldocaml/mdx/pull/137).
+It verifies that the promotion to a ml file is done even if it is empty.
+
+```ocaml file=sync_to_empty_ml.ml
+let f = "hello world!"
+```

--- a/test/sync_to_empty_ml.md
+++ b/test/sync_to_empty_ml.md
@@ -1,4 +1,4 @@
-This test is a reggresion test for [PR 137](https://github.com/realworldocaml/mdx/pull/137).
+This test is a reggresion test for [PR 139](https://github.com/realworldocaml/mdx/pull/139).
 It verifies that the promotion to a ml file is done even if it is empty.
 
 ```ocaml file=sync_to_empty_ml.ml

--- a/test/sync_to_empty_ml.ml.expected
+++ b/test/sync_to_empty_ml.ml.expected
@@ -1,0 +1,1 @@
+let f = "hello world!"


### PR DESCRIPTION
When running `ocaml-mdx` with the direction `to-ml`, if a targeted ml file is empty, no corrections would be generated for this file.
This is due to the file parts parsing ignoring empty strings, therefore generating an empty list of parts if the file is totally empty.
My correcting forces the creation of at least one empty part.

The two commits corresponds to:
- Adding a test which should work but is currently broken. (using `--force-output` we can see that the generated correction is empty).
- Correcting the problem.