### PR TITLE
[WIP] Add latex generation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Add a `require-package` label to explicitly declare dune `package` dependencies of a code block
   (#149, @Julow)
 - Add an `unset-` label to unset env variables in shell blocks (#132, @clecat)
+- Add latex generation with `-t` option to output command (#188, @clecat)
 
 #### Changed
 

--- a/bin/output.ml
+++ b/bin/output.ml
@@ -23,53 +23,57 @@ let pp_section ppf (n, title) =
 
 let pp_list pp = Fmt.(list ~sep:(unit "") pp)
 
-let pp_html ppf s =
-  let add = function
-    | '"' -> Fmt.string ppf "&quot;"
-    | '&' -> Fmt.string ppf "&amp;"
-    | '<' -> Fmt.string ppf "&lt;"
-    | '>' -> Fmt.string ppf "&gt;"
-    | c   -> Fmt.char ppf c
-  in
-  String.iter add s
+let pp_text ~html ppf s =
+  if html
+  then
+    let add = function
+      | '"' -> Fmt.string ppf "&quot;"
+      | '&' -> Fmt.string ppf "&amp;"
+      | '<' -> Fmt.string ppf "&lt;"
+      | '>' -> Fmt.string ppf "&gt;"
+      | c   -> Fmt.char ppf c
+    in
+    String.iter add s
+  else
+    Fmt.string ppf s
 
-let pp_output ppf = function
-  |`Output s -> Fmt.pf ppf ">%a\n" pp_html s
+let pp_output ~html ppf = function
+  |`Output s -> Fmt.pf ppf ">%a\n" (pp_text ~html) s
   |`Ellipsis -> Fmt.pf ppf "...\n"
 
-let pp_line ppf l = Fmt.pf ppf "%a\n" pp_html l
+let pp_line ~html ppf l = Fmt.pf ppf "%a\n" (pp_text ~html) l
 
-let pp_toplevel ppf (t:Mdx.Toplevel.t) =
+let pp_toplevel ~html ppf (t:Mdx.Toplevel.t) =
   let cmds = match t.command with [c] -> [c ^ ";;"] | l -> l @ [";;"] in
-  Fmt.pf ppf "%a%a" (pp_list pp_line) cmds (pp_list pp_output) t.output
+  Fmt.pf ppf "%a%a" (pp_list (pp_line ~html)) cmds (pp_list (pp_output ~html)) t.output
 
-let pp_contents (t:Mdx.Block.t) ppf =
-  Fmt.(list ~sep:(unit "\n") pp_html) ppf t.contents
+let pp_contents ~html (t:Mdx.Block.t) ppf =
+  Fmt.(list ~sep:(unit "\n") (pp_text ~html)) ppf t.contents
 
-let pp_cram ppf (t:Mdx.Cram.t) =
+let pp_cram ~html ppf (t:Mdx.Cram.t) =
   let pp_exit ppf = match t.exit_code with
     | 0 -> ()
     | i -> Fmt.pf ppf "[%d]" i
   in
   Fmt.pf ppf "%a%a%t"
-    (pp_list pp_line) t.command
-    (pp_list pp_output) t.output pp_exit
+    (pp_list (pp_line ~html)) t.command
+    (pp_list (pp_output ~html)) t.output pp_exit
 
 let pp_block_html ppf (b:Mdx.Block.t) =
   let lang, pp_code, attrs = match b.value with
-    | Toplevel t -> Some "ocaml", (fun ppf -> pp_list pp_toplevel ppf t), [
+    | Toplevel t -> Some "ocaml", (fun ppf -> pp_list (pp_toplevel ~html:true) ppf t), [
         ("class"             , "command-line");
         ("data-prompt"       , "#");
         ("data-filter-output", ">");
       ]
-    | OCaml  -> Some "ocaml", pp_contents b, []
-    | Cram t -> Some "bash" , (fun ppf -> pp_list pp_cram ppf t.tests), [
+    | OCaml  -> Some "ocaml", (pp_contents ~html:true) b, []
+    | Cram t -> Some "bash" , (fun ppf -> pp_list (pp_cram ~html:true) ppf t.tests), [
         ("class"             , "command-line");
         ("data-user"         , "fun");
         ("data-host"         , "lama");
         ("data-filter-output", ">");
       ]
-    | Raw     -> b.header, pp_contents b, []
+    | Raw     -> b.header, (pp_contents ~html:true) b, []
     | Error s -> Some "error", (fun ppf -> pp_list Fmt.string ppf s), []
   in
   let pp_attr ppf (k, v) = Fmt.pf ppf "%s=%S" k v in
@@ -86,10 +90,10 @@ let pp_block_html ppf (b:Mdx.Block.t) =
 
 let pp_block_latex ppf (b:Mdx.Block.t) =
   let lang, pp_code = match b.value with
-    | Toplevel t -> Some "ocaml", (fun ppf -> pp_list pp_toplevel ppf t)
-    | OCaml  -> Some "ocaml", pp_contents b
-    | Cram t -> Some "bash" , (fun ppf -> pp_list pp_cram ppf t.tests)
-    | Raw     -> b.header, pp_contents b
+    | Toplevel t -> Some "ocaml", (fun ppf -> pp_list (pp_toplevel ~html:false) ppf t)
+    | OCaml  -> Some "ocaml", (pp_contents ~html:false) b
+    | Cram t -> Some "bash" , (fun ppf -> pp_list (pp_cram ~html:false) ppf t.tests)
+    | Raw     -> b.header, (pp_contents ~html:false) b
     | Error s -> Some "error", (fun ppf -> pp_list Fmt.string ppf s)
   in
   let lang = match lang with
@@ -99,16 +103,42 @@ let pp_block_latex ppf (b:Mdx.Block.t) =
   Fmt.pf ppf "```%s\n%t\n```"
     lang pp_code
 
+let pp_text_html ppf l =
+  List.iter (Fmt.pf ppf "%s\n") (List.rev l)
+
+open Astring
+
+let pp_text_latex ppf l =
+  let l = List.rev l in
+  let t = String.concat ~sep:"\n" l in
+  let rec f t acc =
+    match String.find_sub ~rev:true ~sub:"]{.idx}" t with
+    | None -> t::acc
+    | Some i ->
+      begin
+        match String.find ~rev:true ~start:i (Char.equal '[') t with
+        | None -> t::acc
+        | Some j ->
+          let b = String.sub ~stop:j t |> String.Sub.to_string in
+          let m = String.sub ~start:(j + 1) ~stop:i t |> String.Sub.to_string |> Fmt.strf "\\ref{%s}" in
+          let e = String.sub ~start:(i + 7) t |> String.Sub.to_string in
+          f b (m::e::acc)
+      end
+  in
+  let t = f t [] in
+  List.iter (Fmt.pf ppf "%s") t;
+  Fmt.pf ppf "\n"
+
 type outputs =
     Html
   | Latex
 
 let get_output_infos = function
-  | Html -> pp_block_html, "-t html"
-  | Latex -> pp_block_latex, "-t latex --listings"
+  | Html -> pp_block_html, pp_text_html, "-t html"
+  | Latex -> pp_block_latex, pp_text_latex,  "-t latex --listings"
 
 let run (`Setup ()) (`File file) (`Output output) output_type =
-  let (pp_block, out_args) = get_output_infos output_type in
+  let (pp_block, pp_text, out_args) = get_output_infos output_type in
   let t = Mdx.parse_file Normal file in
   match t with
   | [] -> 1
@@ -116,15 +146,19 @@ let run (`Setup ()) (`File file) (`Output output) output_type =
     let tmp = Filename.temp_file "ocaml-mdx" "pandoc" in
     let oc = open_out tmp in
     let ppf = Format.formatter_of_out_channel oc in
-    List.iter (function
-        | Mdx.Section s -> Fmt.pf ppf "%a" pp_section s
-        | Text t        -> Fmt.pf ppf "%s\n" t
+    let f acc t =
+      match t with
+        | Mdx.Section s ->
+          Fmt.pf ppf "%a%a" pp_text acc pp_section s;
+          []
+        | Text t        -> t::acc
         | Block b ->
           let b = Mdx.Block.eval b in
           Log.debug (fun l -> l "output: %a" Mdx.Block.dump b);
-          Fmt.pf ppf "%a\n" pp_block b
-      ) t;
-    Fmt.pf ppf "%!";
+          Fmt.pf ppf "%a%a" pp_text acc pp_block b;
+          []
+    in
+    Fmt.pf ppf "%a%!" pp_text (List.fold_left f [] t);
     close_out oc;
     let output = match output with None -> "-" | Some o -> o in
     Fmt.pr "Generating %s...\n%!" output;

--- a/bin/output.ml
+++ b/bin/output.ml
@@ -119,8 +119,20 @@ let pp_text_latex ppf l =
         match String.find ~rev:true ~start:i (Char.equal '[') t with
         | None -> t::acc
         | Some j ->
+          let escape_latex acc c =
+            match c with
+              | '&' | '%' | '$' | '#' | '_' | '{' | '}' | '~' | '^' |  '\\' ->
+                ("\\" ^ (String.of_char c)) :: acc
+              | _ -> String.of_char c :: acc
+          in
           let b = String.sub ~stop:j t |> String.Sub.to_string in
-          let m = String.sub ~start:(j + 1) ~stop:i t |> String.Sub.to_string |> Fmt.strf "\\ref{%s}" in
+          let m = String.sub ~start:(j + 1) ~stop:i t
+            |> String.Sub.to_string
+            |> String.fold_left escape_latex []
+            |> List.rev
+            |> String.concat
+            |> Fmt.strf "\\index{%s}"
+          in
           let e = String.sub ~start:(i + 7) t |> String.Sub.to_string in
           f b (m::e::acc)
       end

--- a/test/bin/output_expect/dune
+++ b/test/bin/output_expect/dune
@@ -8,3 +8,14 @@
   (progn
    (run ocaml-mdx output %{x} -o output.html)
    (diff? %{y} output.html))))
+
+(alias
+ (name runtest)
+ (deps
+  (:x latex.md)
+  (:y latex.tex.expected)
+  (package mdx))
+ (action
+  (progn
+   (run ocaml-mdx output %{x} -t latex -o latex.tex)
+   (diff? %{y} latex.tex))))

--- a/test/bin/output_expect/latex.md
+++ b/test/bin/output_expect/latex.md
@@ -1,0 +1,30 @@
+Latex files can also be generated
+
+# Test0, -toto- and titi
+
+toto
+
+# Test1, -toto- and titi! {#test-toto-and-titi}
+
+titi
+
+# Test2, <toto> and titi!
+
+yo!
+
+# Test3, <span class="toto">toto</a> and titi!
+
+haha!!
+
+# --Test4, ?toto! a.nd. I/O
+
+foo
+
+
+```ocaml
+type <record-name> =
+    { <field> : <type>;
+      <field> : <type>;
+      ...
+    }
+```

--- a/test/bin/output_expect/latex.tex.expected
+++ b/test/bin/output_expect/latex.tex.expected
@@ -27,9 +27,9 @@ haha!!
 foo
 
 \begin{lstlisting}[language=Caml]
-type &lt;record-name&gt; =
-    { &lt;field&gt; : &lt;type&gt;;
-      &lt;field&gt; : &lt;type&gt;;
+type <record-name> =
+    { <field> : <type>;
+      <field> : <type>;
       ...
     }
 \end{lstlisting}

--- a/test/bin/output_expect/latex.tex.expected
+++ b/test/bin/output_expect/latex.tex.expected
@@ -1,0 +1,36 @@
+Latex files can also be generated
+
+\hypertarget{test0--toto--and-titi}{%
+\section{Test0, -toto- and titi}\label{test0--toto--and-titi}}
+
+toto
+
+\hypertarget{test-toto-and-titi}{%
+\section{Test1, -toto- and titi!}\label{test-toto-and-titi}}
+
+titi
+
+\hypertarget{test2-and-titi}{%
+\section{\texorpdfstring{Test2, and
+titi!}{Test2,  and titi!}}\label{test2-and-titi}}
+
+yo!
+
+\hypertarget{test3-toto-and-titi}{%
+\section{Test3, toto and titi!}\label{test3-toto-and-titi}}
+
+haha!!
+
+\hypertarget{test4-toto-a.nd.-io}{%
+\section{--Test4, ?toto! a.nd. I/O}\label{test4-toto-a.nd.-io}}
+
+foo
+
+\begin{lstlisting}[language=Caml]
+type &lt;record-name&gt; =
+    { &lt;field&gt; : &lt;type&gt;;
+      &lt;field&gt; : &lt;type&gt;;
+      ...
+    }
+\end{lstlisting}
+


### PR DESCRIPTION
This small PR adds support for latex file generation.
When launching the `output` command, the user can specify the option `-t` followed by either `html` or `latex` to choose the output format.

Keep in mind that generated files needs are not build as standalone.