### PR TITLE
Changing ocaml-mdx rule diffs order

### DIFF
--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -81,8 +81,8 @@ let print_rule ~nd ~prelude ~md_file ~ml_files ~dirs ~root options =
 \ (name   %s)\n\
 \ (deps   (:x %s)%s)\n\
 \ (action (progn\n\
-\           (run ocaml-mdx test %a %s%s%%{x})\n\
-\           (diff? %%{x} %%{x}.corrected)\n%a)))\n"
+\           (run ocaml-mdx test %a %s%s%%{x})\n%a\n\
+\           (diff? %%{x} %%{x}.corrected))))\n"
       name
       md_file
       deps

--- a/test/dune_rules.inc
+++ b/test/dune_rules.inc
@@ -6,6 +6,6 @@
          (source_tree foo))
  (action (progn
            (run ocaml-mdx test --direction=to-ml %{x})
-           (diff? %{x} %{x}.corrected)
            (diff? %{y1} %{y1}.corrected)
-           (diff? %{y0} %{y0}.corrected))))
+           (diff? %{y0} %{y0}.corrected)
+           (diff? %{x} %{x}.corrected))))


### PR DESCRIPTION
This pull small request move the diff of the markdown file with it's correction after the diff of the ocaml files in the generation of the dune rule.

#### The reason why is quite simple:
In the case of a promotion from md to ml, if a difference is detected between the ocaml block and the associated .ml file, the .md fiel will be corrected first by the generated rule.
Which means, that if another shell block of the markdown depends on the mentioned .ml file (eg. with a call to dune build), the markdown will first be corrected using the wrong content of the ml file, then after promotion, mdx will detect the error in the ml file, and then, after another promotion, mdx will again ask for changes in the previously wrongly corrected shell block, which means that we need 3 promotion:

```
shell block considered wrong because of the broken ml source
   |
   v
promotion of the shell block
   |
   v
ocaml source error detected
   |
   v
promotion of the ocaml source
   |
   v
shell block error added by first promotion detected
   |
   v
promotion of the shell block back to first stage
```

This is why moving the diff of the markdown file should solve the problem and avoid the 2 meaningless promotions of the shell blocks, directly going to the ocaml source promotion:
```
ocaml source error detected
   |
   v
promotion of the ocaml source
```

There is no proper way to do a regression test for this correction, as we would want to generate the rule and then modify it to check if the expected corrections are proposed.