### PR TITLE
Use ocaml-version to parse the version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: c
 env:
   # Check build and unit tests
   # NOTE: testing needs OPAMBUILDTEST=true so that test deps are installed
+  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.02.3
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.03.0
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.04.2
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.05.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 env:
   # Check build and unit tests
   # NOTE: testing needs OPAMBUILDTEST=true so that test deps are installed
-  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.02.3
+  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.02.3 OPAM_OPTS=--unlock-base
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.03.0
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.04.2
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.05.0
@@ -25,7 +25,7 @@ install:
   - wget https://github.com/jgm/pandoc/releases/download/2.4/pandoc-2.4-linux.tar.gz
   - sudo tar xvzf pandoc-2.4-linux.tar.gz --strip-components 1 -C /usr/local
   - ${HOME}/opam pin add --no-action mdx .
-  - ${HOME}/opam install --deps-only mdx
+  - ${HOME}/opam install --deps-only mdx ${OPAM_OPTS}
 script:
   # Build and launch the tests
   - if [ "$TO_TEST" = "tests" ]; then make && make test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 env:
   # Check build and unit tests
   # NOTE: testing needs OPAMBUILDTEST=true so that test deps are installed
-  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.02.3 OPAM_OPTS=--unlock-base
+  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.02.3
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.03.0
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.04.2
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.05.0
@@ -25,7 +25,7 @@ install:
   - wget https://github.com/jgm/pandoc/releases/download/2.4/pandoc-2.4-linux.tar.gz
   - sudo tar xvzf pandoc-2.4-linux.tar.gz --strip-components 1 -C /usr/local
   - ${HOME}/opam pin add --no-action mdx .
-  - ${HOME}/opam install --deps-only mdx ${OPAM_OPTS}
+  - ${HOME}/opam install --deps-only mdx
 script:
   # Build and launch the tests
   - if [ "$TO_TEST" = "tests" ]; then make && make test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: c
 env:
   # Check build and unit tests
   # NOTE: testing needs OPAMBUILDTEST=true so that test deps are installed
-  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.02.3
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.03.0
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.04.2
   - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.05.0

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -111,11 +111,6 @@ val executable_contents: t -> string list
    or a cram block, or [t]'s commands if [t] is a toplevel fragments
    (e.g. the phrase result is discarded). *)
 
-val version:
-  t ->
-  [`Eq | `Neq | `Ge | `Gt | `Le | `Lt] * int option * int option * int option
-(** [version t] is [t]'s OCaml version. *)
-
 val version_enabled: t -> bool
 (** [version_supported t] if the current OCaml version complies with [t]'s
     version. *)

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name        mdx)
  (public_name mdx)
  (preprocess (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
- (libraries   astring fmt logs ocaml-migrate-parsetree re result))
+ (libraries   astring fmt logs ocaml-migrate-parsetree ocaml-version re result))
 
 (ocamllex lexer)
 (ocamllex lexer_cram)

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -72,19 +72,3 @@ let err lexbuf fmt =
   Fmt.kstrf (fun str ->
       Fmt.failwith "%a: %s" pp_position lexbuf str
     ) fmt
-
-let parse_version v =
-  let to_string = String.Sub.to_string in
-  let to_int x = try Some (int_of_string x) with _ -> None in
-  let is_dot c = c = '.' in
-  match String.find is_dot v with
-  | None -> to_int v, None, None
-  | Some i_dot_1 ->
-     let major = String.sub ~stop:i_dot_1 v |> to_string |> to_int in
-     let remain = String.sub ~start:(i_dot_1+1) v |> to_string in
-     match String.find is_dot remain with
-     | None -> major, to_int remain, None
-     | Some i_dot_2 ->
-        let minor = String.sub ~stop:i_dot_2 remain |> to_string |> to_int in
-        let remain = String.sub ~start:(i_dot_2+1) remain |> to_string in
-        major, minor, to_int remain

--- a/mdx.opam
+++ b/mdx.opam
@@ -25,7 +25,7 @@ depends: [
   "re" {>= "1.7.2"}
   "result"
   "ocaml-migrate-parsetree" {>= "1.0.6"}
-  "ocaml-version"
+  "ocaml-version" {>= "2.3.0"}
   "lwt" {with-test}
   "conf-pandoc" {with-test}
 ]

--- a/mdx.opam
+++ b/mdx.opam
@@ -25,6 +25,7 @@ depends: [
   "re" {>= "1.7.2"}
   "result"
   "ocaml-migrate-parsetree" {>= "1.0.6"}
+  "ocaml-version"
   "lwt" {with-test}
   "conf-pandoc" {with-test}
 ]

--- a/mdx.opam
+++ b/mdx.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.03.0"}
   "dune" {build}
   "ocamlfind"
   "fmt"

--- a/mdx.opam
+++ b/mdx.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.02.3"}
   "dune" {build}
   "ocamlfind"
   "fmt"


### PR DESCRIPTION
Fix #151 
Now the parsing is done with `ocaml-version` and every weird-shaped version should be correctly handled. Difficult to test because not every version can be tested with the CI script.