### PR TITLE
Add support for '--syntax' flag in 'ocaml-mdx rule'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ### unreleased
 
+#### Added
+
+- Add `--syntax` option to `rule` subcommand to allow generating rules for cram
+  tests (#177, @craigfe)
+
 #### Fixed
 
 - Remove trailing whitespaces at the end of toplevel or bash evaluation lines

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -91,6 +91,11 @@ let print_rule ~nd ~prelude ~md_file ~ml_files ~dirs ~root ~requires options =
   pp "runtest" [];
   if nd then pp "runtest-all" ["--non-deterministic"]
 
+let options_of_syntax = function
+  | Some Mdx.Normal -> [ "--syntax=normal" ]
+  | Some Mdx.Cram -> [ "--syntax=cram" ]
+  | None -> []
+
 let pp_direction fmt = function
   | `To_md -> Fmt.pf fmt "--direction=to-md"
   | `To_ml -> Fmt.pf fmt "--direction=to-ml"
@@ -100,7 +105,7 @@ let pp_prelude_str fmt s = Fmt.pf fmt "--prelude-str %S" s
 
 let add_opt e s = match e with None -> s | Some e -> String.Set.add e s
 
-let run (`Setup ()) (`File md_file) (`Section section) (`Direction direction)
+let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax) (`Direction direction)
     (`Prelude prelude) (`Prelude_str prelude_str) (`Root root) =
   let section = match section with
     | None   -> None
@@ -141,7 +146,8 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Direction direction)
     let options =
       List.map (Fmt.to_to_string pp_prelude) prelude @
       List.map (Fmt.to_to_string pp_prelude_str) prelude_str @
-      [Fmt.to_to_string pp_direction direction]
+      [Fmt.to_to_string pp_direction direction] @
+      options_of_syntax syntax
     in
     print_rule ~md_file ~prelude ~nd ~ml_files ~dirs ~root ~requires options;
     file_contents
@@ -154,6 +160,6 @@ open Cmdliner
 let cmd =
   let doc = "Produce dune rules to synchronize markdown and OCaml files." in
   Term.(pure run
-        $ Cli.setup $ Cli.file $ Cli.section $ Cli.direction
+        $ Cli.setup $ Cli.file $ Cli.section $ Cli.syntax $ Cli.direction
         $ Cli.prelude $ Cli.prelude_str $ Cli.root),
   Term.info "rule" ~doc

--- a/test/dune
+++ b/test/dune
@@ -30,6 +30,7 @@
     (run ocaml-mdx rule --prelude prelude.ml %{dep:prelude_file.md})
     (run ocaml-mdx rule --direction=to-ml %{dep:dune_rules.md})
     (run ocaml-mdx rule %{dep:require/require-package.md})
+    (run ocaml-mdx rule --syntax=cram %{dep:cram.t})
    ))))
 
 (alias
@@ -85,12 +86,6 @@
            (run ocaml-mdx output %{x} -o output.html)
            (diff? %{y} output.html))))
 
-(alias
- (name   runtest)
- (deps   (:x cram.t) (package mdx))
- (action (progn
-           (run ocaml-mdx test --syntax=cram %{x})
-           (diff? %{x} %{x}.corrected))))
 
 (alias
  (name   runtest)

--- a/test/dune.inc
+++ b/test/dune.inc
@@ -150,3 +150,9 @@
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})
            (diff? %{x} %{x}.corrected))))
+(alias
+ (name   runtest)
+ (deps   (:x cram.t))
+ (action (progn
+           (run ocaml-mdx test --direction=to-md --syntax=cram %{x})
+           (diff? %{x} %{x}.corrected))))


### PR DESCRIPTION
`ocaml-mdx rule` accepts some options solely in order to pass them to the `ocaml-mdx test` rule that it generates (`--direction`, `--prelude` etc.), but it doesn't allow for passing the `--syntax` flag. This adds the `--syntax` flag.

This is very similar to #176, making me think this logic probably warrants a refactor to make it easier to understand; a pass-through option like `--test-options="--syntax=cram"` might work.