### PR TITLE
Fix parts syncing

### DIFF
--- a/lib/top/part.mli
+++ b/lib/top/part.mli
@@ -30,4 +30,5 @@ val find: file -> part:string option -> string list option
 
 val replace: file -> part:string option -> lines:string list -> file
 (** [replace ~file ~part ~lines] returns the lines of the file [file] where
-    the lines of part [part] have been replaced by [lines]. *)
+    the lines of part [part] have been replaced by [lines].
+    If [part] does not occur in the file, a new part is added at the end. *)

--- a/test/sync_to_ml.md
+++ b/test/sync_to_ml.md
@@ -30,6 +30,10 @@ val x : int = 2
 - : unit = ()
 ```
 
+```ocaml file=sync_to_ml.ml,part=new-part-not-in-original
+let g = [ f ]
+```
+
 ```ocaml file=sync_to_broken_ml.ml
 let () =
   module MyString = String;

--- a/test/sync_to_ml.md.expected
+++ b/test/sync_to_ml.md.expected
@@ -30,6 +30,10 @@ val x : int = 2
 - : unit = ()
 ```
 
+```ocaml file=sync_to_ml.ml,part=new-part-not-in-original
+let g = [ f ]
+```
+
 ```ocaml file=sync_to_broken_ml.ml
 let () =
   module MyString = String;

--- a/test/sync_to_ml.ml.expected
+++ b/test/sync_to_ml.ml.expected
@@ -21,3 +21,7 @@ let f = "hello world!"
 
 let () =
   f x print_int
+
+[@@@part "new-part-not-in-original"] ;;
+
+let g = [ f ]


### PR DESCRIPTION
Fixes https://github.com/realworldocaml/mdx/issues/154.

If a part does not exist it is appended to the file.
A bug remain: Parts are not inserted in the order they appear in the markdown file.