### PR TITLE
Add a dependency on mdx package in mdx generated rules

### DIFF
--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -79,7 +79,8 @@ let print_rule ~nd ~prelude ~md_file ~ml_files ~dirs ~root options =
       "\
 (alias\n\
 \ (name   %s)\n\
-\ (deps   (:x %s)%s)\n\
+\ (deps   (:x %s)\n\
+\         (package mdx)%s)\n\
 \ (action (progn\n\
 \           (run ocaml-mdx test %a %s%s%%{x})\n\
 \           (diff? %%{x} %%{x}.corrected)\n%a)))\n"

--- a/test/dune_rules.inc
+++ b/test/dune_rules.inc
@@ -1,6 +1,7 @@
 (alias
  (name   runtest)
  (deps   (:x dune_rules.md)
+         (package mdx)
          (:y1 dune_rules_1.ml)
          (:y0 dune_rules_2.ml)
          (source_tree foo))


### PR DESCRIPTION
This prevents error due to duplicate binary from happening when vendoring mdx. It's a quick fix rather than a long term solution to #138 since technically we still need to make `ocaml-mdx` depend on `ocaml-mdx-test`.

