### PR TITLE
Fix a bug with sync of ml files in sub directories

### DIFF
--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -326,16 +326,16 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
             if Output.equal test.output output then ()
             else err_eval ~cmd:test.command e
         ) tests
-    | true, _, Some file, _, kind ->
+    | true, _, Some ext_file, _, kind ->
         (match kind with
         | OCaml | Toplevel _ ->
           assert (syntax <> Some Cram);
-          update_file_or_block ?root ppf file file t direction
+          update_file_or_block ?root ppf file ext_file t direction
         | _ when Util.Option.is_some (Block.part t) ->
           Fmt.failwith
             "Parts are not supported for non-OCaml code blocks."
         | Cram _ | Raw ->
-          let new_content = (read_part file (Block.part t)) in
+          let new_content = (read_part ext_file (Block.part t)) in
           update_block_content ppf t new_content
         | _ -> print_block ())
     | true, _, None, _, kind ->

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -360,6 +360,18 @@
  (action (diff spaces/test-case.md spaces.actual)))
 
 (rule
+ (target sync-from-subdir.actual)
+ (deps (package mdx) (source_tree sync-from-subdir))
+ (action
+  (with-stdout-to %{target}
+   (chdir sync-from-subdir
+    (run ocaml-mdx test --output - test-case.md)))))
+
+(alias
+ (name runtest)
+ (action (diff sync-from-subdir/test-case.md.expected sync-from-subdir.actual)))
+
+(rule
  (target sync-to-md.actual)
  (deps (package mdx) (source_tree sync-to-md))
  (action

--- a/test/bin/mdx-test/expect/sync-from-subdir/some_dir/some_module.ml
+++ b/test/bin/mdx-test/expect/sync-from-subdir/some_dir/some_module.ml
@@ -1,0 +1,4 @@
+let _ = "Do not include me"
+
+[@@@part "1"]
+let _ = "Include me"

--- a/test/bin/mdx-test/expect/sync-from-subdir/test-case.md
+++ b/test/bin/mdx-test/expect/sync-from-subdir/test-case.md
@@ -1,0 +1,4 @@
+You can sync files from subdirs:
+
+```ocaml file=some_dir/some_module.ml,part=1
+```

--- a/test/bin/mdx-test/expect/sync-from-subdir/test-case.md.expected
+++ b/test/bin/mdx-test/expect/sync-from-subdir/test-case.md.expected
@@ -1,0 +1,5 @@
+You can sync files from subdirs:
+
+```ocaml file=some_dir/some_module.ml,part=1
+let _ = "Include me"
+```


### PR DESCRIPTION
I discovered it when trying to upgrade the mdx verison used by RWO. The fix comes with a regression test!

The bug was never released so I did not update the changelog!