### PR TITLE
Add a --output/-o option to specify mdx test output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 #### Added
 
+- Add a `--output`/`-o` option to the `test` subcommand to allow specifying a different
+  output file to write the corrected to, or to write it to the standard output (#194, @NathanReb)
 - Migrate to OCaml 4.08 AST to add support for `let*` bindings (#190, @gpetiot)
 - Add `--syntax` option to `rule` subcommand to allow generating rules for cram
   tests (#177, @craigfe)

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -127,7 +127,7 @@ let output =
     Printf.sprintf
       "Specify where to write the command output. $(docv) should be $(b,-) for \
        stdout or a filename. Defaults to $(i,%s).corrected. \
-       Note that setting the output to stdout implies $(b,--force-output)."
+       Note that setting this option implies $(b,--force-output)."
       file_docv
   in
   named (fun x -> `Output x)

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -1,4 +1,5 @@
 open Cmdliner
+open Result
 
 let named wrapper =
   Term.(app (const wrapper))
@@ -25,10 +26,12 @@ let syntax =
   named (fun x -> `Syntax x)
     Arg.(value & opt (some syntax) None & info ["syntax"] ~doc ~docv:"SYNTAX")
 
+let file_docv = "FILE"
+
 let file =
   let doc = "The file to use." in
   named (fun x -> `File x)
-    Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:"FILE")
+    Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:file_docv)
 
 let section =
   let doc =
@@ -99,6 +102,36 @@ let force_output =
   let doc = "Force generation of corrected file (even if there was no diff)" in
   named (fun x -> `Force_output x)
     Arg.(value & flag & info ["force-output"] ~doc)
+
+type output =
+  | File of string
+  | Stdout
+
+let output_conv =
+  let (sparse, sprint) = Arg.string in
+  let parse s =
+    match sparse s with
+    | `Ok "-" -> Ok Stdout
+    | `Ok s -> Ok (File s)
+    | `Error msg -> Error (`Msg msg)
+  in
+  let print fmt = function
+    | Stdout -> sprint fmt "-"
+    | File s -> sprint fmt s
+  in
+  Arg.conv ~docv:"OUTPUT" (parse, print)
+
+let output =
+  let docv = "OUTPUT" in
+  let doc =
+    Printf.sprintf
+      "Specify where to write the command output. $(docv) should be $(b,-) for \
+       stdout or a filename. Defaults to $(i,%s).corrected. \
+       Note that setting the output to stdout implies $(b,--force-output)."
+      file_docv
+  in
+  named (fun x -> `Output x)
+    Arg.(value & opt (some output_conv) None & info ~doc ~docv ["o"; "output"])
 
 let setup_log style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -24,4 +24,14 @@ val direction: [> `Direction of [ `To_md | `To_ml ] ] t
 
 val force_output: [> `Force_output of bool ] t
 
+type output =
+  | File of string
+  | Stdout
+
+(** A --output option to overwrite the command output.
+    One can pass it ["-"] to set it to stdout which should imply [force_output].
+    [default_doc] is used to describe the default value in the command's
+    manpage *)
+val output: [> `Output of output option] t
+
 val setup: [> `Setup of unit ] t

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -41,5 +41,6 @@ let cmd: int Term.t * Term.info =
   Term.(pure run
         $ Cli.setup $ Cli.non_deterministic $ Cli.not_verbose $ Cli.syntax
         $ Cli.silent $ Cli.verbose_findlib $ Cli.prelude $ Cli.prelude_str
-        $ Cli.file $ Cli.section $ Cli.root $ Cli.direction $ Cli.force_output),
+        $ Cli.file $ Cli.section $ Cli.root $ Cli.direction $ Cli.force_output
+        $ Cli.output),
   Term.info "test" ~doc

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -372,13 +372,12 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
     Format.pp_print_flush ppf ();
     Buffer.contents buf
   in
-  let run_to_file outfile =
-    Mdx.run_to_file ?syntax ~force_output ~outfile ~f:gen_corrected file
-  in
   (match (output : Cli.output option) with
    | Some Stdout -> Mdx.run_to_stdout ?syntax ~f:gen_corrected file
-   | Some (File outfile) -> run_to_file outfile
-   | None -> run_to_file (file ^ ".corrected"));
+   | Some (File outfile) ->
+     Mdx.run_to_file ?syntax ~outfile ~f:gen_corrected file
+   | None ->
+     Mdx.run ?syntax ~force_output ~f:gen_corrected file);
   Hashtbl.iter (write_parts ~force_output) files;
   0
 

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -266,7 +266,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
     (`Not_verbose not_verbose) (`Syntax syntax) (`Silent silent)
     (`Verbose_findlib verbose_findlib) (`Prelude prelude)
     (`Prelude_str prelude_str) (`File file) (`Section section) (`Root root)
-    (`Direction direction) (`Force_output force_output) =
+    (`Direction direction) (`Force_output force_output) (`Output output) =
   let c =
     Mdx_top.init ~verbose:(not not_verbose) ~silent ~verbose_findlib ()
   in
@@ -353,25 +353,32 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
       | None ->
         run_toplevel_tests ?root c ppf tests t
   in
-
-  Mdx.run ?syntax ~force_output file ~f:(fun file_contents items ->
-      let temp_file = Filename.temp_file "ocaml-mdx" ".output" in
-      at_exit (fun () -> Sys.remove temp_file);
-      let buf = Buffer.create (String.length file_contents + 1024) in
-      let ppf = Format.formatter_of_buffer buf in
-      List.iter (function
-          | Section _
-          | Text _ as t -> Mdx.pp_line ?syntax ppf t
-          | Block t ->
-            List.iter (fun (k, v) -> Unix.putenv k v) (Block.set_variables t);
-            try
-              Mdx_top.in_env (Block.environment t)
-                (fun () -> test_block ~ppf ~temp_file t)
-            with Failure msg ->
-              raise (Test_block_failure (t, msg))
-        ) items;
-      Format.pp_print_flush ppf ();
-      Buffer.contents buf);
+  let gen_corrected file_contents items =
+    let temp_file = Filename.temp_file "ocaml-mdx" ".output" in
+    at_exit (fun () -> Sys.remove temp_file);
+    let buf = Buffer.create (String.length file_contents + 1024) in
+    let ppf = Format.formatter_of_buffer buf in
+    List.iter (function
+        | Section _
+        | Text _ as t -> Mdx.pp_line ?syntax ppf t
+        | Block t ->
+          List.iter (fun (k, v) -> Unix.putenv k v) (Block.set_variables t);
+          try
+            Mdx_top.in_env (Block.environment t)
+              (fun () -> test_block ~ppf ~temp_file t)
+          with Failure msg ->
+            raise (Test_block_failure (t, msg))
+      ) items;
+    Format.pp_print_flush ppf ();
+    Buffer.contents buf
+  in
+  let run_to_file outfile =
+    Mdx.run_to_file ?syntax ~force_output ~outfile ~f:gen_corrected file
+  in
+  (match (output : Cli.output option) with
+   | Some Stdout -> Mdx.run_to_stdout ?syntax ~f:gen_corrected file
+   | Some (File outfile) -> run_to_file outfile
+   | None -> run_to_file (file ^ ".corrected"));
   Hashtbl.iter (write_parts ~force_output) files;
   0
 
@@ -387,10 +394,10 @@ let report_error_in_block block msg =
     kind block.file block.line msg
 
 let run setup non_deterministic not_verbose syntax silent verbose_findlib
-    prelude prelude_str file section root direction force_output : int =
+    prelude prelude_str file section root direction force_output output : int =
     try
     run_exn setup non_deterministic not_verbose syntax silent verbose_findlib
-      prelude prelude_str file section root direction force_output
+      prelude prelude_str file section root direction force_output output
     with
     | Failure f ->
       prerr_endline f;
@@ -410,7 +417,8 @@ let cmd =
   Term.(pure run
         $ Cli.setup $ Cli.non_deterministic $ Cli.not_verbose $ Cli.syntax
         $ Cli.silent $ Cli.verbose_findlib $ Cli.prelude $ Cli.prelude_str
-        $ Cli.file $ Cli.section $ Cli.root $ Cli.direction $ Cli.force_output),
+        $ Cli.file $ Cli.section $ Cli.root $ Cli.direction $ Cli.force_output
+        $ Cli.output),
   Term.info "ocaml-mdx-test" ~version:"%%VERSION%%" ~doc ~exits ~man
 
 let main () = Term.(exit_status @@ eval cmd)

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -69,12 +69,27 @@ val parse_lexbuf: syntax -> Lexing.lexbuf -> t
 
 (** {2 Evaluation} *)
 
+val run_to_stdout : ?syntax: syntax -> f:(string -> t -> string) -> string -> unit
+(** [run_to_stdout ?syntax ~f file] runs the callback [f] on the raw and
+    structured content of [file], as specified  by [syntax] (defaults to [Normal]).
+    The returned corrected version is then written to stdout. *)
+
+val run_to_file :
+  ?syntax: syntax ->
+  ?force_output: bool ->
+  f:(string -> t -> string) ->
+  outfile: string ->
+  string ->
+  unit
+(** [run_to_file ?syntax ?force_output ~f ~outfile file] runs the callback [f]
+    similarly to [run_to_stdout] to generate its corrected version. If
+    [force_output] is [true] (defaults to [false]) or if the corrected version
+    differs from the original file content, it writes it to [outfile].
+    Otherwise, if [outfile] already exists, it removes it. *)
+
 val run: ?syntax:syntax -> ?force_output:bool -> f:(string -> t -> string) -> string -> unit
-(** [run ?syntax ~f n] runs the expect callback [f] over the file named
-   [n]. [f] is called with the raw contents of [n] and its structured
-   contents; it returns the new file contents. If the result of [f] is
-   different from the initial contents or if force_output was set to true, then
-   [$n.corrected] is created with the new contents. *)
+(** [run ?syntax ?force_output ~f file] is
+    [run_to_file ?syntax ?force_output ~f ~outfile:(file ^ ".corrected") file]. *)
 
 (** {2 Filtering} *)
 

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -76,20 +76,18 @@ val run_to_stdout : ?syntax: syntax -> f:(string -> t -> string) -> string -> un
 
 val run_to_file :
   ?syntax: syntax ->
-  ?force_output: bool ->
   f:(string -> t -> string) ->
   outfile: string ->
   string ->
   unit
+(** Same as [run_to_stdout] but writes the corrected version to [outfile]*)
+
+val run: ?syntax:syntax -> ?force_output:bool -> f:(string -> t -> string) -> string -> unit
 (** [run_to_file ?syntax ?force_output ~f ~outfile file] runs the callback [f]
     similarly to [run_to_stdout] to generate its corrected version. If
     [force_output] is [true] (defaults to [false]) or if the corrected version
-    differs from the original file content, it writes it to [outfile].
-    Otherwise, if [outfile] already exists, it removes it. *)
-
-val run: ?syntax:syntax -> ?force_output:bool -> f:(string -> t -> string) -> string -> unit
-(** [run ?syntax ?force_output ~f file] is
-    [run_to_file ?syntax ?force_output ~f ~outfile:(file ^ ".corrected") file]. *)
+    differs from the original file content, it writes it to <file>.corrected.
+    Otherwise, if <file>.corrected already exists, it removes it. *)
 
 (** {2 Filtering} *)
 

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -48,18 +48,6 @@ let init file =
     };
   file_contents, lexbuf
 
-let run_expect_test ~force_output file ~f =
-  let file_contents, lexbuf = init file in
-  let expected = f file_contents lexbuf in
-  let corrected_file = file ^ ".corrected" in
-  if force_output || file_contents <> expected then begin
-    let oc = open_out_bin corrected_file in
-    output_string oc expected;
-    close_out oc;
-  end else begin
-    if Sys.file_exists corrected_file then Sys.remove corrected_file
-  end
-
 let pp_position ppf lexbuf =
   let p = Lexing.lexeme_start_p lexbuf in
   Fmt.pf ppf

--- a/test/bin/test-output-option/dune
+++ b/test/bin/test-output-option/dune
@@ -1,0 +1,37 @@
+(rule
+ (target std-out.corrected)
+ (deps (package mdx) (:md test-case.md))
+ (action
+  (with-stdout-to %{target}
+   (run ocaml-mdx test --output - %{md}))))
+
+(alias
+ (name runtest)
+ (deps
+  (:expected test-case.md)
+  (:actual std-out.corrected))
+ (action (diff %{expected} %{actual})))
+
+(rule
+ (target explicit-outfile.corrected)
+ (deps (package mdx) (:md test-case.md))
+ (action (run ocaml-mdx test --force-output --output %{target} %{md})))
+
+(alias
+ (name runtest)
+ (deps
+  (:expected test-case.md)
+  (:actual explicit-outfile.corrected))
+ (action (diff %{expected} %{actual})))
+
+(rule
+ (target test-case.md.corrected)
+ (deps (package mdx) (:md test-case.md))
+ (action (run ocaml-mdx test --force-output %{md})))
+
+(alias
+ (name runtest)
+ (deps
+  (:expected test-case.md)
+  (:actual test-case.md.corrected))
+ (action (diff %{expected} %{actual})))

--- a/test/bin/test-output-option/test-case.md
+++ b/test/bin/test-output-option/test-case.md
@@ -1,0 +1,11 @@
+`mdx-test` output can be configured via the `--output`/`-o` CLI option. It can be used to write
+to a file or to stdout by passing `--output -`.
+
+When not specified, it should default to `<input_file>.corrected`.
+
+Check the dune file in this folder to see the actual tests!
+
+```ocaml
+# let x = 1 + 1;;
+val x : int = 2
+```


### PR DESCRIPTION
Fixes #193 

This PR adds a `--output/-o` option to set the output for the `ocaml-mdx test` command.

It used to always write to `<input_file>.corrected` so the default behaviour is preserved, i.e. if you do not pass the `--output` option, it still writes to that file.
If passed `--output -`, the command will write the corrected file to stdout instead of writing it to a file. Setting stdout as the output implies `--force-output`. This seems like the best behaviour if you want to pipe it into some other command or redirect it to a file for later diffing.

I deleted the code of `Misc.run_expect_test` (which isn't part of the pulbic API) since it was only used in `Mdx.run`. Instead I created a more generic function `Mdx.run_str` which returns a pair composed of the test result (whether the corrected version is equal to the input or not) and the corrected content.

It is used by two new functions `Mdx.run_to_stdout` and `Mdx.run_to_file`. The former just writes the corrected content to stdout no matter what, the second preserves the behaviour of `Misc.run` except that it takes an `outfile` argument.

I wasn't too sure about what needed to be done with the "clean up" behaviour which takes care of deleting the corrected file if it exists and the test succeeded so I kept it for any output file, whether it's the default are an explicitly specified one. I don't think it's necessary to do that when used through dune as it doesn't use the file presence alone to determine which files need to be promoted but that's unrelated to this PR.

Finally, to preserve the public API, I exposed these two new functions and re-implemented `Mdx.run` on top of `Mdx.run_to_file` so that its behaviour and signature remain the same.

I also added tests to ensure that this option works properly.

Let me know what you think!