### PR TITLE
Refactor handling of CLI parameters

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -1,8 +1,12 @@
 open Cmdliner
 
+let named wrapper =
+  Term.(app (const wrapper))
+
 let non_deterministic =
   let doc = "Run non-deterministic tests." in
-  Arg.(value & flag & info ["non-deterministic"; "n"] ~doc)
+  named (fun x -> `Non_deterministic x)
+    Arg.(value & flag & info ["non-deterministic"; "n"] ~doc)
 
 let syntax =
   let parse = function
@@ -18,31 +22,37 @@ let syntax =
   in
   let syntax = parse, print in
   let doc = "Which syntax to use. Either 'normal' or 'cram'." in
-  Arg.(value & opt (some syntax) None & info ["syntax"] ~doc ~docv:"SYNTAX")
+  named (fun x -> `Syntax x)
+    Arg.(value & opt (some syntax) None & info ["syntax"] ~doc ~docv:"SYNTAX")
 
 let file =
   let doc = "The file to use." in
-  Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:"FILE")
+  named (fun x -> `File x)
+    Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:"FILE")
 
 let section =
   let doc =
     "Select file sub-sections. Will be interpreted as a Perl regular expression."
   in
-  Arg.(value & opt (some string) None & info ["section"; "s"] ~doc ~docv:"PAT")
+  named (fun x -> `Section x)
+    Arg.(value & opt (some string) None & info ["section"; "s"] ~doc ~docv:"PAT")
 
 let not_verbose =
   let doc = "Do not show the result of evaluating toplevel phrases." in
-  Arg.(value & flag & info ["silent-eval"] ~doc)
+  named (fun x -> `Not_verbose x)
+    Arg.(value & flag & info ["silent-eval"] ~doc)
 
 let silent =
   let doc = "Do not show any (phrases and findlib directives) results." in
-  Arg.(value & flag & info ["silent"] ~doc)
+  named (fun x -> `Silent x)
+    Arg.(value & flag & info ["silent"] ~doc)
 
 let verbose_findlib =
   let doc =
     "Show the result of evaluating findlib directives in toplevel fragments."
   in
-  Arg.(value & flag & info ["verbose-findlib"] ~doc)
+  named (fun x -> `Verbose_findlib x)
+    Arg.(value & flag & info ["verbose-findlib"] ~doc)
 
 let prelude =
   let doc =
@@ -51,7 +61,8 @@ let prelude =
      can be provided:they will be evaluated in the order they are provided \
      on the command-line."
   in
-  Arg.(value & opt_all string [] & info ["prelude"] ~doc ~docv:"FILE")
+  named (fun x -> `Prelude x)
+    Arg.(value & opt_all string [] & info ["prelude"] ~doc ~docv:"FILE")
 
 let prelude_str =
   let doc =
@@ -60,11 +71,13 @@ let prelude_str =
      should not contain any spaces. Multiple prelude strings can be provided: \
      they will be evaluated in the order they are provided on the command-line."
   in
-  Arg.(value & opt_all string [] & info ["prelude-str"] ~doc ~docv:"STR")
+  named (fun x -> `Prelude_str x)
+    Arg.(value & opt_all string [] & info ["prelude-str"] ~doc ~docv:"STR")
 
 let root =
   let doc = "The directory to run the tests from." in
-  Arg.(value & opt (some string) None & info ["root"] ~doc ~docv:"DIR")
+  named (fun x -> `Root x)
+    Arg.(value & opt (some string) None & info ["root"] ~doc ~docv:"DIR")
 
 let direction =
   let doc = "Direction of file synchronization. $(b,to-ml) assumes \
@@ -82,11 +95,13 @@ let direction =
   let names = ["direction"] in
   let docv = String.concat "|" (List.map fst opt_names) in
   let docv = "{" ^ docv ^ "}" in
-  Arg.(value & opt (enum opt_names) `Infer_timestamp & info names ~doc ~docv)
+  named (fun x -> `Direction x)
+    Arg.(value & opt (enum opt_names) `Infer_timestamp & info names ~doc ~docv)
 
 let force_output =
   let doc = "Force generation of corrected file (even if there was no diff)" in
-  Arg.(value & flag & info ["force-output"] ~doc)
+  named (fun x -> `Force_output x)
+    Arg.(value & flag & info ["force-output"] ~doc)
 
 let setup_log style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();
@@ -95,4 +110,5 @@ let setup_log style_renderer level =
   ()
 
 let setup =
-  Term.(const setup_log $ Fmt_cli.style_renderer () $ Logs_cli.level ())
+  named (fun x -> `Setup x)
+    Term.(const setup_log $ Fmt_cli.style_renderer () $ Logs_cli.level ())

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -1,0 +1,27 @@
+open Cmdliner.Term
+
+val non_deterministic: [> `Non_deterministic of bool ] t
+
+val syntax: [> `Syntax of Mdx.syntax option ] t
+
+val file: [> `File of string ] t
+
+val section: [> `Section of string option ] t
+
+val not_verbose: [> `Not_verbose of bool ] t
+
+val silent: [> `Silent of bool ] t
+
+val verbose_findlib: [> `Verbose_findlib of bool ] t
+
+val prelude: [> `Prelude of string list ] t
+
+val prelude_str: [> `Prelude_str of string list ] t
+
+val root: [> `Root of string option ] t
+
+val direction: [> `Direction of [ `Infer_timestamp | `To_md | `To_ml ] ] t
+
+val force_output: [> `Force_output of bool ] t
+
+val setup: [> `Setup of unit ] t

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -17,7 +17,7 @@
 open Cmdliner
 
 let cmds = [Test.cmd; Pp.cmd; Rule.cmd; Output.cmd]
-let main () = `Help (`Pager, None)
+let main (`Setup ()) = `Help (`Pager, None)
 
 let main =
   let doc = "Execute markdown files." in

--- a/bin/output.ml
+++ b/bin/output.ml
@@ -84,7 +84,7 @@ let pp_block ppf (b:Mdx.Block.t) =
   Fmt.pf ppf "<div class=\"highlight\"><pre%a><code%a>%t</code></pre></div>"
     pp_attrs () pp_lang () pp_code
 
-let run () file output =
+let run (`Setup ()) (`File file) (`Output output) =
   let t = Mdx.parse_file Normal file in
   match t with
   | [] -> 1
@@ -118,7 +118,8 @@ open Cmdliner
 let output =
   let doc = "Write output to $(b,FILE) instead of stdout.  If $(b,FILE) is -, \
              output will go to stdout," in
-  Arg.(value & opt (some string) None & info ["o";"output"] ~doc ~docv:"FILE")
+  Term.(app (const (fun x -> `Output x)))
+    Arg.(value & opt (some string) None & info ["o";"output"] ~doc ~docv:"FILE")
 
 let cmd =
   let doc = "Pre-process markdown files to produce OCaml code." in

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -17,7 +17,7 @@
 let src = Logs.Src.create "cram.pp"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let run () file section =
+let run (`Setup ()) (`File file) (`Section section) =
   let t = Mdx.parse_file Normal file in
   let t = match section with
     | None   -> t

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -102,7 +102,8 @@ let pp_prelude_str fmt s = Fmt.pf fmt "--prelude-str %S" s
 
 let add_opt e s = match e with None -> s | Some e -> String.Set.add e s
 
-let run () md_file section direction prelude prelude_str root =
+let run (`Setup ()) (`File md_file) (`Section section) (`Direction direction)
+    (`Prelude prelude) (`Prelude_str prelude_str) (`Root root) =
   let section = match section with
     | None   -> None
     | Some p -> Some (Re.Perl.compile_pat p)

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -21,7 +21,7 @@ let (/) x y = match x with
   | "." -> y
   | _   -> Filename.concat x y
 
-let run () _ _ _ _ _ _ _ _ _ _ =
+let run (`Setup ()) _ _ _ _ _ _ _ _ _ _ =
   let base = Filename.basename Sys.argv.(0) in
   let dir = Filename.dirname Sys.argv.(0) in
   let cmd = match base with

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -377,11 +377,11 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
   0
 
 let run setup non_deterministic not_verbose syntax silent verbose_findlib
-    prelude prelude_str file section root direction =
+    prelude prelude_str file section root direction force_output : int =
     try
     run_exn setup non_deterministic not_verbose syntax silent verbose_findlib
-      prelude prelude_str file section root direction
-    with Failure f -> prerr_endline f; exit 1
+      prelude prelude_str file section root direction force_output
+    with Failure f -> (prerr_endline f; exit 1)
  
 (**** Cmdliner ****)
 

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -268,10 +268,11 @@ let update_file_or_block ?root ppf md_file ml_file block direction =
   | `To_ml ->
      update_file_with_block ppf block ml_file (Block.part block)
 
-let run_exn ()
-    non_deterministic not_verbose syntax silent verbose_findlib prelude
-    prelude_str file section root direction force_output
-  =
+let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
+    (`Not_verbose not_verbose) (`Syntax syntax) (`Silent silent)
+    (`Verbose_findlib verbose_findlib) (`Prelude prelude)
+    (`Prelude_str prelude_str) (`File file) (`Section section) (`Root root)
+    (`Direction direction) (`Force_output force_output) =
   let c =
     Mdx_top.init ~verbose:(not not_verbose) ~silent ~verbose_findlib ()
   in
@@ -375,12 +376,10 @@ let run_exn ()
   Hashtbl.iter (write_parts ~force_output) files;
   0
 
-let run ()
-    non_deterministic not_verbose syntax silent verbose_findlib prelude
-    prelude_str file section root direction
-  =
+let run setup non_deterministic not_verbose syntax silent verbose_findlib
+    prelude prelude_str file section root direction =
     try
-    run_exn () non_deterministic not_verbose syntax silent verbose_findlib
+    run_exn setup non_deterministic not_verbose syntax silent verbose_findlib
       prelude prelude_str file section root direction
     with Failure f -> prerr_endline f; exit 1
  


### PR DESCRIPTION
This adds polymorphic variant wrappers to all of the various CLI parameters in an effort to prevent them from being re-ordered along the way.

More verbose, but hopefully safer w.r.t. future changes.