### PR TITLE
Infer syntax kind when --syntax is not set, and add 'markdown' as an alias to 'normal'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Allow to set the `--non-deterministic` option through the `MDX_RUN_NON_DETERMINISTIC`
   env variables (#208, @NathanReb)
 - Add support for OCaml 4.10 (#204, @kit-ty-kate)
+- Infer syntax kind when `--syntax` is not set, and add 'markdown' as an alias to 'normal' (#222, @gpetiot)
 
 #### Fixed
 

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -12,7 +12,7 @@ let non_deterministic =
 
 let syntax =
   let parse = function
-    | "normal" -> `Ok Mdx.Normal
+    | "markdown" | "normal" -> `Ok Mdx.Normal
     | "cram" -> `Ok Mdx.Cram
     | s -> `Error (Format.sprintf "unrecognized syntax %S" s)
   in
@@ -23,7 +23,9 @@ let syntax =
        | Mdx.Cram -> "cram")
   in
   let syntax = parse, print in
-  let doc = "Which syntax to use. Either 'normal' or 'cram'." in
+  let doc =
+    "Which syntax to use. Either 'markdown' (also 'normal') or 'cram'."
+  in
   named (fun x -> `Syntax x)
     Arg.(value & opt (some syntax) None & info ["syntax"] ~doc ~docv:"SYNTAX")
 

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -11,18 +11,12 @@ let non_deterministic =
     Arg.(value & flag & info ["non-deterministic"; "n"] ~env ~doc)
 
 let syntax =
-  let parse = function
-    | "markdown" | "normal" -> `Ok Mdx.Normal
-    | "cram" -> `Ok Mdx.Cram
-    | s -> `Error (Format.sprintf "unrecognized syntax %S" s)
+  let parse s =
+    match Mdx.Syntax.of_string s with
+    | Some syntax -> `Ok syntax
+    | None -> `Error (Format.sprintf "unrecognized syntax %S" s)
   in
-  let print fmt syn =
-    Format.fprintf fmt "%s"
-      (match syn with
-       | Mdx.Normal -> "normal"
-       | Mdx.Cram -> "cram")
-  in
-  let syntax = parse, print in
+  let syntax = parse, Mdx.Syntax.pp in
   let doc =
     "Which syntax to use. Either 'markdown' (also 'normal') or 'cram'."
   in

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -168,6 +168,11 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax)
     (`Prelude prelude) (`Prelude_str prelude_str) (`Root root)
     (`Duniverse_mode duniverse_mode) (`Locks locks) =
   let open Mdx.Util.Result.Infix in
+  let syntax =
+    match syntax with
+    | Some syntax -> Some syntax
+    | None -> Mdx.Syntax.infer ~file:md_file
+  in
   let active =
     let section = match section with
       | None   -> None

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -233,6 +233,11 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
     (`Verbose_findlib verbose_findlib) (`Prelude prelude)
     (`Prelude_str prelude_str) (`File file) (`Section section) (`Root root)
     (`Force_output force_output) (`Output output) =
+  let syntax =
+    match syntax with
+    | Some syntax -> Some syntax
+    | None -> Syntax.infer ~file
+  in
   let c = Mdx_top.init ~verbose:(not silent_eval) ~silent ~verbose_findlib () in
   let section = match section with
     | None   -> None

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -26,6 +26,7 @@ module Migrate_ast = Migrate_ast
 module Compat = Compat
 module Util = Util
 module Prelude = Prelude
+module Syntax = Syntax
 
 type line =
   | Section of (int * string)

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -32,6 +32,7 @@ module Migrate_ast = Migrate_ast
 module Compat = Compat
 module Util = Util
 module Prelude = Prelude
+module Syntax = Syntax
 
 (** {2 Lines} *)
 

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -15,3 +15,8 @@ let infer ~file =
   | ".t" -> Some Cram
   | ".md" -> Some Normal
   | _ -> None
+
+let of_string = function
+  | "markdown" | "normal" -> Some Normal
+  | "cram" -> Some Cram
+  | _ -> None

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -1,3 +1,17 @@
+open Compat
+
 type t = Normal | Cram
 
 let cram_default_header = Some "sh" (* FIXME: bash? *)
+
+let pp fs = function
+  | Normal -> Fmt.string fs "normal"
+  | Cram -> Fmt.string fs "cram"
+
+let equal x y = x = y
+
+let infer ~file =
+  match Filename.extension file with
+  | ".t" -> Some Cram
+  | ".md" -> Some Normal
+  | _ -> None

--- a/test/bin/mdx-rule/misc/duniverse-mode/dune.gen.expected
+++ b/test/bin/mdx-rule/misc/duniverse-mode/dune.gen.expected
@@ -10,5 +10,5 @@
  (action
   (progn
    (run ocaml-mdx test --prelude=prelude.ml --prelude-str
-     "#require \"prelude-str\"" %{x})
+     "#require \"prelude-str\"" --syntax=normal %{x})
    (diff? %{x} %{x}.corrected))))

--- a/test/bin/mdx-test/misc/syntax/dune
+++ b/test/bin/mdx-test/misc/syntax/dune
@@ -1,0 +1,47 @@
+(rule
+ (target test-case.md.corrected)
+ (deps (package mdx) (:md test-case.md))
+ (action (run ocaml-mdx test --output %{target} %{md})))
+
+(alias
+ (name runtest)
+ (deps
+  (:expected test-case.md)
+  (:actual test-case.md.corrected))
+ (action (diff %{expected} %{actual})))
+
+(rule
+ (target test-case.t.corrected)
+ (deps (package mdx) (:md test-case.t))
+ (action (run ocaml-mdx test --output %{target} %{md})))
+
+(alias
+ (name runtest)
+ (deps
+  (:expected test-case.t)
+  (:actual test-case.t.corrected))
+ (action (diff %{expected} %{actual})))
+
+(rule
+ (target test-case-md.ext.corrected)
+ (deps (package mdx) (:md test-case-md.ext))
+ (action (run ocaml-mdx test %{md} --output %{target} --syntax markdown)))
+
+(alias
+ (name runtest)
+ (deps
+  (:expected test-case-md.ext)
+  (:actual test-case-md.ext.corrected))
+ (action (diff %{expected} %{actual})))
+
+(rule
+ (target test-case-cram.ext.corrected)
+ (deps (package mdx) (:md test-case-cram.ext))
+ (action (run ocaml-mdx test %{md} --output %{target} --syntax cram)))
+
+(alias
+ (name runtest)
+ (deps
+  (:expected test-case-cram.ext)
+  (:actual test-case-cram.ext.corrected))
+ (action (diff %{expected} %{actual})))

--- a/test/bin/mdx-test/misc/syntax/test-case-cram.ext
+++ b/test/bin/mdx-test/misc/syntax/test-case-cram.ext
@@ -1,0 +1,11 @@
+The syntax of this file is `cram`, it can't be inferred by its file extension, so `--syntax=cram` is required.
+
+  $ cat <<EOF > foo \
+  > hello\
+  > world\
+  > EOF
+  $ cat foo
+  hello
+  world
+  $ echo foo
+  foo

--- a/test/bin/mdx-test/misc/syntax/test-case-md.ext
+++ b/test/bin/mdx-test/misc/syntax/test-case-md.ext
@@ -1,0 +1,6 @@
+The syntax of this file is `markdown`, it can't be inferred by its file extension, so `--syntax=markdown` is required.
+
+```ocaml
+# let x = 1 + 1;;
+val x : int = 2
+```

--- a/test/bin/mdx-test/misc/syntax/test-case.md
+++ b/test/bin/mdx-test/misc/syntax/test-case.md
@@ -1,0 +1,6 @@
+The syntax of this file is `markdown` and will be inferred by its file extension.
+
+```ocaml
+# let x = 1 + 1;;
+val x : int = 2
+```

--- a/test/bin/mdx-test/misc/syntax/test-case.t
+++ b/test/bin/mdx-test/misc/syntax/test-case.t
@@ -1,0 +1,11 @@
+The syntax of this file is `cram` and will be inferred by its file extension.
+
+  $ cat <<EOF > foo \
+  > hello\
+  > world\
+  > EOF
+  $ cat foo
+  hello
+  world
+  $ echo foo
+  foo

--- a/test/lib/test_mdx_lib.ml
+++ b/test/lib/test_mdx_lib.ml
@@ -2,4 +2,5 @@ let () =
   Alcotest.run "Mdx"
     [ Test_block.suite
     ; Test_library.suite
+    ; Test_syntax.suite
     ]

--- a/test/lib/test_syntax.ml
+++ b/test/lib/test_syntax.ml
@@ -1,0 +1,23 @@
+module Testable = struct
+  open Mdx.Syntax
+
+  let syntax = Alcotest.testable pp equal
+end
+
+let test_infer =
+  let make_test ~file ~expected () =
+    let test_name = Printf.sprintf "infer: %S" file in
+    let test_fun () =
+      let actual = Mdx.Syntax.infer ~file in
+      Alcotest.(check (option Testable.syntax)) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [ make_test ~file:"" ~expected:None ()
+  ; make_test ~file:"test.md" ~expected:(Some Normal) ()
+  ; make_test ~file:"test.t" ~expected:(Some Cram) ()
+  ; make_test ~file:"test.mli" ~expected:None ()
+  ; make_test ~file:"no_ext" ~expected:None ()
+  ]
+
+let suite = ("Syntax", test_infer)

--- a/test/lib/test_syntax.mli
+++ b/test/lib/test_syntax.mli
@@ -1,0 +1,1 @@
+val suite : unit Alcotest.test


### PR DESCRIPTION
Fix #220