### PR TITLE
Add support for mli files

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -18,7 +18,7 @@ let syntax =
   in
   let syntax = (parse, Mdx.Syntax.pp) in
   let doc =
-    "Which syntax to use. Either 'markdown' (also 'normal') or 'cram'."
+    "Which syntax to use. Either 'markdown' (also 'normal'), 'cram', or 'mli'."
   in
   named
     (fun x -> `Syntax x)
@@ -47,6 +47,12 @@ let silent_eval =
   named
     (fun x -> `Silent_eval x)
     Arg.(value & flag & info [ "silent-eval" ] ~doc)
+
+let record_backtrace =
+  let doc = "Print backtraces when evaluating toplevel phrases." in
+  named
+    (fun x -> `Record_backtrace x)
+    Arg.(value & flag & info [ "record-backtrace" ] ~doc)
 
 let silent =
   let doc = "Do not show any (phrases and findlib directives) results." in

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -12,6 +12,8 @@ val section : [> `Section of string option ] t
 
 val silent_eval : [> `Silent_eval of bool ] t
 
+val record_backtrace : [> `Record_backtrace of bool ] t
+
 val silent : [> `Silent of bool ] t
 
 val verbose_findlib : [> `Verbose_findlib of bool ] t

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -37,7 +37,7 @@ let run (`Setup ()) (`File file) (`Section section) =
               if not (Mdx.Block.skip b) then (
                 Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
                 let pp_lines = Fmt.(list ~sep:(unit "\n") string) in
-                let contents = Mdx.Block.executable_contents b in
+                let contents = Mdx.Block.executable_contents ~syntax:Normal b in
                 match b.value with
                 | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
                 | OCaml _ ->

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -123,6 +123,7 @@ let print_format_dune_rules pp_rules =
 let options_of_syntax = function
   | Some Mdx.Normal -> [ "--syntax=normal" ]
   | Some Mdx.Cram -> [ "--syntax=cram" ]
+  | Some Mdx.Mli -> [ "--syntax=mli" ]
   | None -> []
 
 let options_of_section = function
@@ -177,7 +178,7 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax)
       | Some re, Some s -> Re.execp re (snd s)
   in
   let on_item acc = function
-    | Mdx.Section _ | Text _ -> Ok acc
+    | Mdx.Document.Section _ | Text _ -> Ok acc
     | Block b when active b ->
         let files, dirs, nd, packages = acc in
         let nd =

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -82,6 +82,7 @@ type section = int * string
 
 type t = {
   line : int;
+  column : int;
   file : string;
   section : section option;
   dir : string option;
@@ -102,6 +103,7 @@ type t = {
 val mk :
   line:int ->
   file:string ->
+  column:int ->
   section:section option ->
   labels:Label.t list ->
   legacy_labels:bool ->
@@ -121,7 +123,7 @@ val pp_header : ?syntax:Syntax.t -> t Fmt.t
 val pp_contents : ?syntax:Syntax.t -> t Fmt.t
 (** [pp_contents] pretty-prints block contents. *)
 
-val pp_footer : ?syntax:Syntax.t -> unit Fmt.t
+val pp_footer : ?syntax:Syntax.t -> t Fmt.t
 (** [pp_footer] pretty-prints block footer. *)
 
 val pp : ?syntax:Syntax.t -> t Fmt.t
@@ -170,7 +172,7 @@ val value : t -> value
 val section : t -> section option
 (** [section t] is [t]'s section. *)
 
-val executable_contents : t -> string list
+val executable_contents : syntax:Syntax.t -> t -> string list
 (** [executable_contents t] is either [t]'s contents if [t] is a raw
    or a cram block, or [t]'s commands if [t] is a toplevel fragments
    (e.g. the phrase result is discarded). *)

--- a/lib/compat.ml
+++ b/lib/compat.ml
@@ -128,6 +128,14 @@ module Warnings = struct
 #endif
 end
 
+module Lexer = struct
+  include Lexer
+
+#if OCAML_VERSION < (4, 3, 0)
+  let handle_docstrings = ref true
+#endif
+end
+
 #if OCAML_VERSION < (4, 4, 0)
 module Env = struct
   include Env

--- a/lib/document.ml
+++ b/lib/document.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type syntax = Syntax.t = Normal | Cram
+type syntax = Syntax.t = Normal | Cram | Mli
 
 type line = Section of (int * string) | Text of string | Block of Block.t
 
@@ -24,7 +24,10 @@ let pp_line ?syntax ppf (l : line) =
   match l with
   | Block b -> Fmt.pf ppf "%a\n" (Block.pp ?syntax) b
   | Section (d, s) -> Fmt.pf ppf "%s %s\n" (String.make d '#') s
-  | Text s -> Fmt.pf ppf "%s\n" s
+  | Text s -> (
+      match syntax with
+      | Some Mli -> Fmt.pf ppf "%s" s
+      | _ -> Fmt.pf ppf "%s\n" s )
 
 let pp ?syntax ppf t =
   Fmt.pf ppf "%a\n" Fmt.(list ~sep:(unit "\n") (pp_line ?syntax)) t

--- a/lib/document.mli
+++ b/lib/document.mli
@@ -16,7 +16,7 @@
 
 (** {2 Lines} *)
 
-type syntax = Syntax.t = Normal | Cram
+type syntax = Syntax.t = Normal | Cram | Mli
 
 (** The type for the lines of a markdown or cram file. *)
 type line = Section of (int * string) | Text of string | Block of Block.t

--- a/lib/dune
+++ b/lib/dune
@@ -4,9 +4,10 @@
  (preprocess
   (action
    (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
- (libraries astring fmt logs ocaml-migrate-parsetree ocaml-version re result))
+ (libraries astring fmt logs ocaml-migrate-parsetree ocaml-version
+   odoc.parser re result str))
 
-(ocamllex lexer)
+(ocamllex lexer_mdx)
 
 (ocamllex lexer_cram)
 

--- a/lib/lexer_mdx.mll
+++ b/lib/lexer_mdx.mll
@@ -46,13 +46,14 @@ rule text section = parse
                 | _ -> `Output x) e
         in
         let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
+        let column = lexbuf.Lexing.lex_start_p.Lexing.pos_cnum in
         newline lexbuf;
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         newline lexbuf;
         let block =
           match
-            Block.mk ~file ~line ~section ~header ~contents ~labels
+            Block.mk ~file ~line ~column ~section ~header ~contents ~labels
               ~legacy_labels ~errors
           with
           | Ok block -> block
@@ -89,12 +90,13 @@ and cram_text section = parse
         let labels = [] in
         let legacy_labels = false in
         let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
+        let column = lexbuf.Lexing.lex_start_p.Lexing.pos_cnum in
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
         let block =
           match
-            Block.mk ~file ~line ~section ~header ~contents ~labels
+            Block.mk ~file ~line ~column ~section ~header ~contents ~labels
               ~legacy_labels ~errors:[]
           with
           | Ok block -> block
@@ -112,13 +114,14 @@ and cram_text section = parse
         in
         let legacy_labels = false in
         let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
+        let column = lexbuf.Lexing.lex_start_p.Lexing.pos_cnum in
         newline lexbuf;
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
         let block =
           match
-            Block.mk ~file ~line ~section ~header ~contents ~labels
+            Block.mk ~file ~line ~column ~section ~header ~contents ~labels
               ~legacy_labels ~errors:[]
           with
           | Ok block -> block
@@ -138,10 +141,13 @@ and cram_block = parse
         requires_empty_line, str :: lst }
 
 {
-let token syntax lexbuf =
-  try
-    match syntax with
-    | Syntax.Normal -> text      None lexbuf
-    | Syntax.Cram   -> cram_text None lexbuf
-  with Failure e -> Misc.err lexbuf "invalid code block: %s" e
+  let markdown_token lexbuf =
+    try
+      text None lexbuf
+    with Failure e -> Misc.err lexbuf "invalid code block: %s" e
+
+let cram_token lexbuf =
+    try
+      cram_text None lexbuf
+    with Failure e -> Misc.err lexbuf "invalid code block: %s" e
 }

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -16,15 +16,19 @@
 
 let src = Logs.Src.create "ocaml-mdx"
 
+module Lexer_mdx = Lexer_mdx
+
 module Log = (val Logs.src_log src : Logs.LOG)
 
 module Output = Output
 module Cram = Cram
+module Document = Document
 module Toplevel = Toplevel
 module Library = Library
 module Part = Part
 module Block = Block
 module Migrate_ast = Migrate_ast
+module Mli_parser = Mli_parser
 module Compat = Compat
 module Util = Util
 module Prelude = Prelude
@@ -56,11 +60,20 @@ let parse l =
       | `Text t -> Text t | `Section s -> Section s | `Block b -> Block b)
     l
 
-let parse_lexbuf syntax l = parse (Lexer.token syntax l)
+let parse_lexbuf file_contents syntax l =
+  match syntax with
+  | Syntax.Mli -> Mli_parser.parse_mli file_contents
+  | Normal -> parse (Lexer_mdx.markdown_token l)
+  | Cram -> parse (Lexer_mdx.cram_token l)
 
-let parse_file syntax f = parse (Lexer.token syntax (snd (Misc.init f)))
+let parse_file syntax f =
+  let l = snd (Misc.init f) in
+  parse_lexbuf f syntax l
 
-let of_string syntax s = parse_lexbuf syntax (Lexing.from_string s)
+let of_string syntax s =
+  match syntax with
+  | Syntax.Mli -> Mli_parser.parse_mli s
+  | Syntax.Normal | Syntax.Cram -> parse_lexbuf s syntax (Lexing.from_string s)
 
 let dump_line ppf (l : line) =
   match l with
@@ -74,10 +87,11 @@ type expect_result = Identical | Differs
 
 let run_str ~syntax ~f file =
   let file_contents, lexbuf = Misc.init file in
-  let items = parse_lexbuf syntax lexbuf in
+  let items = parse_lexbuf file_contents syntax lexbuf in
   Log.debug (fun l -> l "run @[%a@]" dump items);
   let corrected = f file_contents items in
-  let result = if corrected <> file_contents then Differs else Identical in
+  let has_changed = corrected <> file_contents in
+  let result = if has_changed then Differs else Identical in
   (result, corrected)
 
 let write_file ~outfile content =

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -23,13 +23,16 @@
     Cram tests and toplevel phrases are sequences of commands and
    {{!Output}outputs}.  *)
 
+module Lexer_mdx = Lexer_mdx
 module Output = Output
 module Cram = Cram
+module Document = Document
 module Toplevel = Toplevel
 module Library = Library
 module Part = Part
 module Block = Block
 module Migrate_ast = Migrate_ast
+module Mli_parser = Mli_parser
 module Compat = Compat
 module Util = Util
 module Prelude = Prelude
@@ -38,6 +41,8 @@ module Label = Label
 module Dep = Dep
 
 include module type of Document
+
+val dump : line list Fmt.t
 
 (** {2 Document} *)
 
@@ -48,7 +53,7 @@ val of_string : syntax -> string -> t
 val parse_file : syntax -> string -> t
 (** [parse_file s] is {!of_string} of [s]'s contents. *)
 
-val parse_lexbuf : syntax -> Lexing.lexbuf -> t
+val parse_lexbuf : string -> syntax -> Lexing.lexbuf -> t
 (** [parse_lexbuf l] is {!of_string} of [l]'s contents. *)
 
 (** {2 Evaluation} *)

--- a/lib/mli_parser.ml
+++ b/lib/mli_parser.ml
@@ -1,0 +1,187 @@
+open! Compat
+
+module Code_block = struct
+  type t = { location : Odoc_model.Location_.span; contents : string }
+end
+
+let drop_last lst =
+  match List.rev lst with
+  | [] -> None
+  | last :: rev_tl -> Some (List.rev rev_tl, last)
+
+(* drop_first_and_last [1; 2; 3; 4] = Some (1, Some ([2; 3], 4)). *)
+let drop_first_and_last = function
+  | [] -> None
+  | first :: tl -> Some (first, drop_last tl)
+
+let slice lines ~(start : Odoc_model.Location_.point)
+    ~(end_ : Odoc_model.Location_.point) =
+  let lines_to_include =
+    Util.Array.slice lines ~from:(start.line - 1) ~to_:(end_.line - 1)
+    |> Array.to_list
+  in
+  match drop_first_and_last lines_to_include with
+  | None -> ""
+  | Some (line, None) ->
+      String.sub line start.column (end_.column - start.column)
+  (* Imagine we were slicing the file from (Line 2, Column 3) to (Line 6, Column 7):
+
+       0123456789
+       1 ----------
+       2 ---[---
+       3 ---------
+       4 --
+       5 ----------
+       6 -------]--
+       7 ----------
+       8 ----------
+
+       The case below handles this multiline case, concatenating the included substrings
+       from lines 2-6 ([lines_to_include]). *)
+  | Some (first_line, Some (stripped, last_line)) ->
+      let first_line =
+        String.sub first_line start.column
+          (String.length first_line - start.column)
+      in
+      let last_line = String.sub last_line 0 end_.column in
+      String.concat "\n" ([ first_line ] @ stripped @ [ last_line ])
+
+(* Imagine a docstring that is within a file with four characters # of indentation. (I'll
+   use square brackets rather than parens to avoid escaping):
+
+   ####[** foo
+   ####
+   ####bar
+   ####
+   ####baz *]
+   ####val x : int
+   ####val y : int
+
+   According to odoc, the "b" in "bar" is at column 0 inside the docstring and at column 4
+   within the broader file. That is correct. But it says the "f" in "foo" is at column 1
+   inside the docstring and column 5 within the file. This isn't right.
+
+   The problem is that it starts counting the inside-the-docstring column number from the
+   end of "[**", but doesn't add those three characters to the within-the-file column
+   number. Here, we make the adjustment.
+*)
+let account_for_docstring_open_token (location : Odoc_model.Location_.span) =
+  let start_shift = 3 in
+  let end_shift = if location.start.line = location.end_.line then 3 else 0 in
+  {
+    location with
+    start = { location.start with column = location.start.column + start_shift };
+    end_ = { location.end_ with column = location.end_.column + end_shift };
+  }
+
+let extract_code_blocks ~(location : Lexing.position) ~docstring =
+  let rec acc blocks =
+    List.map
+      (fun block ->
+        match Odoc_model.Location_.value block with
+        | `Code_block contents ->
+            let location =
+              if location.pos_lnum = block.location.start.line then
+                account_for_docstring_open_token block.location
+              else block.location
+            in
+            [ { Code_block.location; contents } ]
+        | `List (_, _, lists) -> List.map acc lists |> List.concat
+        | _ -> [])
+      blocks
+    |> List.concat
+  in
+  let parsed = Odoc_parser.parse_comment_raw ~location ~text:docstring in
+  List.iter
+    (fun error -> failwith (Odoc_model.Error.to_string error))
+    parsed.warnings;
+  List.map
+    (fun element ->
+      match Odoc_model.Location_.value element with
+      | #Odoc_parser.Ast.nestable_block_element as e ->
+          acc
+            [ { Odoc_model.Location_.location = element.location; value = e } ]
+      | `Tag tag -> (
+          match tag with
+          | `Deprecated blocks -> acc blocks
+          | `Param (_, blocks) -> acc blocks
+          | `Raise (_, blocks) -> acc blocks
+          | `Return blocks -> acc blocks
+          | `See (_, _, blocks) -> acc blocks
+          | `Before (_, blocks) -> acc blocks
+          | _ -> [] )
+      | `Heading _ -> [])
+    parsed.value
+  |> List.concat
+
+let docstrings lexbuf =
+  let rec loop list =
+    match Lexer.token_with_comments lexbuf with
+    | Parser.EOF -> list
+    | Parser.DOCSTRING docstring ->
+        let docstring =
+          ( Docstrings.docstring_body docstring,
+            Docstrings.docstring_loc docstring )
+        in
+        loop (docstring :: list)
+    | _ -> loop list
+  in
+  loop [] |> List.rev
+
+let docstring_code_blocks str =
+  Lexer.handle_docstrings := true;
+  Lexer.init ();
+  List.map
+    (fun (docstring, (location : Location.t)) ->
+      extract_code_blocks ~location:location.loc_start ~docstring)
+    (docstrings (Lexing.from_string str))
+  |> List.concat
+
+let parse_mli file_contents =
+  (* Find the locations of the code blocks within [file_contents], then slice it up into
+     [Text] and [Block] parts by using the starts and ends of those blocks as
+     boundaries. *)
+  let code_blocks = docstring_code_blocks file_contents in
+  let cursor = ref { Odoc_model.Location_.line = 1; column = 0 } in
+  let lines = String.split_on_char '\n' file_contents |> Array.of_list in
+  let tokens =
+    List.map
+      (fun (code_block : Code_block.t) ->
+        let pre_text =
+          Document.Text
+            (slice lines ~start:!cursor ~end_:code_block.location.start)
+        in
+        let column = code_block.location.start.column in
+        let contents = Compat.String.split_on_char '\n' code_block.contents in
+        let block =
+          match
+            Block.mk ~line:code_block.location.start.line ~file:"" ~column
+              ~section:None ~labels:[] ~header:(Some OCaml) ~contents
+              ~legacy_labels:false ~errors:[]
+          with
+          | Ok block -> Document.Block block
+          | Error _ -> failwith "Error creating block"
+        in
+        let hpad =
+          if List.length contents = 1 then ""
+          else Astring.String.v ~len:column (fun _ -> ' ')
+        in
+        cursor := code_block.location.end_;
+        [ pre_text; Text "{["; block; Text (hpad ^ "]}") ])
+      code_blocks
+    |> List.concat
+  in
+  let eof =
+    {
+      Odoc_model.Location_.line = Array.length lines;
+      column = String.length lines.(Array.length lines - 1);
+    }
+  in
+  let eof_is_beyond_location (loc : Odoc_model.Location_.point) =
+    eof.line > loc.line || (eof.line = loc.line && eof.column > loc.column)
+  in
+  if eof_is_beyond_location !cursor then
+    let remainder = slice lines ~start:!cursor ~end_:eof in
+    if not (Compat.String.equal remainder "") then tokens @ [ Text remainder ]
+    else tokens
+  else tokens

--- a/lib/mli_parser.mli
+++ b/lib/mli_parser.mli
@@ -1,0 +1,12 @@
+open! Compat
+
+module Code_block : sig
+  type t = { location : Odoc_model.Location_.span; contents : string }
+end
+
+val docstring_code_blocks : string -> Code_block.t list
+(** Parse an mli file as a string and return a list of the code blocks that appear inside
+    its docstrings. *)
+
+val parse_mli : string -> Document.line list
+(** Slice an mli file into its [Text] and [Block] parts. *)

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -1,10 +1,11 @@
 open Compat
 
-type t = Normal | Cram
+type t = Normal | Cram | Mli
 
 let pp fs = function
   | Normal -> Fmt.string fs "normal"
   | Cram -> Fmt.string fs "cram"
+  | Mli -> Fmt.string fs "mli"
 
 let equal x y = x = y
 
@@ -12,9 +13,11 @@ let infer ~file =
   match Filename.extension file with
   | ".t" -> Some Cram
   | ".md" -> Some Normal
+  | ".mli" -> Some Mli
   | _ -> None
 
 let of_string = function
   | "markdown" | "normal" -> Some Normal
   | "cram" -> Some Cram
+  | "mli" -> Some Mli
   | _ -> None

--- a/lib/syntax.mli
+++ b/lib/syntax.mli
@@ -1,0 +1,9 @@
+type t = Normal | Cram | Mli
+
+val pp : Format.formatter -> t -> unit
+
+val equal : t -> t -> bool
+
+val infer : file:string -> t option
+
+val of_string : string -> t option

--- a/lib/toplevel.mli
+++ b/lib/toplevel.mli
@@ -41,8 +41,14 @@ val pp_command : t Fmt.t
 
 (** {2 Parser} *)
 
-val of_lines : file:string -> line:int -> string list -> t list
-(** [of_lines ~file ~line lines] is the list of toplevel blocks from
+val of_lines :
+  syntax:Syntax.t ->
+  file:string ->
+  line:int ->
+  column:int ->
+  string list ->
+  t list
+(** [of_lines ~file ~line ~column lines] is the list of toplevel blocks from
    file [file] starting at line [line]. Return the vertical and
    horizontal whitespace padding as well.*)
 

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -121,3 +121,9 @@ module List = struct
     in
     aux l
 end
+
+module Array = struct
+  let slice t ~from ~to_ =
+    let start_index, length = (from, to_ - from + 1) in
+    Array.sub t start_index length
+end

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -69,3 +69,7 @@ module Sexp : sig
     val to_string : t -> string
   end
 end
+
+module Array : sig
+  val slice : 'a array -> from:int -> to_:int -> 'a array
+end

--- a/mdx.opam
+++ b/mdx.opam
@@ -26,6 +26,7 @@ depends: [
   "result"
   "ocaml-migrate-parsetree" {>= "1.0.6"}
   "ocaml-version" {>= "2.3.0"}
+  "odoc"
   "lwt" {with-test}
   "alcotest" {with-test}
 ]

--- a/test/bin/gen_rule_helpers/gen_rule_helpers.ml
+++ b/test/bin/gen_rule_helpers/gen_rule_helpers.ml
@@ -42,6 +42,8 @@ let cwd_test_file_md = "test-case.md"
 
 let cwd_test_file_t = "test-case.t"
 
+let cwd_test_file_mli = "test-case.mli"
+
 type dir = {
   test_file : string;
   target_file : string;
@@ -51,18 +53,20 @@ type dir = {
 }
 
 let test_file ~dir_name files =
-  let is_test_file f = f = cwd_test_file_md || f = cwd_test_file_t in
+  let is_test_file f =
+    f = cwd_test_file_md || f = cwd_test_file_t || f = cwd_test_file_mli
+  in
   match List.filter is_test_file files with
   | [ test_file ] -> test_file
   | [] ->
       Printf.eprintf "No test file for %s\n" dir_name;
-      Printf.eprintf "There should be one of %s or %s\n" cwd_test_file_md
-        cwd_test_file_t;
+      Printf.eprintf "There should be one of %s, %s, or %s\n" cwd_test_file_md
+        cwd_test_file_t cwd_test_file_mli;
       exit 1
   | _ ->
       Printf.eprintf "More than one test file for %s\n" dir_name;
-      Printf.eprintf "There should be only one of %s or %s\n" cwd_test_file_md
-        cwd_test_file_t;
+      Printf.eprintf "There should be only one of %s, %s, or %s\n"
+        cwd_test_file_md cwd_test_file_t cwd_test_file_mli;
       exit 1
 
 let expected_file ~dir_name ~test_file files =

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -396,6 +396,18 @@
  (action (diff shell-file-inc/test-case.md.expected shell-file-inc.actual)))
 
 (rule
+ (target simple-mli.actual)
+ (deps (package mdx) (source_tree simple-mli))
+ (action
+  (with-stdout-to %{target}
+   (chdir simple-mli
+    (run ocaml-mdx test --output - --syntax=mli test-case.mli)))))
+
+(rule
+ (alias runtest)
+ (action (diff simple-mli/test-case.mli simple-mli.actual)))
+
+(rule
  (target spaces.actual)
  (deps (package mdx) (source_tree spaces))
  (action

--- a/test/bin/mdx-test/expect/simple-mli/test-case.mli
+++ b/test/bin/mdx-test/expect/simple-mli/test-case.mli
@@ -1,0 +1,20 @@
+(** This is a doc comment with some code blocks in it:
+
+    {[
+      # List.map (fun x -> x * x) [(1 + 9); 2; 3]
+      - : int list = [100; 4; 9]
+    ]}
+
+    {[List.map (fun x -> x * x) [1; 2; 3]]}
+
+    {[
+      # List.map (fun x -> x * x) [(1 + 9); 2; 3]
+      - : int list = [100; 4; 9]
+      # List.map (fun x -> x * x) [1; 2; 3]
+      - : int list = [1; 4; 9]
+    ]}
+*)
+val foo : string
+
+(** {[1 + 1 = 3]} *)
+val bar : string

--- a/test/bin/mdx-test/expect/simple-mli/test-case.opts
+++ b/test/bin/mdx-test/expect/simple-mli/test-case.opts
@@ -1,0 +1,1 @@
+--syntax=mli

--- a/test/lib/test_dep.ml
+++ b/test/lib/test_dep.ml
@@ -23,8 +23,8 @@ let test_of_block =
     match Mdx.Label.of_string s with
     | Ok labels -> (
         match
-          Mdx.Block.mk ~line:0 ~file:"" ~section:None ~labels ~header:None
-            ~contents:[] ~legacy_labels:false ~errors:[]
+          Mdx.Block.mk ~line:0 ~file:"" ~column:0 ~section:None ~labels
+            ~header:None ~contents:[] ~legacy_labels:false ~errors:[]
         with
         | Ok block -> block
         | Error _ -> assert false )

--- a/test/lib/test_mdx_lib.ml
+++ b/test/lib/test_mdx_lib.ml
@@ -8,4 +8,5 @@ let () =
       Test_syntax.suite;
       Test_util.suite;
       Test_part.suite;
+      Test_mli_parser.suite;
     ]

--- a/test/lib/test_mli_parser.ml
+++ b/test/lib/test_mli_parser.ml
@@ -1,0 +1,68 @@
+let mli =
+  {|
+(** This is a doc comment with some code blocks in it:
+
+    {[
+      # List.map (fun x -> x * x) [(1 + 9); 2; 3]
+      - : int list = [100; 4; 9]
+    ]}
+
+    {[List.map (fun x -> x * x) [1; 2; 3]]}
+
+    {[
+      # List.map (fun x -> x * x) [(1 + 9); 2; 3]
+      - : int list = [100; 4; 9]
+      # List.map (fun x -> x * x) [1; 2; 3]
+      - : int list = [1; 4; 9]
+    ]}
+*)
+val foo : string
+
+(** {[1 + 1 = 3]} *)
+val bar : string
+|}
+
+let test_parse_mli =
+  let make_test ~test_name ~mli ~expected () =
+    let test_fun () =
+      let buffer = Buffer.create 256 in
+      let fmt = Format.formatter_of_buffer buffer in
+      let actual = Mdx.Mli_parser.parse_mli mli in
+      Mdx.dump fmt actual;
+      let actual = Buffer.contents buffer in
+      Alcotest.(check string) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [
+    make_test ~test_name:"mli" ~mli
+      ~expected:
+        {x|[Text "\n(** This is a doc comment with some code blocks in it:\n\n    ";
+ Text "{[";
+ Block {file: ; line: 4; column: 4; section: None; labels: [];
+        header: Some ocaml;
+                contents: ["# List.map (fun x -> x * x) [(1 + 9); 2; 3]";
+                           "- : int list = [100; 4; 9]"];
+        value: Toplevel};
+ Text "    ]}"; Text "\n\n    "; Text "{[";
+ Block {file: ; line: 9; column: 4; section: None; labels: [];
+        header: Some ocaml;
+                contents: ["List.map (fun x -> x * x) [1; 2; 3]"];
+        value: OCaml};
+ Text "]}"; Text "\n\n    "; Text "{[";
+ Block {file: ; line: 11; column: 4; section: None; labels: [];
+        header: Some ocaml;
+                contents: ["# List.map (fun x -> x * x) [(1 + 9); 2; 3]";
+                           "- : int list = [100; 4; 9]";
+                           "# List.map (fun x -> x * x) [1; 2; 3]";
+                           "- : int list = [1; 4; 9]"];
+        value: Toplevel};
+ Text "    ]}"; Text "\n*)\nval foo : string\n\n(** "; Text "{[";
+ Block {file: ; line: 20; column: 4; section: None; labels: [];
+        header: Some ocaml;
+                contents: ["1 + 1 = 3"]; value: OCaml};
+ Text "]}";|x}
+      ();
+  ]
+
+let suite = ("Mli_parser", test_parse_mli)

--- a/test/lib/test_mli_parser.mli
+++ b/test/lib/test_mli_parser.mli
@@ -1,0 +1,1 @@
+val suite : unit Alcotest.test

--- a/test/lib/test_syntax.ml
+++ b/test/lib/test_syntax.ml
@@ -17,7 +17,8 @@ let test_infer =
     make_test ~file:"" ~expected:None ();
     make_test ~file:"test.md" ~expected:(Some Normal) ();
     make_test ~file:"test.t" ~expected:(Some Cram) ();
-    make_test ~file:"test.mli" ~expected:None ();
+    make_test ~file:"test.ml" ~expected:None ();
+    make_test ~file:"test.mli" ~expected:(Some Mli) ();
     make_test ~file:"no_ext" ~expected:None ();
   ]
 


### PR DESCRIPTION
Teach mdx to process the code blocks inside docstrings in mli files.

For instance, the following:

```ocaml
(** {[# List.map (fun x -> x * x) [1; 2; 3]]} *)
```

is corrected in-place to become:

```ocaml
(** {[# List.map (fun x -> x * x) [1; 2; 3]
      - : int list = [1; 4; 9]
    ]} *)
```

## Implementation

1. We lex mli files in two phases: first, we use the OCaml lexer (via `ppxlib`) to extract docstrings, then we use the odoc parser to extract code blocks within them. We then slice the input into contiguous regions of `Text` and `Block` items, just like the lexer for `Normal` syntax.

2. We add a new `Syntax.Mli` and thread `~syntax` arguments through a few more places so that we can properly format the output of mli's (avoiding newlines, etc.).

3. Since mli files are often written with formatters like ocamlformat and ocp-indent, and since these formatters might clobber the output of mdx, we make mdx's diff for the `Mli` syntax whitespace-invariant.

## Notes

* There is currently no support for header attributes (like `env=main`), because the odoc parser doesn't currently support an extended `{env=main[ let x = ... ]}` syntax for code blocks. This will have to be added later.

* We made changes to mdx to get the library to build within our environment (we're using Jenga). I also made the changes in this pull request against an earlier version of mdx, and wrote tests for them according to our internal conventions. I did my best to port the changes to this new version. But there are currently no tests and I'm not sure that this will build!

So I'd appreciate any instructions on how to get mdx running with dune (from scratch, more or less), and how to run the test suite.