### PR TITLE
Remove infer-timestamp direction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
 - Remove trailing whitespaces at the end of toplevel or bash evaluation lines
   (#166, @clecat)
 
+#### Removed
+
+- Remove the `infer-timestamp` direction (#171 @Julow)
+
 ### 1.4.0 (2019-06-11)
 
 - Add `--force-output` option to force generation of diff file (#118 @clecat)

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -84,7 +84,7 @@ let direction =
              the .md file is the reference and updates the .ml and \
              the .md files accordingly. $(b,to-md) assumes the .ml \
              file is the reference and updates the .md file \
-             accordingly." in
+             accordingly. The default is $(b,to-md)." in
   let opt_names =
     [ "to-md", `To_md
     ; "to-ml", `To_ml ]
@@ -93,7 +93,7 @@ let direction =
   let docv = String.concat "|" (List.map fst opt_names) in
   let docv = "{" ^ docv ^ "}" in
   named (fun x -> `Direction x)
-    Arg.(value & opt (some (enum opt_names)) None & info names ~doc ~docv)
+    Arg.(value & opt (enum opt_names) `To_md & info names ~doc ~docv)
 
 let force_output =
   let doc = "Force generation of corrected file (even if there was no diff)" in

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -84,19 +84,16 @@ let direction =
              the .md file is the reference and updates the .ml and \
              the .md files accordingly. $(b,to-md) assumes the .ml \
              file is the reference and updates the .md file \
-             accordingly. $(b,infer-timestamp) uses the files last \
-             modification timestamps to determine the reference file \
-             and updates the least recent files." in
+             accordingly." in
   let opt_names =
-    [ "infer-timestamp", `Infer_timestamp
-    ; "to-md", `To_md
+    [ "to-md", `To_md
     ; "to-ml", `To_ml ]
   in
   let names = ["direction"] in
   let docv = String.concat "|" (List.map fst opt_names) in
   let docv = "{" ^ docv ^ "}" in
   named (fun x -> `Direction x)
-    Arg.(value & opt (enum opt_names) `Infer_timestamp & info names ~doc ~docv)
+    Arg.(value & opt (some (enum opt_names)) None & info names ~doc ~docv)
 
 let force_output =
   let doc = "Force generation of corrected file (even if there was no diff)" in

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -20,7 +20,7 @@ val prelude_str: [> `Prelude_str of string list ] t
 
 val root: [> `Root of string option ] t
 
-val direction: [> `Direction of [ `Infer_timestamp | `To_md | `To_ml ] ] t
+val direction: [> `Direction of [ `To_md | `To_ml ] option ] t
 
 val force_output: [> `Force_output of bool ] t
 

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -20,7 +20,7 @@ val prelude_str: [> `Prelude_str of string list ] t
 
 val root: [> `Root of string option ] t
 
-val direction: [> `Direction of [ `To_md | `To_ml ] option ] t
+val direction: [> `Direction of [ `To_md | `To_ml ] ] t
 
 val force_output: [> `Force_output of bool ] t
 

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -93,9 +93,8 @@ let print_rule ~nd ~prelude ~md_file ~ml_files ~dirs ~root ~requires options =
   if nd then pp "runtest-all" "--non-deterministic "
 
 let pp_direction fmt = function
-  | Some `To_md -> Fmt.pf fmt "--direction=to-md"
-  | Some `To_ml -> Fmt.pf fmt "--direction=to-ml"
-  | None -> ()
+  | `To_md -> Fmt.pf fmt "--direction=to-md"
+  | `To_ml -> Fmt.pf fmt "--direction=to-ml"
 
 let pp_prelude fmt s = Fmt.pf fmt "--prelude=%s" s
 let pp_prelude_str fmt s = Fmt.pf fmt "--prelude-str %S" s

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -93,9 +93,9 @@ let print_rule ~nd ~prelude ~md_file ~ml_files ~dirs ~root ~requires options =
   if nd then pp "runtest-all" "--non-deterministic "
 
 let pp_direction fmt = function
-  | `Infer_timestamp -> Fmt.pf fmt "--direction=infer-timestamp"
-  | `To_md -> Fmt.pf fmt "--direction=to-md"
-  | `To_ml -> Fmt.pf fmt "--direction=to-ml"
+  | Some `To_md -> Fmt.pf fmt "--direction=to-md"
+  | Some `To_ml -> Fmt.pf fmt "--direction=to-ml"
+  | None -> ()
 
 let pp_prelude fmt s = Fmt.pf fmt "--prelude=%s" s
 let pp_prelude_str fmt s = Fmt.pf fmt "--prelude-str %S" s

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -254,13 +254,10 @@ let update_file_or_block ?root ppf md_file ml_file block direction =
   in
   let direction =
     match direction with
-    | `To_md -> `To_md
-    | `To_ml -> `To_ml
-    | `Infer_timestamp ->
-       let md_file_mtime = (Unix.stat md_file).st_mtime in
-       let ml_file_mtime = (Unix.stat ml_file).st_mtime in
-       if ml_file_mtime < md_file_mtime then `To_ml
-       else `To_md
+    | Some `To_md -> `To_md
+    | Some `To_ml -> `To_ml
+    | None ->
+        Fmt.failwith "--direction must be set to update this file."
   in
   match direction with
   | `To_md ->

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -252,15 +252,6 @@ let update_file_or_block ?root ppf md_file ml_file block direction =
     | None   -> dir / ml_file
     | Some r -> r / dir / ml_file
   in
-  let direction =
-    match direction with
-    | Some `To_md -> `To_md
-    | Some `To_ml -> `To_ml
-    | None        ->
-        Fmt.failwith "This block must be synchronised with %s, \
-                      the --direction option must be provided."
-          ml_file
-  in
   match direction with
   | `To_md ->
      update_block_with_file ppf block ml_file (Block.part block)

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -256,8 +256,10 @@ let update_file_or_block ?root ppf md_file ml_file block direction =
     match direction with
     | Some `To_md -> `To_md
     | Some `To_ml -> `To_ml
-    | None ->
-        Fmt.failwith "--direction must be set to update this file."
+    | None        ->
+        Fmt.failwith "This block must be synchronised with %s, \
+                      the --direction option must be provided."
+          ml_file
   in
   match direction with
   | `To_md ->

--- a/test/dune.inc
+++ b/test/dune.inc
@@ -2,147 +2,147 @@
  (name   runtest)
  (deps   (:x pp.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x ellipsis.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x envs.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x empty_line.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x spaces.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x errors.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest-all)
  (deps   (:x errors.md))
  (action (progn
-           (run ocaml-mdx test  --non-deterministic %{x})
+           (run ocaml-mdx test --direction=to-md --non-deterministic %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x heredoc.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x mlt.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x semisemi.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x exit.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x padding.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x multilines.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x lines.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x lwt.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x non-det.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest-all)
  (deps   (:x non-det.md))
  (action (progn
-           (run ocaml-mdx test  --non-deterministic %{x})
+           (run ocaml-mdx test --direction=to-md --non-deterministic %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x code.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x set_environment_variable.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x unset_environment_variable.md))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x prelude.md))
  (action (progn
-           (run ocaml-mdx test --prelude-str "#require \"lwt\"" --prelude-str "toto:let x = \"42\""  %{x})
+           (run ocaml-mdx test --prelude-str "#require \"lwt\"" --prelude-str "toto:let x = \"42\"" --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
@@ -150,7 +150,7 @@
  (deps   (:x prelude_file.md)
          prelude.ml)
  (action (progn
-           (run ocaml-mdx test --prelude=prelude.ml  %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
@@ -169,6 +169,6 @@
  (deps   (:x require/require-package.md)
          (package example_lib))
  (action (progn
-           (run ocaml-mdx test  %{x})
+           (run ocaml-mdx test --direction=to-md %{x})
 
            (diff? %{x} %{x}.corrected))))

--- a/test/dune.inc
+++ b/test/dune.inc
@@ -2,147 +2,147 @@
  (name   runtest)
  (deps   (:x pp.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x ellipsis.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x envs.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x empty_line.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x spaces.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x errors.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest-all)
  (deps   (:x errors.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp --non-deterministic %{x})
+           (run ocaml-mdx test  --non-deterministic %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x heredoc.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x mlt.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x semisemi.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x exit.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x padding.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x multilines.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x lines.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x lwt.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x non-det.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest-all)
  (deps   (:x non-det.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp --non-deterministic %{x})
+           (run ocaml-mdx test  --non-deterministic %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x code.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x set_environment_variable.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x unset_environment_variable.md))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
  (deps   (:x prelude.md))
  (action (progn
-           (run ocaml-mdx test --prelude-str "#require \"lwt\"" --prelude-str "toto:let x = \"42\"" --direction=infer-timestamp %{x})
+           (run ocaml-mdx test --prelude-str "#require \"lwt\"" --prelude-str "toto:let x = \"42\""  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
@@ -150,7 +150,7 @@
  (deps   (:x prelude_file.md)
          prelude.ml)
  (action (progn
-           (run ocaml-mdx test --prelude=prelude.ml --direction=infer-timestamp %{x})
+           (run ocaml-mdx test --prelude=prelude.ml  %{x})
 
            (diff? %{x} %{x}.corrected))))
 (alias
@@ -169,6 +169,6 @@
  (deps   (:x require/require-package.md)
          (package example_lib))
  (action (progn
-           (run ocaml-mdx test --direction=infer-timestamp %{x})
+           (run ocaml-mdx test  %{x})
 
            (diff? %{x} %{x}.corrected))))


### PR DESCRIPTION
Implement https://github.com/realworldocaml/mdx/issues/169

Instead of setting `to-ml` or `to-md` as default, `direction` is now an option. An exception is raised if this option is needed but not provided.