### PR TITLE
Used module_presence type to check if module is in the topevel env

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 
 #### Fixed
 
+- Used module_presence information on Env.summary to prevent fetching absent modules from the toplevel env (#186, @clecat)
 - Remove trailing whitespaces at the end of toplevel or bash evaluation lines
   (#166, @clecat)
 - Improve error reporting of ocaml-mdx test (#172, @Julow)

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -761,7 +761,7 @@ let rec save_summary acc s =
   | Env_value (summary, id, _) ->
      save_summary (Ident.name id :: acc) summary
 #if OCAML_MAJOR >= 4 && OCAML_MINOR >= 8
-  | Env_module (summary, id, _, _)
+  | Env_module (summary, id, Mp_present, _)
 #else
   | Env_module (summary, id, _)
 #endif
@@ -779,6 +779,9 @@ let rec save_summary acc s =
         else acc
       in
       save_summary acc summary
+#if OCAML_MAJOR >= 4 && OCAML_MINOR >= 8
+  | Env_module (_, _, Mp_absent, _)
+#endif
   | Env_empty -> acc
 #if OCAML_MAJOR >= 4 && OCAML_MINOR >= 4
   | Env_constraints (summary, _)

--- a/test/dune
+++ b/test/dune
@@ -19,6 +19,7 @@
     (run ocaml-mdx rule %{dep:semisemi.md})
     (run ocaml-mdx rule %{dep:exit.md})
     (run ocaml-mdx rule %{dep:padding.md})
+    (run ocaml-mdx rule %{dep:module_alias.md})
     (run ocaml-mdx rule %{dep:multilines.md})
     (run ocaml-mdx rule %{dep:lines.md})
     (run ocaml-mdx rule %{dep:lwt.md})

--- a/test/dune.inc
+++ b/test/dune.inc
@@ -72,6 +72,12 @@
            (diff? %{x} %{x}.corrected))))
 (alias
  (name   runtest)
+ (deps   (:x module_alias.md))
+ (action (progn
+           (run ocaml-mdx test --direction=to-md %{x})
+           (diff? %{x} %{x}.corrected))))
+(alias
+ (name   runtest)
  (deps   (:x multilines.md))
  (action (progn
            (run ocaml-mdx test --direction=to-md %{x})

--- a/test/module_alias.md
+++ b/test/module_alias.md
@@ -1,0 +1,8 @@
+Mdx used to fail with module aliases, this is a regression test to ensure nothing breaks again in the future.
+
+```ocaml
+# module Test = String;;
+module Test = String
+```
+
+The bug was caused by an attempt to load the newly created module without checking if it was supposed to be in the store (advertised by the module_presence type).


### PR DESCRIPTION
When generating the list of the objects to load from the toplevel environment (function `save_summary` in file `lib/top/mdx_top`), mdx was not checking if the module was supposed to be present in the environment.

Indeed, a new information defined by the type `module_presence` was introduced in 4.08.0 in the `Ocaml.Env.summary` type, but it is actually ignored with a wildcard.

I simply added a check, ignoring the module if it's presence was set to `Mp_absent`.

The problem could for example append when dealing with module aliases:
```ocaml
# module Test = String;;
module Test = String
```

This PR should therefore solve the mdx tests of those two packages:
- [containers](https://github.com/ocaml/opam-repository/pull/14791#issuecomment-529057288)
- [datalog](https://github.com/ocaml/opam-repository/pull/14970#issuecomment-537434474)