### PR TITLE
Modify 'pp' to respect the 'skip' label

### DIFF
--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -34,16 +34,18 @@ let run () file section =
         | Mdx.Section _ | Text _ -> ()
         | Block b ->
           let b = Mdx.Block.eval b in
-          Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
-          let pp_lines = Fmt.(list ~sep:(unit "\n") string) in
-          let contents = Mdx.Block.executable_contents b in
-          match b.value with
-          | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
-          | OCaml      ->
-            Fmt.pr "%a\n%a\n"
-              Mdx.Block.pp_line_directive (file, b.line)
-              pp_lines contents
-          | _          -> ()
+          if not (Mdx.Block.skip b) then (
+            Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
+            let pp_lines = Fmt.(list ~sep:(unit "\n") string) in
+            let contents = Mdx.Block.executable_contents b in
+            match b.value with
+            | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
+            | OCaml      ->
+              Fmt.pr "%a\n%a\n"
+                Mdx.Block.pp_line_directive (file, b.line)
+                pp_lines contents
+            | _          -> ()
+          )
       ) t;
     0
 

--- a/test/section.md
+++ b/test/section.md
@@ -40,3 +40,11 @@ let () = print_endline (string_of_int x)
    # print_endline "42";;
    42
 ```
+
+## Skipped blocks
+
+This block should not be executed by the tests:
+
+```ocaml skip
+let () = assert false
+```

--- a/test/section.md.expected
+++ b/test/section.md.expected
@@ -50,3 +50,11 @@ let () = print_endline (string_of_int x)
    # print_endline "42";;
    42
 ```
+
+## Skipped blocks
+
+This block should not be executed by the tests:
+
+```ocaml skip
+let () = assert false
+```


### PR DESCRIPTION
This fixes #159.

Perhaps there are less hacky ways to do this? I was trying to minimise the diff.