### PR TITLE
Allow to set --non-deterministic through an env var

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -6,8 +6,9 @@ let named wrapper =
 
 let non_deterministic =
   let doc = "Run non-deterministic tests." in
+  let env = Arg.env_var ~doc "MDX_RUN_NON_DETERMINISTIC" in
   named (fun x -> `Non_deterministic x)
-    Arg.(value & flag & info ["non-deterministic"; "n"] ~doc)
+    Arg.(value & flag & info ["non-deterministic"; "n"] ~env ~doc)
 
 let syntax =
   let parse = function

--- a/test/bin/mdx-test/misc/non-det-env-var/dune
+++ b/test/bin/mdx-test/misc/non-det-env-var/dune
@@ -1,0 +1,10 @@
+(rule
+ (target test-case.md.corrected)
+ (deps (package mdx))
+ (action
+  (setenv MDX_RUN_NON_DETERMINISTIC true
+   (run ocaml-mdx test --force-output %{dep:test-case.md}))))
+
+(alias
+ (name runtest)
+ (action (diff test-case.md.expected test-case.md.corrected)))

--- a/test/bin/mdx-test/misc/non-det-env-var/test-case.md
+++ b/test/bin/mdx-test/misc/non-det-env-var/test-case.md
@@ -1,0 +1,6 @@
+The `--non-deterministic` option can also be set through the `MDX_RUN_NON_DETERMINISTIC` env
+variable.
+
+```sh non-deterministic
+$ echo "lol"
+```

--- a/test/bin/mdx-test/misc/non-det-env-var/test-case.md.expected
+++ b/test/bin/mdx-test/misc/non-det-env-var/test-case.md.expected
@@ -1,0 +1,7 @@
+The `--non-deterministic` option can also be set through the `MDX_RUN_NON_DETERMINISTIC` env
+variable.
+
+```sh non-deterministic
+$ echo "lol"
+lol
+```


### PR DESCRIPTION
This is especially helpful if you're invoking mdx through dune rules you wrote or generated yourself. It will also prove useful with the mdx stanza which won't run non-deterministic tests by default.