### PR TITLE
Switch to using ocaml-ci-scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,19 @@
 language: c
+sudo: false
+services:
+  - docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash ./.travis-docker.sh
 env:
-  # Check build and unit tests
-  # NOTE: testing needs OPAMBUILDTEST=true so that test deps are installed
-  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.02.3
-  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.03.0
-  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.04.2
-  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.05.0
-  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.06.1
-  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.07.1
-  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.08.1
-  - TO_TEST=tests OPAMBUILDTEST=true OCAML_VERSION=4.09.0
-  - TO_TEST=install OPAMBUILDTEST=true OCAML_VERSION=4.09.0
-before_install:
-  # Download and use opam2
-  - wget -O ${HOME}/opam https://github.com/ocaml/opam/releases/download/2.0.4/opam-2.0.4-x86_64-linux
-  - chmod +x ${HOME}/opam
-  # Some opam boilerplate
-  - export OPAMYES=1
-  - export OPAMJOBS=2
-  # Init opam, and the default switch with the right ocaml version
-  - ${HOME}/opam init --compiler=${OCAML_VERSION} --disable-sandboxing
-  - eval `${HOME}/opam config env`
-  - export OPAMVERBOSE=1
-install:
-  # Install dependencies
-  - wget https://github.com/jgm/pandoc/releases/download/2.4/pandoc-2.4-linux.tar.gz
-  - sudo tar xvzf pandoc-2.4-linux.tar.gz --strip-components 1 -C /usr/local
-  - ${HOME}/opam pin add --no-action mdx .
-  - ${HOME}/opam install --deps-only mdx
-script:
-  # Build and launch the tests
-  - if [ "$TO_TEST" = "tests" ]; then make && make test; fi
-  # Try and install the package with opam
-  - if [ "$TO_TEST" = "install" ]; then ${HOME}/opam install mdx; fi
+  global:
+    - PACKAGE=mdx
+    - DISTRO=debian-stable
+  matrix:
+    - OCAML_VERSION=4.02.3
+    - OCAML_VERSION=4.03.0
+    - OCAML_VERSION=4.04
+    - OCAML_VERSION=4.05
+    - OCAML_VERSION=4.06
+    - OCAML_VERSION=4.07
+    - OCAML_VERSION=4.08
+    - OCAML_VERSION=4.09

--- a/mdx.opam
+++ b/mdx.opam
@@ -10,7 +10,7 @@ doc:          "https://realworldocaml.github.io/mdx/"
 build: [
  ["dune" "subst"] {pinned}
  ["dune" "build" "-p" name "-j" jobs]
- ["make" "test"] {with-test}
+ [make "test"] {with-test}
 ]
 
 depends: [


### PR DESCRIPTION
This seems like a more reliable CI until we can use `ocaml-ci`.

This will allow us to easily add revdeps builds btw which could prove useful once we want to stabilize mdx's API and avoid breaking users' tests!