### PR TITLE
Convert tabulations to spaces to fix the parsing of code blocks in toplevel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 
 #### Fixed
 
+- Convert tabulations to spaces to fix the parsing of code blocks in toplevel (#191, @gpetiot)
 - Use module_presence information on Env.summary to prevent fetching absent modules from the
   toplevel env (#186, @clecat)
 - Remove trailing whitespaces at the end of toplevel or bash evaluation lines

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -349,6 +349,9 @@ let guess_ocaml_kind b =
 let toplevel ~file ~line lines = Toplevel (Toplevel.of_lines ~line ~file lines)
 
 let eval t =
+  let re_tab = Re.(compile (char '\t')) in
+  let contents = List.map Re.(replace_string re_tab ~by:"      ") t.contents in
+  let t = {t with contents} in
   match check_labels t with
   | Error e -> { t with value = Error e }
   | Ok ()   ->

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -360,7 +360,7 @@ let eval t =
     let s' =  Re.replace_string re_tab ~by:"    " s in
     if not (String.equal s s') then
       Misc.warn (location t)
-        ("Warning: tabulation of line " ^ Int.to_string i ^
+        ("Warning: tabulation of line " ^ string_of_int i ^
          " automatically converted to 4 spaces, please update the source.");
     s'
   in

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Migrate_ast
+
 (** Code blocks. *)
 
 type cram_value = { pad: int; tests: Cram.t list }
@@ -31,6 +33,7 @@ type section = int * string
 
 (** The type for supported code blocks. *)
 type t = {
+  loc     : Location.t;
   line    : int;
   file    : string;
   section : section option;
@@ -66,6 +69,8 @@ val pp_line_directive: (string * int) Fmt.t
    filename and line number. *)
 
 (** {2 Accessors} *)
+
+val location : t -> Location.t
 
 val mode: t -> [`Non_det of [`Command|`Output] | `Normal]
 (** [mode t] is [t]'s mode. *)

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -1,4 +1,5 @@
 {
+open Migrate_ast
 open Astring
 
 let line_ref = ref 1
@@ -20,6 +21,7 @@ rule text section = parse
   | "```" ([^' ' '\n']* as h) ws* ([^'\n']* as l) eol
       { let header = if h = "" then None else Some h in
         let contents = block lexbuf in
+        let loc = Location.curr lexbuf in
         let labels = Block.labels_of_string l in
         let value = Block.Raw in
         let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
@@ -27,7 +29,8 @@ rule text section = parse
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         newline lexbuf;
-        `Block { Block.file; line; section; header; contents; labels; value }
+        `Block
+          { Block.loc; file; line; section; header; contents; labels; value }
         :: text section lexbuf }
   | ([^'\n']* as str) eol
       { newline lexbuf;
@@ -51,10 +54,12 @@ and cram_text section = parse
         let labels = [] in
         let value = Block.Raw in
         let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
+        let loc = Location.curr lexbuf in
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
-        `Block { Block.file; line; section; header; contents; labels; value }
+        `Block
+          { Block.loc; file; line; section; header; contents; labels; value }
         :: (if requires_empty_line then `Text "" :: rest else rest) }
   | "<-- non-deterministic" ws* (("command"|"output") as choice) eol
       { let header = Syntax.cram_default_header in
@@ -62,11 +67,13 @@ and cram_text section = parse
         let labels = ["non-deterministic", Some (`Eq, choice)] in
         let value = Block.Raw in
         let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
+        let loc = Location.curr lexbuf in
         newline lexbuf;
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
-        `Block { Block.file; line; section; header; contents; labels; value }
+        `Block
+          { Block.loc; file; line; section; header; contents; labels; value }
         :: (if requires_empty_line then `Text "" :: rest else rest) }
   | ([^'\n']* as str) eol
       { newline lexbuf;

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -60,3 +60,7 @@ let err lexbuf fmt =
   Fmt.kstrf (fun str ->
       Fmt.failwith "%a: %s" pp_position lexbuf str
     ) fmt
+
+let warn loc s =
+  Format.fprintf Format.err_formatter "%!@{<loc>%a@}:@ %s\n%!"
+    Location.print_loc loc s

--- a/test/bin/test_expect/tabs.md
+++ b/test/bin/test_expect/tabs.md
@@ -1,0 +1,51 @@
+The tabulations will be converted to spaces:
+
+```ocaml version<4.08
+# let gen_shape =
+	let open Quickcheck.Generator.Let_syntax in
+	let module G = Quickcheck.Generator in
+	let circle =
+	  let%map radius = Float.gen_positive in
+	  Circle { radius }
+	in
+	let rect =
+	  let%map height = Float.gen_positive
+	  and width = Float.gen_positive
+	  in
+	  Rect { height; width }
+	in
+	let poly =
+	  let%map points =
+		List.gen (G.both Float.gen_positive Float.gen_positive)
+	  in
+	  Poly points
+	in
+	G.union [circle; rect; poly];;
+Characters 31-62:
+Error: Unbound module Quickcheck
+```
+
+```ocaml version>=4.08
+# let gen_shape =
+	let open Quickcheck.Generator.Let_syntax in
+	let module G = Quickcheck.Generator in
+	let circle =
+	  let%map radius = Float.gen_positive in
+	  Circle { radius }
+	in
+	let rect =
+	  let%map height = Float.gen_positive
+	  and width = Float.gen_positive
+	  in
+	  Rect { height; width }
+	in
+	let poly =
+	  let%map points =
+		List.gen (G.both Float.gen_positive Float.gen_positive)
+	  in
+	  Poly points
+	in
+	G.union [circle; rect; poly];;
+Line 2, characters 16-47:
+Error: Unbound module Quickcheck
+```

--- a/test/bin/test_expect/tabs.md
+++ b/test/bin/test_expect/tabs.md
@@ -46,6 +46,6 @@ Error: Unbound module Quickcheck
 	  Poly points
 	in
 	G.union [circle; rect; poly];;
-Line 2, characters 16-47:
+Line 2, characters 14-45:
 Error: Unbound module Quickcheck
 ```

--- a/test/bin/test_expect/tabs.md
+++ b/test/bin/test_expect/tabs.md
@@ -21,7 +21,7 @@ The tabulations will be converted to spaces:
 	  Poly points
 	in
 	G.union [circle; rect; poly];;
-Characters 31-62:
+Characters 29-60:
 Error: Unbound module Quickcheck
 ```
 

--- a/test/bin/test_expect/tabs.md.expected
+++ b/test/bin/test_expect/tabs.md.expected
@@ -21,7 +21,7 @@ The tabulations will be converted to spaces:
       Poly points
     in
     G.union [circle; rect; poly];;
-Characters 31-62:
+Characters 29-60:
 Error: Unbound module Quickcheck
 ```
 

--- a/test/bin/test_expect/tabs.md.expected
+++ b/test/bin/test_expect/tabs.md.expected
@@ -2,50 +2,50 @@ The tabulations will be converted to spaces:
 
 ```ocaml version<4.08
 # let gen_shape =
-      let open Quickcheck.Generator.Let_syntax in
-      let module G = Quickcheck.Generator in
-      let circle =
-        let%map radius = Float.gen_positive in
-        Circle { radius }
+    let open Quickcheck.Generator.Let_syntax in
+    let module G = Quickcheck.Generator in
+    let circle =
+      let%map radius = Float.gen_positive in
+      Circle { radius }
+    in
+    let rect =
+      let%map height = Float.gen_positive
+      and width = Float.gen_positive
       in
-      let rect =
-        let%map height = Float.gen_positive
-        and width = Float.gen_positive
-        in
-        Rect { height; width }
+      Rect { height; width }
+    in
+    let poly =
+      let%map points =
+        List.gen (G.both Float.gen_positive Float.gen_positive)
       in
-      let poly =
-        let%map points =
-            List.gen (G.both Float.gen_positive Float.gen_positive)
-        in
-        Poly points
-      in
-      G.union [circle; rect; poly];;
+      Poly points
+    in
+    G.union [circle; rect; poly];;
 Characters 31-62:
 Error: Unbound module Quickcheck
 ```
 
 ```ocaml version>=4.08
 # let gen_shape =
-      let open Quickcheck.Generator.Let_syntax in
-      let module G = Quickcheck.Generator in
-      let circle =
-        let%map radius = Float.gen_positive in
-        Circle { radius }
+    let open Quickcheck.Generator.Let_syntax in
+    let module G = Quickcheck.Generator in
+    let circle =
+      let%map radius = Float.gen_positive in
+      Circle { radius }
+    in
+    let rect =
+      let%map height = Float.gen_positive
+      and width = Float.gen_positive
       in
-      let rect =
-        let%map height = Float.gen_positive
-        and width = Float.gen_positive
-        in
-        Rect { height; width }
+      Rect { height; width }
+    in
+    let poly =
+      let%map points =
+        List.gen (G.both Float.gen_positive Float.gen_positive)
       in
-      let poly =
-        let%map points =
-            List.gen (G.both Float.gen_positive Float.gen_positive)
-        in
-        Poly points
-      in
-      G.union [circle; rect; poly];;
-Line 2, characters 16-47:
+      Poly points
+    in
+    G.union [circle; rect; poly];;
+Line 2, characters 14-45:
 Error: Unbound module Quickcheck
 ```

--- a/test/bin/test_expect/tabs.md.expected
+++ b/test/bin/test_expect/tabs.md.expected
@@ -1,0 +1,51 @@
+The tabulations will be converted to spaces:
+
+```ocaml version<4.08
+# let gen_shape =
+      let open Quickcheck.Generator.Let_syntax in
+      let module G = Quickcheck.Generator in
+      let circle =
+        let%map radius = Float.gen_positive in
+        Circle { radius }
+      in
+      let rect =
+        let%map height = Float.gen_positive
+        and width = Float.gen_positive
+        in
+        Rect { height; width }
+      in
+      let poly =
+        let%map points =
+            List.gen (G.both Float.gen_positive Float.gen_positive)
+        in
+        Poly points
+      in
+      G.union [circle; rect; poly];;
+Characters 31-62:
+Error: Unbound module Quickcheck
+```
+
+```ocaml version>=4.08
+# let gen_shape =
+      let open Quickcheck.Generator.Let_syntax in
+      let module G = Quickcheck.Generator in
+      let circle =
+        let%map radius = Float.gen_positive in
+        Circle { radius }
+      in
+      let rect =
+        let%map height = Float.gen_positive
+        and width = Float.gen_positive
+        in
+        Rect { height; width }
+      in
+      let poly =
+        let%map points =
+            List.gen (G.both Float.gen_positive Float.gen_positive)
+        in
+        Poly points
+      in
+      G.union [circle; rect; poly];;
+Line 2, characters 16-47:
+Error: Unbound module Quickcheck
+```


### PR DESCRIPTION
This allows to execute a code using tabulations instead of spaces (see #179).
Not sure this should close the issue as it would be better to print back the input when an exception has been raised, in addition to the error message.