### PR TITLE
Do not unset INSIDE_DUNE by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 - Add support for OCaml 4.10 (#204, @kit-ty-kate)
 - Infer syntax kind when `--syntax` is not set, and add 'markdown' as an alias to 'normal' (#222, @gpetiot)
 
+#### Changed
+
+- Do not unset `INSIDE_DUNE` when executing shell commands by default (#224, @NathanReb)
+
 #### Fixed
 
 - Fix a bug that could cause `ocaml-mdx test` to crash on some `include` in toplevel code blocks

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -63,7 +63,6 @@ let with_dir root f =
       raise e
 
 let get_env blacklist =
-  let blacklist = "INSIDE_DUNE"::blacklist in
   let env = Array.to_list (Unix.environment ()) in
   let env = List.map (String.cuts ~sep:"=") env in
   let f env var =

--- a/test/bin/mdx-test/expect/environment-variable-unset/test-case.md
+++ b/test/bin/mdx-test/expect/environment-variable-unset/test-case.md
@@ -9,5 +9,3 @@ Environment variables can be blacklisted in an shell and bash blocks.
   $ echo $HOME
   
 ```
-
-By default, the variable INSIDE_DUNE is blacklisted, in order to keep the wanted outputs from dune related commands.


### PR DESCRIPTION
This can mess with dune pretty bad, in particular in dune's test suite. It can still be set on a block by block basis if it's actually needed.

I tested that on RWO and there's only one block where I had to set it. That block could also be preserved by simply adding an ellipsis `...`.

I still need to see if it fixes the issues I had in the dune's test suite.