### PR TITLE
Remove extra package deps on mdx

### DIFF
--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -78,8 +78,7 @@ let print_rule ~nd ~prelude ~md_file ~ml_files ~dirs ~root ~requires options =
       "\
 (alias\n\
 \ (name   %s)\n\
-\ (deps   (:x %s)\n\
-\         (package mdx)%s)\n\
+\ (deps   (:x %s)%s)\n\
 \ (action (progn\n\
 \           (run ocaml-mdx test %a %s%s%%{x})\n%a\n\
 \           (diff? %%{x} %%{x}.corrected))))\n"

--- a/test/dune.inc
+++ b/test/dune.inc
@@ -1,167 +1,146 @@
 (alias
  (name   runtest)
- (deps   (:x pp.md)
-         (package mdx))
+ (deps   (:x pp.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x ellipsis.md)
-         (package mdx))
+ (deps   (:x ellipsis.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x envs.md)
-         (package mdx))
+ (deps   (:x envs.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x empty_line.md)
-         (package mdx))
+ (deps   (:x empty_line.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x spaces.md)
-         (package mdx))
+ (deps   (:x spaces.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x errors.md)
-         (package mdx))
+ (deps   (:x errors.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest-all)
- (deps   (:x errors.md)
-         (package mdx))
+ (deps   (:x errors.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp --non-deterministic %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x heredoc.md)
-         (package mdx))
+ (deps   (:x heredoc.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x mlt.md)
-         (package mdx))
+ (deps   (:x mlt.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x semisemi.md)
-         (package mdx))
+ (deps   (:x semisemi.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x exit.md)
-         (package mdx))
+ (deps   (:x exit.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x padding.md)
-         (package mdx))
+ (deps   (:x padding.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x multilines.md)
-         (package mdx))
+ (deps   (:x multilines.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x lines.md)
-         (package mdx))
+ (deps   (:x lines.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x lwt.md)
-         (package mdx))
+ (deps   (:x lwt.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x non-det.md)
-         (package mdx))
+ (deps   (:x non-det.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest-all)
- (deps   (:x non-det.md)
-         (package mdx))
+ (deps   (:x non-det.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp --non-deterministic %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x code.md)
-         (package mdx))
+ (deps   (:x code.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x set_environment_variable.md)
-         (package mdx))
+ (deps   (:x set_environment_variable.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x unset_environment_variable.md)
-         (package mdx))
+ (deps   (:x unset_environment_variable.md))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
- (deps   (:x prelude.md)
-         (package mdx))
+ (deps   (:x prelude.md))
  (action (progn
            (run ocaml-mdx test --prelude-str "#require \"lwt\"" --prelude-str "toto:let x = \"42\"" --direction=infer-timestamp %{x})
 
@@ -169,7 +148,6 @@
 (alias
  (name   runtest)
  (deps   (:x prelude_file.md)
-         (package mdx)
          prelude.ml)
  (action (progn
            (run ocaml-mdx test --prelude=prelude.ml --direction=infer-timestamp %{x})
@@ -178,7 +156,6 @@
 (alias
  (name   runtest)
  (deps   (:x dune_rules.md)
-         (package mdx)
          (:y1 dune_rules_1.ml)
          (:y0 dune_rules_2.ml)
          (source_tree foo))
@@ -190,7 +167,6 @@
 (alias
  (name   runtest)
  (deps   (:x require/require-package.md)
-         (package mdx)
          (package example_lib))
  (action (progn
            (run ocaml-mdx test --direction=infer-timestamp %{x})


### PR DESCRIPTION
This reverts #141. Package dependencies cannot be resolved to opam packages by dune as of today. This so-called fix introduces a bug and the package dependency on mdx should only be added when vendoring mdx itself, eg in a duniverse.

I'll re-enable that in the `--duniverse-mode`!