### PR TITLE
Use dune modes stanza to fix warning 58

### DIFF
--- a/lib/top/dune
+++ b/lib/top/dune
@@ -1,5 +1,6 @@
 (library
  (name        mdx_top)
  (public_name mdx.top)
+ (modes       byte)
  (preprocess (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
  (libraries   unix mdx compiler-libs compiler-libs.toplevel threads findlib.top))


### PR DESCRIPTION
Fix the following warnings:
```
File "_none_", line 1: 
Warning 58: no cmx file was found in path for module Topdirs, and its interface was not compiled with -opaque
File "_none_", line 1:
Warning 58: no cmx file was found in path for module Toploop, and its interface was not compiled with -opaque
```