### PR TITLE
Enforce the naming consistency of `silent_eval`

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -41,9 +41,9 @@ let section =
   named (fun x -> `Section x)
     Arg.(value & opt (some string) None & info ["section"; "s"] ~doc ~docv:"PAT")
 
-let not_verbose =
+let silent_eval =
   let doc = "Do not show the result of evaluating toplevel phrases." in
-  named (fun x -> `Not_verbose x)
+  named (fun x -> `Silent_eval x)
     Arg.(value & flag & info ["silent-eval"] ~doc)
 
 let silent =

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -10,7 +10,7 @@ val file: [> `File of string ] t
 
 val section: [> `Section of string option ] t
 
-val not_verbose: [> `Not_verbose of bool ] t
+val silent_eval: [> `Silent_eval of bool ] t
 
 val silent: [> `Silent of bool ] t
 

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -39,7 +39,7 @@ open Cmdliner
 let cmd: int Term.t * Term.info =
   let doc = "Test markdown files." in
   Term.(pure run
-        $ Cli.setup $ Cli.non_deterministic $ Cli.not_verbose $ Cli.syntax
+        $ Cli.setup $ Cli.non_deterministic $ Cli.silent_eval $ Cli.syntax
         $ Cli.silent $ Cli.verbose_findlib $ Cli.prelude $ Cli.prelude_str
         $ Cli.file $ Cli.section $ Cli.root $ Cli.force_output $ Cli.output),
   Term.info "test" ~doc

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -229,13 +229,11 @@ let update_file_or_block ?root ppf md_file ml_file block =
 exception Test_block_failure of Block.t * string
 
 let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
-    (`Not_verbose not_verbose) (`Syntax syntax) (`Silent silent)
+    (`Silent_eval silent_eval) (`Syntax syntax) (`Silent silent)
     (`Verbose_findlib verbose_findlib) (`Prelude prelude)
     (`Prelude_str prelude_str) (`File file) (`Section section) (`Root root)
     (`Force_output force_output) (`Output output) =
-  let c =
-    Mdx_top.init ~verbose:(not not_verbose) ~silent ~verbose_findlib ()
-  in
+  let c = Mdx_top.init ~verbose:(not silent_eval) ~silent ~verbose_findlib () in
   let section = match section with
     | None   -> None
     | Some p -> Some (Re.Perl.compile_pat p)
@@ -366,10 +364,10 @@ let report_error_in_block block msg =
   Fmt.epr "Error in the %scode block in %s at line %d:@]\n%s\n"
     kind block.file block.line msg
 
-let run setup non_deterministic not_verbose syntax silent verbose_findlib
+let run setup non_deterministic silent_eval syntax silent verbose_findlib
     prelude prelude_str file section root force_output output : int =
     try
-    run_exn setup non_deterministic not_verbose syntax silent verbose_findlib
+    run_exn setup non_deterministic silent_eval syntax silent verbose_findlib
       prelude prelude_str file section root force_output output
     with
     | Failure f ->
@@ -388,7 +386,7 @@ let cmd =
   let man = [] in
   let doc = "Test markdown files." in
   Term.(pure run
-        $ Cli.setup $ Cli.non_deterministic $ Cli.not_verbose $ Cli.syntax
+        $ Cli.setup $ Cli.non_deterministic $ Cli.silent_eval $ Cli.syntax
         $ Cli.silent $ Cli.verbose_findlib $ Cli.prelude $ Cli.prelude_str
         $ Cli.file $ Cli.section $ Cli.root $ Cli.force_output $ Cli.output),
   Term.info "ocaml-mdx-test" ~version:"%%VERSION%%" ~doc ~exits ~man


### PR DESCRIPTION
A small simplification for `bin/test/main.ml`