### PR TITLE
Cleanup rule printing

### DIFF
--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -80,14 +80,13 @@ let print_rule ~nd ~prelude ~md_file ~ml_files ~dirs ~root ~requires options =
 \ (name   %s)\n\
 \ (deps   (:x %s)%s)\n\
 \ (action (progn\n\
-\           (run ocaml-mdx test %a %s%s%%{x})\n%a\n\
-\           (diff? %%{x} %%{x}.corrected))))\n"
+\           (run ocaml-mdx test %a %s%s%%{x})\n%a)))\n"
       name
       md_file
       deps
       Fmt.(list ~sep:(unit " ") string) options
       arg root
-      (Fmt.list ~sep:Fmt.cut pp_ml_diff) var_names
+      (Fmt.list ~sep:Fmt.cut pp_ml_diff) ("x" :: var_names)
   in
   pp "runtest" "";
   if nd then pp "runtest-all" "--non-deterministic "

--- a/test/dune.inc
+++ b/test/dune.inc
@@ -122,7 +122,8 @@
  (name   runtest)
  (deps   (:x prelude.md))
  (action (progn
-           (run ocaml-mdx test --prelude-str "#require \"lwt\"" --prelude-str "toto:let x = \"42\"" --direction=to-md %{x})
+           (run ocaml-mdx test --prelude-str "#require \"lwt\""
+                  --prelude-str "toto:let x = \"42\"" --direction=to-md %{x})
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)

--- a/test/dune.inc
+++ b/test/dune.inc
@@ -3,147 +3,126 @@
  (deps   (:x pp.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x ellipsis.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x envs.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x empty_line.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x spaces.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x errors.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest-all)
  (deps   (:x errors.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md --non-deterministic %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x heredoc.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x mlt.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x semisemi.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x exit.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x padding.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x multilines.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x lines.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x lwt.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x non-det.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest-all)
  (deps   (:x non-det.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md --non-deterministic %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x code.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x set_environment_variable.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x unset_environment_variable.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x prelude.md))
  (action (progn
            (run ocaml-mdx test --prelude-str "#require \"lwt\"" --prelude-str "toto:let x = \"42\"" --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
@@ -151,7 +130,6 @@
          prelude.ml)
  (action (progn
            (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
@@ -161,14 +139,13 @@
          (source_tree foo))
  (action (progn
            (run ocaml-mdx test --direction=to-ml %{x})
+           (diff? %{x} %{x}.corrected)
            (diff? %{y1} %{y1}.corrected)
-           (diff? %{y0} %{y0}.corrected)
-           (diff? %{x} %{x}.corrected))))
+           (diff? %{y0} %{y0}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x require/require-package.md)
          (package example_lib))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
-
            (diff? %{x} %{x}.corrected))))


### PR DESCRIPTION
Refactor printing code to use `Format` features, making it more robust and easier to change.

Rebased on top of https://github.com/realworldocaml/mdx/pull/162