### PR TITLE
Duniverse mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### unreleased
+
+#### Added
+
+- Add a `--duniverse-mode` to `ocaml-mdx rule` so that the generated rules work
+  within a duniverse
+
 ### 1.5.0 (2019-11-29)
 
 #### Added

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -1,5 +1,7 @@
 open Cmdliner.Term
 
+val named: ('a -> 'b) -> 'a t -> 'b t
+
 val non_deterministic: [> `Non_deterministic of bool ] t
 
 val syntax: [> `Syntax of Mdx.syntax option ] t

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -145,7 +145,7 @@ let pp_prelude_str fmt s = Fmt.pf fmt "--prelude-str %S" s
 let add_opt e s = match e with None -> s | Some e -> String.Set.add e s
 
 let aggregate_requires ~require_from l =
-  let open Rresult.R.Infix in
+  let open Mdx.Util.Result.Infix in
   Mdx.Util.Result.List.fold
     ~f:(fun acc x -> require_from x >>| Mdx.Library.Set.union acc)
     ~init:Mdx.Library.Set.empty
@@ -171,7 +171,7 @@ let requires_from_prelude prelude_list =
 let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax) (`Direction direction)
     (`Prelude prelude) (`Prelude_str prelude_str) (`Root root)
     (`Duniverse_mode duniverse_mode) (`Locks locks) =
-  let open Rresult.R.Infix in
+  let open Mdx.Util.Result.Infix in
   let active =
     let section = match section with
       | None   -> None

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -43,12 +43,8 @@ let pp_action fmt = function
 let pp_locks_field fmt dirs_and_files =
   match dirs_and_files with
   | [] -> ()
-  | [lock] ->
-    Fmt.pf fmt " (locks %s)\n" lock
-  | l ->
-    let sep = Fmt.(const string "\n   ") in
-    Fmt.(list ~sep string) fmt (" (locks"::l);
-    Fmt.pf fmt ")\n"
+  | locks ->
+    Fmt.pf fmt " (locks @[%a@])\n" Fmt.(list ~sep:(unit "@\n") string) locks
 
 let pp_rules ~nd ~prelude ~md_file ~ml_files ~dirs ~root ~packages ~locks
     fmt options =

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -230,6 +230,7 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax) (`Direct
       Printf.eprintf "Fatal error while parsing block: %s" s;
       exit 1
     | Ok (ml_files, dirs, nd, packages) ->
+      let packages = if duniverse_mode then String.Set.add "mdx" packages else packages in
       let options =
         List.map (Fmt.to_to_string pp_prelude) prelude @
         List.map (Fmt.to_to_string pp_prelude_str) prelude_str @

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -214,10 +214,16 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax) (`Direct
   let on_file file_contents items =
     let empty = String.Set.empty in
     let req_res =
-      requires_from_prelude prelude >>= fun prelude_requires ->
-      requires_from_prelude_str prelude_str >>= fun prelude_str_requires ->
-      let requires = String.Set.union prelude_requires prelude_str_requires in
-      Mdx.Util.Result.List.fold ~f:on_item ~init:(empty, empty, false, requires) items
+      let packages =
+        if duniverse_mode then
+          requires_from_prelude prelude >>= fun prelude_requires ->
+          requires_from_prelude_str prelude_str >>= fun prelude_str_requires ->
+          Ok (String.Set.union prelude_requires prelude_str_requires)
+        else
+          Ok String.Set.empty
+      in
+      packages >>= fun packages ->
+      Mdx.Util.Result.List.fold ~f:on_item ~init:(empty, empty, false, packages) items
     in
     match req_res with
     | Error s ->

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -328,13 +328,9 @@ let required_libraries = function
 let required_packages t =
   let open Rresult.R.Infix in
   let explicit = String.Set.of_list (explicit_required_packages t) in
-  let toplevel_requires =
-    required_libraries t >>| fun lib_set ->
-    Library.Set.elements lib_set
-    |> List.map (fun lib -> lib.Library.base_name)
-    |> String.Set.of_list
-  in
-  toplevel_requires >>| String.Set.union explicit
+  required_libraries t >>| fun toplevel_required_libs ->
+  let toplevel_requires = Library.Set.to_package_set toplevel_required_libs in
+  String.Set.union explicit toplevel_requires
 
 let value t = t.value
 let section t = t.section

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -15,6 +15,7 @@
  *)
 
 open Astring
+open Result
 
 type section = int * string
 
@@ -291,7 +292,7 @@ let unset_variables t =
   in
   List.map f (get_prefixed_labels t "unset-")
 
-let required_packages t =
+let explicit_required_packages t =
   let f = function
     | `Eq, "" ->
       Fmt.failwith "invalid `require-package` label value: requires a value"
@@ -299,6 +300,41 @@ let required_packages t =
     | _ -> Fmt.failwith "invalid `require-package` label value"
   in
   List.map f (get_labels t "require-package")
+
+let require_re =
+  let open Re in
+  seq [str "#require \""; group (rep1 any); str "\""]
+
+let require_from_line line =
+  let open Rresult.R.Infix in
+  let re = Re.compile require_re in
+  match Re.exec_opt re line with
+  | None -> Ok Library.Set.empty
+  | Some group ->
+    let matched = Re.Group.get group 1 in
+    let libs_str = String.cuts ~sep:"," matched in
+    Util.Result.List.map ~f:Library.from_string libs_str >>| fun libs ->
+    List.fold_left (fun acc l -> Library.Set.add l acc) Library.Set.empty libs
+
+let require_from_lines lines =
+  let open Rresult.R.Infix in
+  Util.Result.List.map ~f:require_from_line lines >>| fun libs ->
+  List.fold_left Library.Set.union Library.Set.empty libs
+
+let required_libraries = function
+  | { value = Toplevel _; contents; _} -> require_from_lines contents
+  | { value = (Raw | OCaml | Error _ | Cram _); _ } -> Ok Library.Set.empty
+
+let required_packages t =
+  let open Rresult.R.Infix in
+  let explicit = String.Set.of_list (explicit_required_packages t) in
+  let toplevel_requires =
+    required_libraries t >>| fun lib_set ->
+    Library.Set.elements lib_set
+    |> List.map (fun lib -> lib.Library.base_name)
+    |> String.Set.of_list
+  in
+  toplevel_requires >>| String.Set.union explicit
 
 let value t = t.value
 let section t = t.section

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -314,7 +314,7 @@ let require_from_line line =
     let matched = Re.Group.get group 1 in
     let libs_str = String.cuts ~sep:"," matched in
     Util.Result.List.map ~f:Library.from_string libs_str >>| fun libs ->
-    List.fold_left (fun acc l -> Library.Set.add l acc) Library.Set.empty libs
+    Library.Set.of_list libs
 
 let require_from_lines lines =
   let open Util.Result.Infix in

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -306,7 +306,7 @@ let require_re =
   seq [str "#require \""; group (rep1 any); str "\""]
 
 let require_from_line line =
-  let open Rresult.R.Infix in
+  let open Util.Result.Infix in
   let re = Re.compile require_re in
   match Re.exec_opt re line with
   | None -> Ok Library.Set.empty
@@ -317,7 +317,7 @@ let require_from_line line =
     List.fold_left (fun acc l -> Library.Set.add l acc) Library.Set.empty libs
 
 let require_from_lines lines =
-  let open Rresult.R.Infix in
+  let open Util.Result.Infix in
   Util.Result.List.map ~f:require_from_line lines >>| fun libs ->
   List.fold_left Library.Set.union Library.Set.empty libs
 
@@ -326,7 +326,7 @@ let required_libraries = function
   | { value = (Raw | OCaml | Error _ | Cram _); _ } -> Ok Library.Set.empty
 
 let required_packages t =
-  let open Rresult.R.Infix in
+  let open Util.Result.Infix in
   let explicit = String.Set.of_list (explicit_required_packages t) in
   required_libraries t >>| fun toplevel_required_libs ->
   let toplevel_requires = Library.Set.to_package_set toplevel_required_libs in

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -325,13 +325,6 @@ let required_libraries = function
   | { value = Toplevel _; contents; _} -> require_from_lines contents
   | { value = (Raw | OCaml | Error _ | Cram _); _ } -> Ok Library.Set.empty
 
-let required_packages t =
-  let open Util.Result.Infix in
-  let explicit = String.Set.of_list (explicit_required_packages t) in
-  required_libraries t >>| fun toplevel_required_libs ->
-  let toplevel_requires = Library.Set.to_package_set toplevel_required_libs in
-  String.Set.union explicit toplevel_requires
-
 let value t = t.value
 let section t = t.section
 let header t = t.header

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -94,8 +94,17 @@ val set_variables: t -> (string * string) list
 val unset_variables: t -> string list
 (** [unset_variable t] is the list of environment variable to unset *)
 
-val required_packages: t -> string list
-(** [required_packages t] is the names of the required packages *)
+val explicit_required_packages: t -> string list
+(** [explicit_required_packages t] returns the list of packages explicitly required by the user
+    through require-package labels in the block [t]. *)
+
+val required_libraries: t -> (Library.Set.t, string) Result.result
+(** [required_libraries t] returns the set of libaries that are loaded through [#require]
+    statements in the block [t]. Always returns an empty set if [t] isn't a toplevel
+    block. *)
+
+val required_packages: t -> (Astring.String.Set.t, string) Result.result
+(** [required_packages t] returns all packages that the block [t] depends upon. *)
 
 val skip: t -> bool
 (** [skip t] is true iff [skip] is in the labels of [t]. *)
@@ -130,3 +139,11 @@ val labels_of_string:
   string ->
   (string * ([`Eq | `Neq | `Gt | `Ge | `Lt | `Le] * string) option) list
 (** [labels_of_string s] cuts [s] into a list of labels. *)
+
+val require_from_line : string -> (Library.Set.t, string) Result.result
+(** [require_from_line line] returns the set of libraries imported by the
+    #require statement on [line] or an empty set if [line] is not a require
+    statement. *)
+
+val require_from_lines : string list -> (Library.Set.t, string) Result.result
+(** Same as [require_from_line] but aggregated over several lines *)

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -103,9 +103,6 @@ val required_libraries: t -> (Library.Set.t, string) Result.result
     statements in the block [t]. Always returns an empty set if [t] isn't a toplevel
     block. *)
 
-val required_packages: t -> (Astring.String.Set.t, string) Result.result
-(** [required_packages t] returns all packages that the block [t] depends upon. *)
-
 val skip: t -> bool
 (** [skip t] is true iff [skip] is in the labels of [t]. *)
 

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name        mdx)
  (public_name mdx)
  (preprocess (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
- (libraries   astring fmt logs ocaml-migrate-parsetree ocaml-version re result))
+ (libraries   astring fmt logs ocaml-migrate-parsetree ocaml-version re result rresult))
 
 (ocamllex lexer)
 (ocamllex lexer_cram)

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name        mdx)
  (public_name mdx)
  (preprocess (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
- (libraries   astring fmt logs ocaml-migrate-parsetree ocaml-version re result rresult))
+ (libraries   astring fmt logs ocaml-migrate-parsetree ocaml-version re result))
 
 (ocamllex lexer)
 (ocamllex lexer_cram)

--- a/lib/library.ml
+++ b/lib/library.ml
@@ -48,8 +48,8 @@ let from_string s =
   match Astring.String.cuts ~sep:"." s with
   | [""] | [""; _] | [_; ""] -> invalid ()
   | [base_name] -> Ok {base_name; sub_lib = None}
-  | [base_name; sl] -> Ok {base_name; sub_lib = Some sl}
-  | _ -> invalid ()
+  | base_name::sl -> Ok {base_name; sub_lib = Some (String.concat "." sl)}
+  | [] -> assert false (* String.cuts invariant *)
 
 module Set = struct
   include Set.Make(struct

--- a/lib/library.ml
+++ b/lib/library.ml
@@ -1,0 +1,46 @@
+open Result
+
+type t =
+  { base_name : string
+  ; sub_lib : string option
+  }
+
+let compare t t' =
+  let compare_opt cmp o o' =
+    match o, o' with
+    | None, None -> 0
+    | None, _ -> -1
+    | _, None -> 1
+    | Some x, Some x' -> cmp x x'
+  in
+  let {base_name; sub_lib} = t in
+  let {base_name = base_name'; sub_lib = sub_lib'} = t' in
+  match String.compare base_name base_name' with
+  | 0 -> compare_opt String.compare sub_lib sub_lib'
+  | c -> c
+
+let equal t t' = compare t t' = 0
+
+let pp fmt {base_name; sub_lib} =
+  let cst s = Fmt.(const string s) in
+  Fmt.string fmt "{ ";
+  Fmt.(pair ~sep:(cst "; ") string (option ~none:(cst "None") string)) fmt (base_name, sub_lib);
+  Fmt.string fmt " }"
+
+let from_string s =
+  let invalid () = Error (Printf.sprintf "Invalid library name: %S" s) in
+  match Astring.String.cuts ~sep:"." s with
+  | [""] | [""; _] | [_; ""] -> invalid ()
+  | [base_name] -> Ok {base_name; sub_lib = None}
+  | [base_name; sl] -> Ok {base_name; sub_lib = Some sl}
+  | _ -> invalid ()
+
+module Set = struct
+  include Set.Make(struct
+    type nonrec t = t
+    let compare = compare
+  end)
+
+  let to_package_set t =
+    fold (fun t acc -> Astring.String.Set.add t.base_name acc) t Astring.String.Set.empty
+end

--- a/lib/library.ml
+++ b/lib/library.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2019 Nathan Rebours <nathan.p.rebours@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 open Result
 
 type t =

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -1,0 +1,18 @@
+type t =
+  { base_name : string
+  ; sub_lib : string option
+  }
+
+val equal : t -> t -> bool
+
+val compare : t -> t -> int
+
+val pp : t Fmt.t
+
+val from_string : string -> (t, string) Result.result
+
+module Set : sig
+  include Set.S with type elt = t
+
+  val to_package_set : t -> Astring.String.Set.t
+end

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2019 Nathan Rebours <nathan.p.rebours@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 type t =
   { base_name : string
   ; sub_lib : string option

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -14,6 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+(** The type to represent dune libraries as referred to in '#require' statements
+    or in dune files.
+    I.e. lib.sub_lib is [{base_name = "lib"; sub_lib = Some "sub_lib"}].
+    *)
 type t =
   { base_name : string
   ; sub_lib : string option
@@ -25,10 +29,16 @@ val compare : t -> t -> int
 
 val pp : t Fmt.t
 
+(** [from_string s] returns the library represented by [s] or an error if [s]
+    isn't a valid library. *)
 val from_string : string -> (t, string) Result.result
 
+(** Set of libraries *)
 module Set : sig
   include Set.S with type elt = t
 
+  (** [to_package_set lib_set] returns the set of dune packages needed to get
+      all the libraries in [lib_set].
+      I.e. it's the set of basenames for all the libraries in [lib_set]. *)
   val to_package_set : t -> Astring.String.Set.t
 end

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -25,6 +25,7 @@ module Block = Block
 module Migrate_ast = Migrate_ast
 module Compat = Compat
 module Util = Util
+module Prelude = Prelude
 
 type line =
   | Section of (int * string)

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -20,9 +20,11 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module Output = Output
 module Cram = Cram
 module Toplevel = Toplevel
+module Library = Library
 module Block = Block
 module Migrate_ast = Migrate_ast
 module Compat = Compat
+module Util = Util
 
 type line =
   | Section of (int * string)

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -31,6 +31,7 @@ module Block = Block
 module Migrate_ast = Migrate_ast
 module Compat = Compat
 module Util = Util
+module Prelude = Prelude
 
 (** {2 Lines} *)
 

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -26,9 +26,11 @@
 module Output = Output
 module Cram = Cram
 module Toplevel = Toplevel
+module Library = Library
 module Block = Block
 module Migrate_ast = Migrate_ast
 module Compat = Compat
+module Util = Util
 
 (** {2 Lines} *)
 

--- a/lib/prelude.ml
+++ b/lib/prelude.ml
@@ -1,0 +1,7 @@
+let env_and_file f =
+  match Astring.String.cut ~sep:":" f with
+  | None        -> None, f
+  | Some (e, f) ->
+    if Astring.String.exists ((=) ' ') e
+    then None  , f
+    else Some e, f

--- a/lib/prelude.ml
+++ b/lib/prelude.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2019 Nathan Rebours <nathan.p.rebours@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 let env_and_file f =
   match Astring.String.cut ~sep:":" f with
   | None        -> None, f

--- a/lib/prelude.mli
+++ b/lib/prelude.mli
@@ -1,0 +1,1 @@
+val env_and_file : string -> string option * string

--- a/lib/prelude.mli
+++ b/lib/prelude.mli
@@ -14,4 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+(** [env_and_file s] returns the environment and file/prelude string describe
+    by [s].
+    I.e. [env_and_file "a:prelude.ml"] is [(Some "a", "prelude.ml")]. *)
 val env_and_file : string -> string option * string

--- a/lib/prelude.mli
+++ b/lib/prelude.mli
@@ -1,1 +1,17 @@
+(*
+ * Copyright (c) 2019 Nathan Rebours <nathan.p.rebours@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 val env_and_file : string -> string option * string

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -17,8 +17,20 @@
 open Result
 
 module Result = struct
+  module Infix = struct
+    let (>>=) r f =
+      match r with
+      | Ok x -> f x
+      | Error _ as e -> e
+
+    let (>>|) r f =
+      match r with
+      | Ok x -> Ok (f x)
+      | Error _ as e -> e
+  end
+
   module List = struct
-    open Rresult.R.Infix
+    open Infix
 
     let fold ~f ~init l =
       let rec go acc = function

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -17,3 +17,13 @@ module Result = struct
       fold ~f:(fun acc elm -> f elm >>| fun elm' -> elm'::acc) ~init:[] l >>| List.rev
   end
 end
+
+module File = struct
+  let read_lines file =
+    let ic = open_in file in
+    let r = ref [] in
+    try while true do r := input_line ic :: !r done; assert false
+    with End_of_file ->
+      close_in ic;
+      List.rev !r
+end

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1,0 +1,19 @@
+open Result
+
+module Result = struct
+  module List = struct
+    open Rresult.R.Infix
+
+    let fold ~f ~init l =
+      let rec go acc = function
+        | [] -> Ok acc
+        | hd::tl ->
+          f acc hd >>= fun acc ->
+          go acc tl
+      in
+      go init l
+
+    let map ~f l =
+      fold ~f:(fun acc elm -> f elm >>| fun elm' -> elm'::acc) ~init:[] l >>| List.rev
+  end
+end

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2019 Nathan Rebours <nathan.p.rebours@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 open Result
 
 module Result = struct

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -1,0 +1,14 @@
+module Result : sig
+  module List : sig
+    val fold :
+      f: ('acc -> 'a -> ('acc, 'err) Result.result) ->
+      init: 'acc ->
+      'a list ->
+      ('acc, 'err) Result.result
+
+    val map :
+      f: ('a -> ('b, 'err) Result.result) ->
+      'a list ->
+      ('b list, 'err) Result.result
+  end
+end

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -12,3 +12,7 @@ module Result : sig
       ('b list, 'err) Result.result
   end
 end
+
+module File : sig
+  val read_lines : string -> string list
+end

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -1,3 +1,19 @@
+(*
+ * Copyright (c) 2019 Nathan Rebours <nathan.p.rebours@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 module Result : sig
   module List : sig
     val fold :

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -14,18 +14,26 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Result
+
 module Result : sig
+  module Infix : sig
+    val (>>=) : ('a, 'err) result -> ('a -> ('b, 'err) result) -> ('b, 'err) result
+
+    val (>>|) : ('a, 'err) result -> ('a -> 'b) -> ('b, 'err) result
+  end
+
   module List : sig
     val fold :
-      f: ('acc -> 'a -> ('acc, 'err) Result.result) ->
+      f: ('acc -> 'a -> ('acc, 'err) result) ->
       init: 'acc ->
       'a list ->
-      ('acc, 'err) Result.result
+      ('acc, 'err) result
 
     val map :
-      f: ('a -> ('b, 'err) Result.result) ->
+      f: ('a -> ('b, 'err) result) ->
       'a list ->
-      ('b list, 'err) Result.result
+      ('b list, 'err) result
   end
 end
 

--- a/mdx.opam
+++ b/mdx.opam
@@ -24,7 +24,6 @@ depends: [
   "cmdliner"
   "re" {>= "1.7.2"}
   "result"
-  "rresult"
   "ocaml-migrate-parsetree" {>= "1.0.6"}
   "ocaml-version" {>= "2.3.0"}
   "lwt" {with-test}

--- a/mdx.opam
+++ b/mdx.opam
@@ -24,9 +24,11 @@ depends: [
   "cmdliner"
   "re" {>= "1.7.2"}
   "result"
+  "rresult"
   "ocaml-migrate-parsetree" {>= "1.0.6"}
   "ocaml-version" {>= "2.3.0"}
   "lwt" {with-test}
+  "alcotest" {with-test}
 ]
 
 synopsis: "Executable code blocks inside markdown files"

--- a/test/bin/mdx-rule/misc/duniverse-mode/dune
+++ b/test/bin/mdx-rule/misc/duniverse-mode/dune
@@ -1,0 +1,10 @@
+(rule
+ (target dune.gen)
+ (action
+  (with-stdout-to %{target}
+   (run ocaml-mdx rule --duniverse-mode --prelude %{dep:prelude.ml}
+     --prelude-str "#require \"prelude-str\"" %{dep:duniverse-mode.md}))))
+
+(alias
+ (name runtest)
+ (action (diff %{dep:dune.gen.expected} %{dep:dune.gen})))

--- a/test/bin/mdx-rule/misc/duniverse-mode/dune.gen.expected
+++ b/test/bin/mdx-rule/misc/duniverse-mode/dune.gen.expected
@@ -1,0 +1,14 @@
+(alias
+ (name runtest)
+ (deps
+  (:x duniverse-mode.md)
+  (package block)
+  (package mdx)
+  (package prelude-ml)
+  (package prelude-str)
+  prelude.ml)
+ (action
+  (progn
+   (run ocaml-mdx test --prelude=prelude.ml --prelude-str
+     "#require \"prelude-str\"" --direction=to-md %{x})
+   (diff? %{x} %{x}.corrected))))

--- a/test/bin/mdx-rule/misc/duniverse-mode/duniverse-mode.md
+++ b/test/bin/mdx-rule/misc/duniverse-mode/duniverse-mode.md
@@ -1,0 +1,13 @@
+In duniverse mode, the generated rule for this block should contain a `(package block)` dependency:
+
+```ocaml
+# #require "block";;
+# 1 + 2
+- int : 3
+```
+
+The generated rule should also contain `(package x)` deps for every require in the prelude, both
+`.ml` preludes and string ones.
+
+Finally it should have a `(package mdx)` dependency as well since with duniverse, mdx should be
+vendored!

--- a/test/bin/mdx-rule/misc/duniverse-mode/prelude.ml
+++ b/test/bin/mdx-rule/misc/duniverse-mode/prelude.ml
@@ -1,0 +1,1 @@
+#require "prelude-ml";;

--- a/test/lib/dune
+++ b/test/lib/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_mdx_lib)
+ (libraries alcotest mdx))

--- a/test/lib/test_block.ml
+++ b/test/lib/test_block.ml
@@ -1,0 +1,40 @@
+module Testable = struct
+  let library_set =
+    let open Mdx.Library in
+    let equal = Set.equal in
+    let pp fmt set =
+      let l = Set.elements set in
+      Fmt.string fmt "[ ";
+      Fmt.(list ~sep:(const string "; ") pp) fmt l;
+      Fmt.string fmt " ]"
+    in
+    Alcotest.testable pp equal
+end
+
+let test_require_from_line =
+  let make_test ~line ~expected () =
+    let open Rresult.R.Infix in
+    let test_name = Printf.sprintf "require_from_line: %S" line in
+    let expected = expected >>| Mdx.Library.Set.of_list in
+    let test_fun () =
+      let actual = Mdx.Block.require_from_line line in
+      Alcotest.(check (result Testable.library_set string)) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [ make_test ~line:"let x = 2 + 2" ~expected:(Ok []) ()
+  ; make_test ~line:"#require \"a\"" ~expected:(Ok [{base_name = "a"; sub_lib = None}]) ()
+  ; make_test ~line:"# #require \"a\";;" ~expected:(Ok [{base_name = "a"; sub_lib = None}]) ()
+  ; make_test
+      ~line:"#require \"a,b.c,d\""
+      ~expected:
+        (Ok
+           [ {base_name = "a"; sub_lib = None}
+           ; {base_name = "b"; sub_lib = Some "c"}
+           ; {base_name = "d"; sub_lib = None}
+           ]
+        )
+      ()
+  ]
+
+let suite = ("Block", test_require_from_line)

--- a/test/lib/test_block.ml
+++ b/test/lib/test_block.ml
@@ -13,7 +13,7 @@ end
 
 let test_require_from_line =
   let make_test ~line ~expected () =
-    let open Rresult.R.Infix in
+    let open Mdx.Util.Result.Infix in
     let test_name = Printf.sprintf "require_from_line: %S" line in
     let expected = expected >>| Mdx.Library.Set.of_list in
     let test_fun () =

--- a/test/lib/test_block.mli
+++ b/test/lib/test_block.mli
@@ -1,0 +1,1 @@
+val suite : unit Alcotest.test

--- a/test/lib/test_library.ml
+++ b/test/lib/test_library.ml
@@ -1,0 +1,24 @@
+module Testable = struct
+  open Mdx.Library
+
+  let library = Alcotest.testable pp equal
+end
+
+let test_from_string =
+  let make_test ~str ~expected () =
+    let test_name = Printf.sprintf "from_string: %S" str in
+    let test_fun () =
+      let actual = Mdx.Library.from_string str in
+      Alcotest.(check (result Testable.library string)) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [ make_test ~str:"some-lib" ~expected:(Ok {base_name = "some-lib"; sub_lib = None}) ()
+  ; make_test ~str:"some.lib" ~expected:(Ok {base_name = "some"; sub_lib = Some "lib"}) ()
+  ; make_test ~str:"" ~expected:(Error "Invalid library name: \"\"") ()
+  ; make_test ~str:".lib" ~expected:(Error "Invalid library name: \".lib\"") ()
+  ; make_test ~str:"some." ~expected:(Error "Invalid library name: \"some.\"") ()
+  ; make_test ~str:"a.b.c" ~expected:(Error "Invalid library name: \"a.b.c\"") ()
+  ]
+
+let suite = ("Library", test_from_string)

--- a/test/lib/test_library.ml
+++ b/test/lib/test_library.ml
@@ -15,10 +15,10 @@ let test_from_string =
   in
   [ make_test ~str:"some-lib" ~expected:(Ok {base_name = "some-lib"; sub_lib = None}) ()
   ; make_test ~str:"some.lib" ~expected:(Ok {base_name = "some"; sub_lib = Some "lib"}) ()
+  ; make_test ~str:"some.lib.x" ~expected:(Ok {base_name = "some"; sub_lib = Some "lib.x"}) ()
   ; make_test ~str:"" ~expected:(Error "Invalid library name: \"\"") ()
   ; make_test ~str:".lib" ~expected:(Error "Invalid library name: \".lib\"") ()
   ; make_test ~str:"some." ~expected:(Error "Invalid library name: \"some.\"") ()
-  ; make_test ~str:"a.b.c" ~expected:(Error "Invalid library name: \"a.b.c\"") ()
   ]
 
 let suite = ("Library", test_from_string)

--- a/test/lib/test_library.mli
+++ b/test/lib/test_library.mli
@@ -1,0 +1,1 @@
+val suite : unit Alcotest.test

--- a/test/lib/test_mdx_lib.ml
+++ b/test/lib/test_mdx_lib.ml
@@ -1,0 +1,5 @@
+let () =
+  Alcotest.run "Mdx"
+    [ Test_block.suite
+    ; Test_library.suite
+    ]


### PR DESCRIPTION
This PR adds a `--duniverse-mode` flag to `mdx rule` to generate rules that works within a dune-only context and therefore with a `duniverse`.

This is done by parsing the `#require` statements within OCaml toplevel code blocks, adding `(package ...)` dependencies to the `mdx test` rule for any package found that way and by setting `findlib`'s config so that it looks in the `_build/install` directory instead.

This is more of an hack rather than a long term solution but it gives us something to iterate on and it solves some issues for [realworldocaml/book](https://github.com/realworldocaml/book).

Let me know what you think!