### PR TITLE
Check the blocks during parsing

### DIFF
--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -39,11 +39,11 @@ let run (`Setup ()) (`File file) (`Section section) =
                 Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
                 let pp_lines = Fmt.(list ~sep:(unit "\n") string) in
                 let contents = Mdx.Block.executable_contents b in
-                match b.value with
+                match Mdx.Block.value b with
                 | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
                 | OCaml ->
-                    Fmt.pr "%a\n%a\n" Mdx.Block.pp_line_directive (file, b.line)
-                      pp_lines contents
+                    Fmt.pr "%a\n%a\n" Mdx.Block.pp_line_directive
+                      (file, Mdx.Block.line b) pp_lines contents
                 | _ -> () ))
         t;
       0

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -37,11 +37,11 @@ let run (`Setup ()) (`File file) (`Section section) =
             Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
             let pp_lines = Fmt.(list ~sep:(unit "\n") string) in
             let contents = Mdx.Block.executable_contents b in
-            match Mdx.Block.value b with
+            match b.value with
             | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
             | OCaml _    ->
               Fmt.pr "%a\n%a\n"
-                Mdx.Block.pp_line_directive (file, Mdx.Block.line b)
+                Mdx.Block.pp_line_directive (file, b.line)
                 pp_lines contents
             | _          -> ()
           )

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -39,7 +39,7 @@ let run (`Setup ()) (`File file) (`Section section) =
             let contents = Mdx.Block.executable_contents b in
             match Mdx.Block.value b with
             | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
-            | OCaml      ->
+            | OCaml _    ->
               Fmt.pr "%a\n%a\n"
                 Mdx.Block.pp_line_directive (file, Mdx.Block.line b)
                 pp_lines contents

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -29,24 +29,23 @@ let run (`Setup ()) (`File file) (`Section section) =
   in
   match t with
   | [] -> 1
-  | _  ->
-    List.iter (function
-        | Mdx.Section _ | Text _ -> ()
-        | Block b ->
-          if not (Mdx.Block.skip b) then (
-            Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
-            let pp_lines = Fmt.(list ~sep:(unit "\n") string) in
-            let contents = Mdx.Block.executable_contents b in
-            match b.value with
-            | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
-            | OCaml _    ->
-              Fmt.pr "%a\n%a\n"
-                Mdx.Block.pp_line_directive (file, b.line)
-                pp_lines contents
-            | _          -> ()
-          )
-      ) t;
-    0
+  | _ ->
+      List.iter
+        (function
+          | Mdx.Section _ | Text _ -> ()
+          | Block b ->
+              if not (Mdx.Block.skip b) then (
+                Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
+                let pp_lines = Fmt.(list ~sep:(unit "\n") string) in
+                let contents = Mdx.Block.executable_contents b in
+                match b.value with
+                | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
+                | OCaml _ ->
+                    Fmt.pr "%a\n%a\n" Mdx.Block.pp_line_directive (file, b.line)
+                      pp_lines contents
+                | _ -> () ))
+        t;
+      0
 
 open Cmdliner
 

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -29,24 +29,24 @@ let run (`Setup ()) (`File file) (`Section section) =
   in
   match t with
   | [] -> 1
-  | _ ->
-      List.iter
-        (function
-          | Mdx.Section _ | Text _ -> ()
-          | Block b ->
-              let b = Mdx.Block.eval b in
-              if not (Mdx.Block.skip b) then (
-                Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
-                let pp_lines = Fmt.(list ~sep:(unit "\n") string) in
-                let contents = Mdx.Block.executable_contents b in
-                match Mdx.Block.value b with
-                | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
-                | OCaml ->
-                    Fmt.pr "%a\n%a\n" Mdx.Block.pp_line_directive
-                      (file, Mdx.Block.line b) pp_lines contents
-                | _ -> () ))
-        t;
-      0
+  | _  ->
+    List.iter (function
+        | Mdx.Section _ | Text _ -> ()
+        | Block b ->
+          if not (Mdx.Block.skip b) then (
+            Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
+            let pp_lines = Fmt.(list ~sep:(unit "\n") string) in
+            let contents = Mdx.Block.executable_contents b in
+            match Mdx.Block.value b with
+            | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
+            | OCaml      ->
+              Fmt.pr "%a\n%a\n"
+                Mdx.Block.pp_line_directive (file, Mdx.Block.line b)
+                pp_lines contents
+            | _          -> ()
+          )
+      ) t;
+    0
 
 open Cmdliner
 

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -179,29 +179,31 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax)
   let on_item acc = function
     | Mdx.Section _ | Text _ -> Ok acc
     | Block b when active b ->
-      let files, dirs, nd, packages = acc in
-      let nd = nd || match Mdx.Block.non_det b with
-        | Some _ -> true
-        | None -> false
-      in
-      let source_trees = String.Set.of_list (Mdx.Block.source_trees b) in
-      let dirs =
-        dirs
-        |> add_opt (Mdx.Block.directory b)
-        |> String.Set.union source_trees
-      in
-      let files = add_opt (Mdx.Block.file b) files in
-      let explicit_requires = String.Set.of_list (Mdx.Block.explicit_required_packages b) in
-      let requires_from_statement =
-        if duniverse_mode then
-          Mdx.Block.required_libraries b >>| Mdx.Library.Set.to_package_set
-        else
-          Ok String.Set.empty
-      in
-      requires_from_statement >>| fun requires_from_statement ->
-      let (++) = String.Set.union in
-      let packages = packages ++ explicit_requires ++ requires_from_statement in
-      files, dirs, nd, packages
+        let files, dirs, nd, packages = acc in
+        let nd =
+          nd || match Mdx.Block.non_det b with Some _ -> true | None -> false
+        in
+        let source_trees = String.Set.of_list (Mdx.Block.source_trees b) in
+        let dirs =
+          dirs
+          |> add_opt (Mdx.Block.directory b)
+          |> String.Set.union source_trees
+        in
+        let files = add_opt (Mdx.Block.file b) files in
+        let explicit_requires =
+          String.Set.of_list (Mdx.Block.explicit_required_packages b)
+        in
+        let requires_from_statement =
+          if duniverse_mode then
+            Mdx.Block.required_libraries b >>| Mdx.Library.Set.to_package_set
+          else Ok String.Set.empty
+        in
+        requires_from_statement >>| fun requires_from_statement ->
+        let ( ++ ) = String.Set.union in
+        let packages =
+          packages ++ explicit_requires ++ requires_from_statement
+        in
+        (files, dirs, nd, packages)
     | Block _ -> Ok acc
   in
   let on_file file_contents items =

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -179,31 +179,29 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax)
   let on_item acc = function
     | Mdx.Section _ | Text _ -> Ok acc
     | Block b when active b ->
-        let files, dirs, nd, packages = acc in
-        let nd =
-          nd || match Mdx.Block.mode b with `Non_det _ -> true | _ -> false
-        in
-        let source_trees = String.Set.of_list (Mdx.Block.source_trees b) in
-        let dirs =
-          dirs
-          |> add_opt (Mdx.Block.directory b)
-          |> String.Set.union source_trees
-        in
-        let files = add_opt (Mdx.Block.file b) files in
-        let explicit_requires =
-          String.Set.of_list (Mdx.Block.explicit_required_packages b)
-        in
-        let requires_from_statement =
-          if duniverse_mode then
-            Mdx.Block.required_libraries b >>| Mdx.Library.Set.to_package_set
-          else Ok String.Set.empty
-        in
-        requires_from_statement >>| fun requires_from_statement ->
-        let ( ++ ) = String.Set.union in
-        let packages =
-          packages ++ explicit_requires ++ requires_from_statement
-        in
-        (files, dirs, nd, packages)
+      let files, dirs, nd, packages = acc in
+      let nd = nd || match Mdx.Block.mode b with
+        | Some _ -> true
+        | None -> false
+      in
+      let source_trees = String.Set.of_list (Mdx.Block.source_trees b) in
+      let dirs =
+        dirs
+        |> add_opt (Mdx.Block.directory b)
+        |> String.Set.union source_trees
+      in
+      let files = add_opt (Mdx.Block.file b) files in
+      let explicit_requires = String.Set.of_list (Mdx.Block.explicit_required_packages b) in
+      let requires_from_statement =
+        if duniverse_mode then
+          Mdx.Block.required_libraries b >>| Mdx.Library.Set.to_package_set
+        else
+          Ok String.Set.empty
+      in
+      requires_from_statement >>| fun requires_from_statement ->
+      let (++) = String.Set.union in
+      let packages = packages ++ explicit_requires ++ requires_from_statement in
+      files, dirs, nd, packages
     | Block _ -> Ok acc
   in
   let on_file file_contents items =

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -180,7 +180,7 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax)
     | Mdx.Section _ | Text _ -> Ok acc
     | Block b when active b ->
       let files, dirs, nd, packages = acc in
-      let nd = nd || match Mdx.Block.mode b with
+      let nd = nd || match Mdx.Block.non_det b with
         | Some _ -> true
         | None -> false
       in

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -252,22 +252,15 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
     match syntax with Some syntax -> Some syntax | None -> Syntax.infer ~file
   in
   let c = Mdx_top.init ~verbose:(not silent_eval) ~silent ~verbose_findlib () in
-  let section =
-    match section with None -> None | Some p -> Some (Re.Perl.compile_pat p)
-  in
-  let active b =
-    match (section, Block.section b) with
-    | None, _ -> true
-    | Some re, None -> Re.execp re ""
-    | Some re, Some s -> Re.execp re (snd s)
-  in
   eval_prelude ?root c prelude prelude_str;
 
   let test_block ~ppf ~temp_file t =
-    let active = active t && Block.version_enabled t && not (Block.skip t) in
     let print_block () = Block.pp ?syntax ppf t in
-    match
-      (active, non_deterministic, Block.file t, Block.mode t, Block.value t)
+    match Block.is_active ?section t,
+          non_deterministic,
+          Block.file t,
+          Block.mode t,
+          Block.value t
     with
     (* Print errors *)
     | _, _, _, _, Error _

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -341,7 +341,9 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
 let report_error_in_block block msg =
   let kind =
     match block.Block.value with
-    | Raw _ | Error _ | Include _ -> ""
+    | Raw _ | Error _ -> ""
+    | Include { file_kind = Fk_ocaml _; _ } -> "OCaml file include "
+    | Include { file_kind = Fk_other _; _ } -> "file include "
     | OCaml _ -> "OCaml "
     | Cram _ -> "cram "
     | Toplevel _ -> "toplevel "

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -261,14 +261,12 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
       (* Print errors *)
       | Error _ -> print_block ()
       | Raw _ -> print_block ()
-      | Include { file_included; part_included; header } -> (
-          match header with
-          | Some Block.Header.OCaml ->
-            assert (syntax <> Some Cram);
-            update_file_or_block ?root ppf file file_included t part_included
-          | _ ->
-            let new_content = (read_part file_included part_included) in
-            update_block_content ppf t new_content )
+      | Include (Include_OCaml { file_included; part_included }) ->
+        assert (syntax <> Some Cram);
+        update_file_or_block ?root ppf file file_included t part_included
+      | Include (Include_other { file_included; _ }) ->
+        let new_content = (read_part file_included None) in
+        update_block_content ppf t new_content
       | OCaml { non_det; _ } -> (
           match non_det with
           (* the command is non-deterministic so skip everything *)

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -98,12 +98,9 @@ let resolve_root file dir root =
 
 let run_cram_tests ?syntax t ?root ppf temp_file pad tests =
   Block.pp_header ?syntax ppf t;
-  let pad =
-    match syntax with
-    | Some Cram -> pad + 2
-    | _ -> pad
-  in
-  List.iter (fun test ->
+  let pad = match syntax with Some Cram -> pad + 2 | _ -> pad in
+  List.iter
+    (fun test ->
       let root = root_dir ?root ~block:t () in
       let blacklist = Block.unset_variables t in
       let n = run_test ?root blacklist temp_file test in
@@ -140,9 +137,11 @@ let err_eval ~cmd lines =
   exit 1
 
 let eval_raw ?block ?root c ~line lines =
-  let test = Toplevel.{vpad=0; hpad=0; line; command = lines; output = [] } in
+  let test =
+    Toplevel.{ vpad = 0; hpad = 0; line; command = lines; output = [] }
+  in
   match eval_test ?block ?root c test with
-  | Ok _    -> ()
+  | Ok _ -> ()
   | Error e -> err_eval ~cmd:lines e
 
 let lines = function Ok x | Error x -> x
@@ -157,7 +156,8 @@ let split_lines lines =
 
 let run_toplevel_tests ?root c ppf tests t =
   Block.pp_header ppf t;
-  List.iter (fun test ->
+  List.iter
+    (fun test ->
       let lines = lines (eval_test ?root ~block:t c test) in
       let lines = split_lines lines in
       let output =
@@ -233,13 +233,11 @@ let eval_prelude ?root top prelude prelude_str =
   let aux to_lines p =
     let env, f = Mdx.Prelude.env_and_file p in
     let eval () = eval_raw ?root top ~line:0 (to_lines f) in
-    match env with
-    | None   -> eval ()
-    | Some e -> Mdx_top.in_env e eval
+    match env with None -> eval () | Some e -> Mdx_top.in_env e eval
   in
-  match prelude, prelude_str with
+  match (prelude, prelude_str) with
   | [], [] -> ()
-  | [], fs -> List.iter (aux (fun x -> [x])) fs
+  | [], fs -> List.iter (aux (fun x -> [ x ])) fs
   | fs, [] -> List.iter (aux Mdx.Util.File.read_lines) fs
   | _ -> Fmt.failwith "only one of --prelude or --prelude-str shoud be used"
 
@@ -264,53 +262,52 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
       | Include { file_included; part_included; header } -> (
           match header with
           | Some Block.Header.OCaml ->
-            assert (syntax <> Some Cram);
-            update_file_or_block ?root ppf file file_included t part_included
+              assert (syntax <> Some Cram);
+              update_file_or_block ?root ppf file file_included t part_included
           | _ ->
-            (* By construction, there is no part for non-OCaml blocks *)
-            let new_content = (read_part file_included None) in
-            update_block_content ppf t new_content )
+              (* By construction, there is no part for non-OCaml blocks *)
+              let new_content = read_part file_included None in
+              update_block_content ppf t new_content )
       | OCaml { non_det; _ } -> (
           match non_det with
           (* the command is non-deterministic so skip everything *)
           | Some Nd_command when not non_deterministic -> print_block ()
           | _ ->
-            assert (syntax <> Some Cram);
-            eval_raw ~block:t ?root c ~line:t.line t.contents;
-            Block.pp ppf t
-        )
+              assert (syntax <> Some Cram);
+              eval_raw ~block:t ?root c ~line:t.line t.contents;
+              Block.pp ppf t )
       | Cram { tests; pad; non_det } -> (
           match non_det with
           (* the command is non-deterministic so skip everything *)
           | Some Nd_command when not non_deterministic -> print_block ()
           (* its output is non-deterministic; run it but keep the old output. *)
           | Some Nd_output when not non_deterministic ->
-            print_block ();
-            let blacklist = Block.unset_variables t in
-            List.iter
-              (fun t -> ignore (run_test ?root blacklist temp_file t))
-              tests
-          | _ -> run_cram_tests ?syntax t ?root ppf temp_file pad tests
-        )
-      | Toplevel { phrases= tests; non_det; _ } -> (
+              print_block ();
+              let blacklist = Block.unset_variables t in
+              List.iter
+                (fun t -> ignore (run_test ?root blacklist temp_file t))
+                tests
+          | _ -> run_cram_tests ?syntax t ?root ppf temp_file pad tests )
+      | Toplevel { phrases = tests; non_det; _ } -> (
           match non_det with
           (* the command is non-deterministic so skip everything *)
           | Some Nd_command when not non_deterministic -> print_block ()
           (* its output is non-deterministic; run it but keep the old output. *)
           | Some Nd_output when not non_deterministic ->
-            assert (syntax <> Some Cram);
-            print_block ();
-            List.iter (fun test ->
-                match eval_test ~block:t ?root c test with
-                | Ok _    -> ()
-                | Error e ->
-                  let output = List.map (fun l -> `Output l) e in
-                  if Output.equal test.output output then ()
-                  else err_eval ~cmd:test.command e
-              ) tests
+              assert (syntax <> Some Cram);
+              print_block ();
+              List.iter
+                (fun test ->
+                  match eval_test ~block:t ?root c test with
+                  | Ok _ -> ()
+                  | Error e ->
+                      let output = List.map (fun l -> `Output l) e in
+                      if Output.equal test.output output then ()
+                      else err_eval ~cmd:test.command e)
+                tests
           | _ ->
-            assert (syntax <> Some Cram);
-            run_toplevel_tests ?root c ppf tests t )
+              assert (syntax <> Some Cram);
+              run_toplevel_tests ?root c ppf tests t )
     else print_block ()
   in
   let gen_corrected file_contents items =
@@ -347,8 +344,8 @@ let report_error_in_block block msg =
     | Cram _ -> "cram "
     | Toplevel _ -> "toplevel "
   in
-  Fmt.epr "Error in the %scode block in %s at line %d:@]\n%s\n"
-    kind block.file block.line msg
+  Fmt.epr "Error in the %scode block in %s at line %d:@]\n%s\n" kind block.file
+    block.line msg
 
 let run setup non_deterministic silent_eval syntax silent verbose_findlib
     prelude prelude_str file section root force_output output : int =

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -89,7 +89,7 @@ let root_dir ?root ?block () =
       | Some d -> (
           match root with
           | Some r -> Some (r / d)
-          | None -> Some (Filename.dirname (Block.filename t) / d) )
+          | None -> Some (Filename.dirname t.file / d) )
       | None -> root )
   | None -> root
 
@@ -275,7 +275,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
           | Some Nd_command when not non_deterministic -> print_block ()
           | _ ->
             assert (syntax <> Some Cram);
-            eval_raw ~block:t ?root c ~line:(Block.line t) (Block.contents t);
+            eval_raw ~block:t ?root c ~line:t.line (Block.contents t);
             Block.pp ppf t
         )
       | Cram { tests; pad; non_det } -> (
@@ -340,14 +340,14 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
 
 let report_error_in_block block msg =
   let kind =
-    match Block.value block with
+    match block.Block.value with
     | Raw | Error _ | Include _ -> ""
     | OCaml _ -> "OCaml "
     | Cram _ -> "cram "
     | Toplevel _ -> "toplevel "
   in
   Fmt.epr "Error in the %scode block in %s at line %d:@]\n%s\n"
-    kind (Block.filename block) (Block.line block) msg
+    kind block.file block.line msg
 
 let run setup non_deterministic silent_eval syntax silent verbose_findlib
     prelude prelude_str file section root force_output output : int =

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -267,7 +267,8 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
             assert (syntax <> Some Cram);
             update_file_or_block ?root ppf file file_included t part_included
           | _ ->
-            let new_content = (read_part file_included part_included) in
+            (* By construction, there is no part for non-OCaml blocks *)
+            let new_content = (read_part file_included None) in
             update_block_content ppf t new_content )
       | OCaml { non_det; _ } -> (
           match non_det with

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -275,7 +275,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
           | Some Nd_command when not non_deterministic -> print_block ()
           | _ ->
             assert (syntax <> Some Cram);
-            eval_raw ~block:t ?root c ~line:t.line (Block.contents t);
+            eval_raw ~block:t ?root c ~line:t.line t.contents;
             Block.pp ppf t
         )
       | Cram { tests; pad; non_det } -> (

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -266,15 +266,12 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
       (* Print errors *)
       | Error _ -> print_block ()
       | Raw _ -> print_block ()
-      | Include { file_included; part_included; header } -> (
-          match header with
-          | Some Block.Header.OCaml ->
-              assert (syntax <> Some Cram);
-              update_file_or_block ?root ppf file file_included t part_included
-          | _ ->
-              (* By construction, there is no part for non-OCaml blocks *)
-              let new_content = read_part file_included None in
-              update_block_content ppf t new_content )
+      | Include { file_included; file_kind = Fk_ocaml { part_included } } ->
+          assert (syntax <> Some Cram);
+          update_file_or_block ?root ppf file file_included t part_included
+      | Include { file_included; file_kind = Fk_other _ } ->
+          let new_content = read_part file_included None in
+          update_block_content ppf t new_content
       | OCaml { non_det; env } ->
           let det () =
             assert (syntax <> Some Cram);

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -274,7 +274,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
         | Error _ -> print_block ()
         | Raw -> print_block ()
         | OCaml -> (
-            match Block.mode t with
+            match Block.non_det t with
             (* the command is non-deterministic so skip everything *)
             | Some Nd_command when not non_deterministic -> print_block ()
             | _ ->
@@ -284,7 +284,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
               Block.pp ppf t
           )
         | Cram  { tests; pad } -> (
-            match Block.mode t with
+            match Block.non_det t with
             (* the command is non-deterministic so skip everything *)
             | Some Nd_command when not non_deterministic -> print_block ()
             (* its output is non-deterministic; run it but keep the old output. *)
@@ -297,7 +297,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
             | _ -> run_cram_tests ?syntax t ?root ppf temp_file pad tests
           )
         | Toplevel tests ->
-          match Block.mode t with
+          match Block.non_det t with
           (* the command is non-deterministic so skip everything *)
           | Some Nd_command when not non_deterministic -> print_block ()
           (* its output is non-deterministic; run it but keep the old output. *)

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -260,9 +260,9 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
       match Block.value t with
       (* Print errors *)
       | Error _ -> print_block ()
-      | Raw -> print_block ()
-      | Include { file_included; part_included } -> (
-          match Block.header t with
+      | Raw _ -> print_block ()
+      | Include { file_included; part_included; header } -> (
+          match header with
           | Some Block.Header.OCaml ->
             assert (syntax <> Some Cram);
             update_file_or_block ?root ppf file file_included t part_included
@@ -341,7 +341,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
 let report_error_in_block block msg =
   let kind =
     match block.Block.value with
-    | Raw | Error _ | Include _ -> ""
+    | Raw _ | Error _ | Include _ -> ""
     | OCaml _ -> "OCaml "
     | Cram _ -> "cram "
     | Toplevel _ -> "toplevel "

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -263,8 +263,6 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
     let print_block () = Block.pp ?syntax ppf t in
     if Block.is_active ?section t then
       match Block.value t with
-      (* Print errors *)
-      | Error _ -> print_block ()
       | Raw _ -> print_block ()
       | Include { file_included; file_kind = Fk_ocaml { part_included } } ->
           assert (syntax <> Some Cram);
@@ -343,7 +341,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
 let report_error_in_block block msg =
   let kind =
     match block.Block.value with
-    | Raw _ | Error _ -> ""
+    | Raw _ -> ""
     | Include { file_kind = Fk_ocaml _; _ } -> "OCaml file include "
     | Include { file_kind = Fk_other _; _ } -> "file include "
     | OCaml _ -> "OCaml "

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -276,7 +276,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
         | OCaml -> (
             match Block.mode t with
             (* the command is non-deterministic so skip everything *)
-            | `Non_det Nd_command when not non_deterministic -> print_block ()
+            | Some Nd_command when not non_deterministic -> print_block ()
             | _ ->
               assert (syntax <> Some Cram);
               eval_raw
@@ -286,9 +286,9 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
         | Cram  { tests; pad } -> (
             match Block.mode t with
             (* the command is non-deterministic so skip everything *)
-            | `Non_det Nd_command when not non_deterministic -> print_block ()
+            | Some Nd_command when not non_deterministic -> print_block ()
             (* its output is non-deterministic; run it but keep the old output. *)
-            | `Non_det Nd_output when not non_deterministic ->
+            | Some Nd_output when not non_deterministic ->
               print_block ();
               let blacklist = Block.unset_variables t in
               List.iter
@@ -299,9 +299,9 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
         | Toplevel tests ->
           match Block.mode t with
           (* the command is non-deterministic so skip everything *)
-          | `Non_det Nd_command when not non_deterministic -> print_block ()
+          | Some Nd_command when not non_deterministic -> print_block ()
           (* its output is non-deterministic; run it but keep the old output. *)
-          | `Non_det Nd_output when not non_deterministic ->
+          | Some Nd_output when not non_deterministic ->
             assert (syntax <> Some Cram);
             print_block ();
             List.iter (fun test ->

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -85,7 +85,7 @@ let run_test ?root blacklist temp_file t =
 let root_dir ?root t =
   match (root, Mdx.Block.directory t) with
   | None, None -> None
-  | None, Some d -> Some (Filename.dirname t.file / d)
+  | None, Some d -> Some (Filename.dirname (Block.filename t) / d)
   | Some r, Some d -> Some (r / d)
   | Some d, None -> Some d
 
@@ -315,7 +315,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
         match kind with
         | OCaml ->
             assert (syntax <> Some Cram);
-            eval_raw t ?root c ~line:t.line t.contents;
+            eval_raw t ?root c ~line:(Block.line t) (Block.contents t);
             Block.pp ppf t
         | Cram { tests; pad } ->
             run_cram_tests ?syntax t ?root ppf temp_file pad tests
@@ -352,14 +352,14 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
 
 let report_error_in_block block msg =
   let kind =
-    match block.Block.value with
+    match Block.value block with
     | Raw | Error _ -> ""
     | OCaml -> "OCaml "
     | Cram _ -> "cram "
     | Toplevel _ -> "toplevel "
   in
-  Fmt.epr "Error in the %scode block in %s at line %d:@]\n%s\n" kind block.file
-    block.line msg
+  Fmt.epr "Error in the %scode block in %s at line %d:@]\n%s\n"
+    kind (Block.filename block) (Block.line block) msg
 
 let run setup non_deterministic silent_eval syntax silent verbose_findlib
     prelude prelude_str file section root force_output output : int =

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -261,12 +261,14 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
       (* Print errors *)
       | Error _ -> print_block ()
       | Raw _ -> print_block ()
-      | Include (Include_OCaml { file_included; part_included }) ->
-        assert (syntax <> Some Cram);
-        update_file_or_block ?root ppf file file_included t part_included
-      | Include (Include_other { file_included; _ }) ->
-        let new_content = (read_part file_included None) in
-        update_block_content ppf t new_content
+      | Include { file_included; part_included; header } -> (
+          match header with
+          | Some Block.Header.OCaml ->
+            assert (syntax <> Some Cram);
+            update_file_or_block ?root ppf file file_included t part_included
+          | _ ->
+            let new_content = (read_part file_included part_included) in
+            update_block_content ppf t new_content )
       | OCaml { non_det; _ } -> (
           match non_det with
           (* the command is non-deterministic so skip everything *)

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -281,7 +281,8 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
           in
           with_non_det non_deterministic non_det ~command:print_block
             ~output:det ~det
-      | Cram { tests; pad; non_det } ->
+      | Cram { non_det } ->
+          let pad, tests = Cram.of_lines t.contents in
           with_non_det non_deterministic non_det ~command:print_block
             ~output:(fun () ->
               print_block ();
@@ -291,7 +292,8 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
                 tests)
             ~det:(fun () ->
               run_cram_tests ?syntax t ?root ppf temp_file pad tests)
-      | Toplevel { phrases = tests; non_det; env } ->
+      | Toplevel { non_det; env } ->
+          let tests = Toplevel.of_lines ~file:t.file ~line:t.line t.contents in
           with_non_det non_deterministic non_det ~command:print_block
             ~output:(fun () ->
               assert (syntax <> Some Cram);

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -69,6 +69,7 @@ type t = {
   file : string;
   section : section option;
   dir : string option;
+  source_trees : string list;
   labels : Label.t list;
   header : Header.t option;
   contents : string list;
@@ -166,10 +167,7 @@ let file t = match value t with Include t -> Some t.file_included | _ -> None
 
 let version t = t.version
 
-let source_trees t =
-  List.filter_map
-    (function Label.Source_tree x -> Some x | _ -> None)
-    (labels t)
+let source_trees t = t.source_trees
 
 let non_det t =
   match value t with
@@ -287,6 +285,9 @@ let mk ~line ~file ~section ~labels ~header ~contents =
   let version =
     get_label (function Version (x, y) -> Some (x, y) | _ -> None) labels
   in
+  let source_trees =
+    List.filter_map (function Label.Source_tree x -> Some x | _ -> None) labels
+  in
   let open Util.Result.Infix in
   (match get_label (function File x -> Some x | _ -> None) labels with
   | Some file_included -> (
@@ -322,7 +323,8 @@ let mk ~line ~file ~section ~labels ~header ~contents =
     | _ -> Ok Raw)
   >>= fun value ->
   Ok
-    { line; file; section; dir; labels; header; contents; skip; version; value }
+    { line; file; section; dir; source_trees; labels; header; contents; skip;
+      version; value }
 
 let is_active ?section:s t =
   let active =

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -178,12 +178,6 @@ let non_det t =
 
 let skip t = t.skip
 
-let environment t =
-  match t.value with
-  | OCaml b -> b.env
-  | Toplevel b -> b.env
-  | Cram _ | Error _ | Include _ | Raw _ -> "default"
-
 let set_variables t = t.set_variables
 
 let unset_variables t = t.unset_variables
@@ -307,8 +301,9 @@ let mk ~line ~file ~section ~labels ~header ~contents =
   let unset_variables =
     List.filter_map (function Label.Unset x -> Some x | _ -> None) labels
   in
+  let file_inc = get_label (function File x -> Some x | _ -> None) labels in
   let open Util.Result.Infix in
-  ( match get_label (function File x -> Some x | _ -> None) labels with
+  ( match file_inc with
   | Some file_included -> (
       check_not_set
         "`non-deterministic` label cannot be used with a `file` label." non_det

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -274,3 +274,14 @@ let version_enabled t =
 
 let mk ~line ~file ~section ~labels ~header ~contents ~value =
   { line; file; section; labels; header; contents; value }
+
+let is_active ?section:s t =
+  let active =
+    match s with
+    | Some p -> (
+        match section t with
+        | Some s -> Re.execp (Re.Perl.compile_pat p) (snd s)
+        | None -> Re.execp (Re.Perl.compile_pat p) "" )
+    | None -> true
+  in
+  active && version_enabled t && not (skip t)

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -241,18 +241,18 @@ let line_directive = Fmt.to_to_string pp_line_directive
 
 let executable_contents b =
   let contents =
-      match value b with
-      | OCaml _ -> contents b
-      | Error _ | Raw | Cram _ | Include _ -> []
-      | Toplevel { phrases; _ } ->
-        List.flatten (
-          List.map (fun t ->
-              match Toplevel.command t with
-              | [] -> []
-              | cs ->
-                let mk s = String.make (t.hpad+2) ' ' ^ s in
-                line_directive (filename b, t.line) :: List.map mk cs
-            ) phrases )
+    match value b with
+    | OCaml _ -> contents b
+    | Error _ | Raw | Cram _ | Include _ -> []
+    | Toplevel { phrases; _ } ->
+      List.flatten (
+        List.map (fun t ->
+            match Toplevel.command t with
+            | [] -> []
+            | cs ->
+              let mk s = String.make (t.hpad+2) ' ' ^ s in
+              line_directive (filename b, t.line) :: List.map mk cs
+          ) phrases)
   in
   if contents = [] || ends_by_semi_semi contents then contents
   else contents @ [ ";;" ]

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -76,6 +76,7 @@ type t = {
   contents : string list;
   skip : bool;
   version : (Label.Relation.t * Ocaml_version.t) option;
+  set_variables : (string * string) list;
   value : value;
 }
 
@@ -185,10 +186,7 @@ let environment t =
   | Toplevel b -> b.env
   | Cram _ | Error _ | Include _ | Raw -> "default"
 
-let set_variables t =
-  List.filter_map
-    (function Label.Set (v, x) -> Some (v, x) | _ -> None)
-    (labels t)
+let set_variables t = t.set_variables
 
 let unset_variables t =
   List.filter_map (function Label.Unset x -> Some x | _ -> None) (labels t)
@@ -290,6 +288,10 @@ let mk ~line ~file ~section ~labels ~header ~contents =
     List.filter_map
       (function Label.Require_package x -> Some x | _ -> None) labels
   in
+  let set_variables =
+    List.filter_map
+      (function Label.Set (v, x) -> Some (v, x) | _ -> None) labels
+  in
   let open Util.Result.Infix in
   (match get_label (function File x -> Some x | _ -> None) labels with
   | Some file_included -> (
@@ -326,7 +328,7 @@ let mk ~line ~file ~section ~labels ~header ~contents =
   >>= fun value ->
   Ok
     { line; file; section; dir; source_trees; required_packages; labels; header;
-      contents; skip; version; value }
+      contents; skip; version; set_variables; value }
 
 let is_active ?section:s t =
   let active =

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -68,6 +68,7 @@ type t = {
   line : int;
   file : string;
   section : section option;
+  dir : string option;
   labels : Label.t list;
   header : Header.t option;
   contents : string list;
@@ -159,7 +160,7 @@ let pp ?syntax ppf b =
 
 let get_label f t = Util.List.find_map f (labels t)
 
-let directory t = get_label (function Dir x -> Some x | _ -> None) t
+let directory t = t.dir
 
 let file t = match value t with Include t -> Some t.file_included | _ -> None
 
@@ -289,6 +290,7 @@ let mk ~line ~file ~section ~labels ~header ~contents =
   let non_det = get_label (function Non_det x -> x | _ -> None) labels in
   let part = get_label (function Part x -> Some x | _ -> None) labels in
   let env = get_label (function Env x -> Some x | _ -> None) labels in
+  let dir = get_label (function Dir x -> Some x | _ -> None) labels in
   let open Util.Result.Infix in
   (match get_label (function File x -> Some x | _ -> None) labels with
   | Some file_included -> (
@@ -323,7 +325,7 @@ let mk ~line ~file ~section ~labels ~header ~contents =
           Ok (Toplevel { phrases; env; non_det }) )
     | _ -> Ok Raw)
   >>= fun value ->
-  Ok { line; file; section; labels; header; contents; value }
+  Ok { line; file; section; dir; labels; header; contents; value }
 
 let is_active ?section:s t =
   let active =

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -54,17 +54,6 @@ type t = {
   value : value;
 }
 
-let empty =
-  {
-    line = 0;
-    file = "";
-    section = None;
-    labels = [];
-    header = None;
-    contents = [];
-    value = Raw;
-  }
-
 let line t = t.line
 let filename t = t.file
 let section t = t.section

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -276,7 +276,12 @@ let check_not_set msg = function
   | None -> Ok ()
 
 let mk ~line ~file ~section ~labels ~header ~contents =
-  let non_det = get_label (function Non_det x -> x | _ -> None) labels in
+  let non_det =
+    get_label (function
+      | Non_det (Some x) -> Some x
+      | Non_det None -> Some Label.default_non_det
+      | _ -> None) labels
+  in
   let part = get_label (function Part x -> Some x | _ -> None) labels in
   let env = get_label (function Env x -> Some x | _ -> None) labels in
   let dir = get_label (function Dir x -> Some x | _ -> None) labels in

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -77,6 +77,7 @@ type t = {
   skip : bool;
   version : (Label.Relation.t * Ocaml_version.t) option;
   set_variables : (string * string) list;
+  unset_variables : string list;
   value : value;
 }
 
@@ -188,8 +189,7 @@ let environment t =
 
 let set_variables t = t.set_variables
 
-let unset_variables t =
-  List.filter_map (function Label.Unset x -> Some x | _ -> None) (labels t)
+let unset_variables t = t.unset_variables
 
 let explicit_required_packages t = t.required_packages
 
@@ -292,6 +292,9 @@ let mk ~line ~file ~section ~labels ~header ~contents =
     List.filter_map
       (function Label.Set (v, x) -> Some (v, x) | _ -> None) labels
   in
+  let unset_variables =
+    List.filter_map (function Label.Unset x -> Some x | _ -> None) labels
+  in
   let open Util.Result.Infix in
   (match get_label (function File x -> Some x | _ -> None) labels with
   | Some file_included -> (
@@ -328,7 +331,7 @@ let mk ~line ~file ~section ~labels ~header ~contents =
   >>= fun value ->
   Ok
     { line; file; section; dir; source_trees; required_packages; labels; header;
-      contents; skip; version; set_variables; value }
+      contents; skip; version; set_variables; unset_variables; value }
 
 let is_active ?section:s t =
   let active =

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -208,7 +208,7 @@ let source_trees t =
     (function Label.Source_tree x -> Some x | _ -> None)
     (labels t)
 
-let mode = function
+let non_det = function
   | OCaml b -> b.non_det
   | Shell b -> b.non_det
   | Toplevel b -> b.non_det

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -307,15 +307,13 @@ let mk ~line ~file ~section ~labels ~header ~contents =
       >>= fun () ->
       check_not_set "`env` label cannot be used with a `file` label." env
       >>= fun () ->
-      match part with
-      | Some part -> (
-          match header with
-          | Some Header.OCaml ->
-            Ok (Include { file_included; part_included= Some part; header })
-          | _ ->
-            Util.Result.errorf
-              "`part` is not supported for non-OCaml code blocks." )
-      | None -> Ok (Include { file_included; part_included= None; header }) )
+      match header with
+      | Some Header.OCaml ->
+        Ok (Include { file_included; part_included= part; header })
+      | _ ->
+        check_not_set "`part` is not supported for non-OCaml code blocks." part
+        >>= fun () ->
+        Ok (Include { file_included; part_included= None; header }) )
   | None ->
     check_not_set "`part` label requires a `file` label." part >>= fun () ->
     match header with

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -70,6 +70,7 @@ type t = {
   section : section option;
   dir : string option;
   source_trees : string list;
+  required_packages : string list;
   labels : Label.t list;
   header : Header.t option;
   contents : string list;
@@ -192,10 +193,7 @@ let set_variables t =
 let unset_variables t =
   List.filter_map (function Label.Unset x -> Some x | _ -> None) (labels t)
 
-let explicit_required_packages t =
-  List.filter_map
-    (function Label.Require_package x -> Some x | _ -> None)
-    (labels t)
+let explicit_required_packages t = t.required_packages
 
 let require_re =
   let open Re in
@@ -288,6 +286,10 @@ let mk ~line ~file ~section ~labels ~header ~contents =
   let source_trees =
     List.filter_map (function Label.Source_tree x -> Some x | _ -> None) labels
   in
+  let required_packages =
+    List.filter_map
+      (function Label.Require_package x -> Some x | _ -> None) labels
+  in
   let open Util.Result.Infix in
   (match get_label (function File x -> Some x | _ -> None) labels with
   | Some file_included -> (
@@ -323,8 +325,8 @@ let mk ~line ~file ~section ~labels ~header ~contents =
     | _ -> Ok Raw)
   >>= fun value ->
   Ok
-    { line; file; section; dir; source_trees; labels; header; contents; skip;
-      version; value }
+    { line; file; section; dir; source_trees; required_packages; labels; header;
+      contents; skip; version; value }
 
 let is_active ?section:s t =
   let active =

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -85,8 +85,6 @@ let section t = t.section
 
 let header t = t.header
 
-let contents t = t.contents
-
 let value t = t.value
 
 let dump_string ppf s = Fmt.pf ppf "%S" s

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -65,6 +65,12 @@ let empty =
     value = Raw;
   }
 
+let line t = t.line
+let filename t = t.file
+let section t = t.section
+let contents t = t.contents
+let value t = t.value
+
 let dump_string ppf s = Fmt.pf ppf "%S" s
 
 let dump_section = Fmt.(Dump.pair int string)
@@ -204,10 +210,6 @@ let required_libraries = function
   | { value = Toplevel _; contents; _ } -> require_from_lines contents
   | { value = Raw | OCaml | Error _ | Cram _; _ } -> Ok Library.Set.empty
 
-let value t = t.value
-
-let section t = t.section
-
 let cram lines =
   let pad, tests = Cram.of_lines lines in
   Cram { pad; tests }
@@ -281,3 +283,6 @@ let version_enabled t =
           Label.Relation.compare op (Ocaml_version.compare curr_version v) 0
       | None -> true )
   | Error (`Msg e) -> Fmt.failwith "invalid OCaml version: %s" e
+
+let mk ~line ~file ~section ~labels ~header ~contents ~value =
+  { line; file; section; labels; header; contents; value }

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -14,9 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Astring
 open Result
-module List = Compat.List
+open Compat
 
 module Header = struct
   type t = Shell | OCaml | Other of string
@@ -186,7 +185,7 @@ let require_from_line line =
   | None -> Ok Library.Set.empty
   | Some group ->
       let matched = Re.Group.get group 1 in
-      let libs_str = String.cuts ~sep:"," matched in
+      let libs_str = String.split_on_char ',' matched in
       Util.Result.List.map ~f:Library.from_string libs_str >>| fun libs ->
       Library.Set.of_list libs
 
@@ -257,9 +256,9 @@ let executable_contents b =
               match Toplevel.command t with
               | [] -> []
               | cs ->
-                let mk s = String.v ~len:(t.hpad+2) (fun _ -> ' ') ^ s in
-                line_directive (b.file, t.line) :: List.map mk cs)
-              tests)
+                let mk s = String.make (t.hpad+2) ' ' ^ s in
+                line_directive (b.file, t.line) :: List.map mk cs
+            ) tests )
   in
   if contents = [] || ends_by_semi_semi contents then contents
   else contents @ [ ";;" ]

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -72,6 +72,7 @@ type t = {
   labels : Label.t list;
   header : Header.t option;
   contents : string list;
+  skip : bool;
   value : value;
 }
 
@@ -178,7 +179,7 @@ let non_det t =
   | Toplevel b -> b.non_det
   | Error _ | Include _ | Raw -> None
 
-let skip t = List.exists (function Label.Skip -> true | _ -> false) (labels t)
+let skip t = t.skip
 
 let environment t =
   match value t with
@@ -291,6 +292,7 @@ let mk ~line ~file ~section ~labels ~header ~contents =
   let part = get_label (function Part x -> Some x | _ -> None) labels in
   let env = get_label (function Env x -> Some x | _ -> None) labels in
   let dir = get_label (function Dir x -> Some x | _ -> None) labels in
+  let skip = List.exists (function Label.Skip -> true | _ -> false) labels in
   let open Util.Result.Infix in
   (match get_label (function File x -> Some x | _ -> None) labels with
   | Some file_included -> (
@@ -325,7 +327,7 @@ let mk ~line ~file ~section ~labels ~header ~contents =
           Ok (Toplevel { phrases; env; non_det }) )
     | _ -> Ok Raw)
   >>= fun value ->
-  Ok { line; file; section; dir; labels; header; contents; value }
+  Ok { line; file; section; dir; labels; header; contents; skip; value }
 
 let is_active ?section:s t =
   let active =

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -51,15 +51,11 @@ type toplevel_value = {
   non_det : Label.non_det option;
 }
 
-type include_value =
-  | Include_OCaml of {
-      file_included : string;
-      part_included : string option;
-    }
-  | Include_other of {
-      header : Header.t option;
-      file_included : string;
-    }
+type include_value = {
+  header : Header.t option;
+  file_included : string;
+  part_included : string option;
+}
 
 type raw_value = {
   header : Header.t option;
@@ -105,8 +101,7 @@ let header t =
   | Error b -> b.header
   | Cram _ -> Some Header.Shell
   | Toplevel _ -> Some Header.OCaml
-  | Include (Include_OCaml _) -> Some Header.OCaml
-  | Include (Include_other b) -> b.header
+  | Include b -> b.header
 
 let dump_value ppf = function
   | Raw _ -> Fmt.string ppf "Raw"
@@ -175,11 +170,7 @@ let pp ?syntax ppf b =
 
 let directory t = t.dir
 
-let file t =
-  match t.value with
-  | Include (Include_OCaml t) -> Some t.file_included
-  | Include (Include_other t) -> Some t.file_included
-  | _ -> None
+let file t = match t.value with Include t -> Some t.file_included | _ -> None
 
 let source_trees t = t.source_trees
 
@@ -318,11 +309,11 @@ let mk ~line ~file ~section ~labels ~header ~contents =
       >>= fun () ->
       match header with
       | Some Header.OCaml ->
-        Ok (Include (Include_OCaml { file_included; part_included= part }))
+        Ok (Include { file_included; part_included= part; header })
       | _ ->
         check_not_set "`part` is not supported for non-OCaml code blocks." part
         >>= fun () ->
-        Ok (Include (Include_other { file_included; header })) )
+        Ok (Include { file_included; part_included= None; header }) )
   | None ->
     check_not_set "`part` label requires a `file` label." part >>= fun () ->
     match header with

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -81,12 +81,6 @@ type t = {
   value : value;
 }
 
-let section t = t.section
-
-let header t = t.header
-
-let value t = t.value
-
 let dump_string ppf s = Fmt.pf ppf "%S" s
 
 let dump_section = Fmt.(Dump.pair int string)
@@ -159,8 +153,6 @@ let directory t = t.dir
 
 let file t = match t.value with Include t -> Some t.file_included | _ -> None
 
-let version t = t.version
-
 let source_trees t = t.source_trees
 
 let non_det t =
@@ -208,6 +200,10 @@ let required_libraries = function
   | { value = Toplevel _; contents; _} -> require_from_lines contents
   | _ -> Ok Library.Set.empty
 
+let value t = t.value
+let section t = t.section
+let header t = t.header
+
 let guess_ocaml_kind contents =
   let rec aux = function
     | [] -> `Code
@@ -250,7 +246,7 @@ let executable_contents b =
 let version_enabled t =
   match Ocaml_version.of_string Sys.ocaml_version with
   | Ok curr_version -> (
-      match version t with
+      match t.version with
       | Some (op, v) ->
           Label.Relation.compare op (Ocaml_version.compare curr_version v) 0
       | None -> true )

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -87,6 +87,7 @@ type t = {
   contents : string list;
   skip : bool;
   version_enabled: bool;
+  (** Whether the current OCaml version complies with the block's version. *)
   set_variables : (string * string) list;
   unset_variables : string list;
   value : value;

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -26,52 +26,26 @@ end
 
 (** Code blocks. *)
 
-type cram_value = { pad : int; tests : Cram.t list }
-
-(** The type for block values. *)
-type value =
-  | Raw
-  | OCaml
-  | Error of string list
-  | Cram of cram_value
-  | Toplevel of Toplevel.t list
-
-type section = int * string
-(** The type for sections. *)
-
-(** The type for supported code blocks. *)
-type ocaml_block = {
-  line    : int;
-  file    : string;
-  section : section option;
-  labels  : Label.t list;
-  header  : Header.t option;
-  contents: string list;
-  value   : value;
+type cram_value = {
+  pad : int;
+  tests : Cram.t list;
   non_det : Label.non_det option;
-  env     : string;
+}
+
+type ocaml_value = {
+  env : string;
   (** [env] is the name given to the environment where tests are run. *)
-}
-
-type shell_block = {
-  line    : int;
-  file    : string;
-  section : section option;
-  labels  : Label.t list;
-  header  : Header.t option;
-  contents: string list;
-  value   : value;
   non_det : Label.non_det option;
 }
 
-type include_block = {
-  line : int;
-  file : string;
-  section : section option;
-  labels : Label.t list;
-  header : Header.t option;
-  contents : string list;
-  value : value;
+type toplevel_value = {
+  phrases : Toplevel.t list;
+  env : string;
+  (** [env] is the name given to the environment where tests are run. *)
+  non_det : Label.non_det option;
+}
+
+type include_value = {
   file_included : string;
   (** [file_included] is the name of the file to synchronize with. *)
   part_included : string option;
@@ -79,11 +53,28 @@ type include_block = {
       If lines is not specified synchronize the whole file. *)
 }
 
-type t =
-  | Toplevel of ocaml_block
-  | Shell of shell_block
-  | Include of include_block
-  | OCaml of ocaml_block
+(** The type for block values. *)
+type value =
+  | Raw
+  | OCaml of ocaml_value
+  | Error of string list
+  | Cram of cram_value
+  | Toplevel of toplevel_value
+  | Include of include_value
+
+type section = int * string
+(** The type for sections. *)
+
+(** The type for supported code blocks. *)
+type t = {
+  line : int;
+  file : string;
+  section : section option;
+  labels : Label.t list;
+  header : Header.t option;
+  contents : string list;
+  value : value;
+}
 
 val mk:
   line:int
@@ -163,6 +154,9 @@ val required_libraries : t -> (Library.Set.t, string) Result.result
 
 val skip : t -> bool
 (** [skip t] is true iff [skip] is in the labels of [t]. *)
+
+val header : t -> Header.t option
+(** [header t] is [t]'s header. *)
 
 val executable_contents : t -> string list
 (** [executable_contents t] is either [t]'s contents if [t] is a raw

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -130,8 +130,8 @@ val contents : t -> string list
 val value : t -> value
 (** [value t] is [t]'s value. *)
 
-val mode : t -> Label.non_det option
-(** [mode t] is [t]'s mode. *)
+val non_det : t -> Label.non_det option
+(** Whether a block's command or output is non-deterministic. *)
 
 val directory : t -> string option
 (** [directory t] is the directory where [t] tests should be run. *)

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -115,14 +115,6 @@ val pp_line_directive : (string * int) Fmt.t
 
 (** {2 Accessors} *)
 
-val section : t -> section option
-(** [section t] is [t]'s section. *)
-
-val contents : t -> string list
-
-val value : t -> value
-(** [value t] is [t]'s value. *)
-
 val non_det : t -> Label.non_det option
 (** Whether a block's command or output is non-deterministic. *)
 
@@ -157,6 +149,12 @@ val required_libraries : t -> (Library.Set.t, string) Result.result
 
 val skip : t -> bool
 (** [skip t] is true iff [skip] is in the labels of [t]. *)
+
+val value : t -> value
+(** [value t] is [t]'s value. *)
+
+val section : t -> section option
+(** [section t] is [t]'s section. *)
 
 val header : t -> Header.t option
 (** [header t] is [t]'s header. *)

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -78,6 +78,7 @@ type t = {
   contents : string list;
   skip : bool;
   version : (Label.Relation.t * Ocaml_version.t) option;
+  set_variables : (string * string) list;
   value : value;
 }
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -39,16 +39,18 @@ type value =
 type section = int * string
 (** The type for sections. *)
 
-type t = {
-  line : int;
-  file : string;
-  section : section option;
-  labels : Label.t list;
-  header : Header.t option;
-  contents : string list;
-  value : value;
-}
+type t
 (** The type for supported code blocks. *)
+
+val mk:
+  line:int
+  -> file:string
+  -> section:section option
+  -> labels:Label.t list
+  -> header:Header.t option
+  -> contents:string list
+  -> value:value
+  -> t
 
 val empty : t
 (** [empty] is the empty block. *)
@@ -75,6 +77,18 @@ val pp_line_directive : (string * int) Fmt.t
    filename and line number. *)
 
 (** {2 Accessors} *)
+
+val line: t -> int
+
+val filename : t -> string
+
+val section : t -> section option
+(** [section t] is [t]'s section. *)
+
+val contents : t -> string list
+
+val value : t -> value
+(** [value t] is [t]'s value. *)
 
 val mode : t -> [ `Non_det of Label.non_det | `Normal ]
 (** [mode t] is [t]'s mode. *)
@@ -114,12 +128,6 @@ val required_libraries : t -> (Library.Set.t, string) Result.result
 
 val skip : t -> bool
 (** [skip t] is true iff [skip] is in the labels of [t]. *)
-
-val value : t -> value
-(** [value t] is [t]'s value. *)
-
-val section : t -> section option
-(** [section t] is [t]'s section. *)
 
 val executable_contents : t -> string list
 (** [executable_contents t] is either [t]'s contents if [t] is a raw

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -46,6 +46,7 @@ type toplevel_value = {
 }
 
 type include_value = {
+  header : Header.t option;
   file_included : string;
   (** [file_included] is the name of the file to synchronize with. *)
   part_included : string option;
@@ -53,11 +54,20 @@ type include_value = {
       If lines is not specified synchronize the whole file. *)
 }
 
+type raw_value = {
+  header : Header.t option;
+}
+
+type error_value = {
+  header : Header.t option;
+  errors : string list;
+}
+
 (** The type for block values. *)
 type value =
-  | Raw
+  | Raw of raw_value
   | OCaml of ocaml_value
-  | Error of string list
+  | Error of error_value
   | Cram of cram_value
   | Toplevel of toplevel_value
   | Include of include_value
@@ -74,7 +84,6 @@ type t = {
   source_trees : string list;
   required_packages : string list;
   labels : Label.t list;
-  header : Header.t option;
   contents : string list;
   skip : bool;
   version : (Label.Relation.t * Ocaml_version.t) option;

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -48,7 +48,7 @@ type ocaml_block = {
   header  : Header.t option;
   contents: string list;
   value   : value;
-  non_det : [`Output | `Command] option;
+  non_det : Label.non_det option;
   env     : string;
   (** [env] is the name given to the environment where tests are run. *)
 }

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -79,6 +79,7 @@ type t = {
   skip : bool;
   version : (Label.Relation.t * Ocaml_version.t) option;
   set_variables : (string * string) list;
+  unset_variables : string list;
   value : value;
 }
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -34,34 +34,29 @@ type cram_value = {
 
 type ocaml_value = {
   env : string;
-  (** [env] is the name given to the environment where tests are run. *)
+      (** [env] is the name given to the environment where tests are run. *)
   non_det : Label.non_det option;
 }
 
 type toplevel_value = {
   phrases : Toplevel.t list;
   env : string;
-  (** [env] is the name given to the environment where tests are run. *)
+      (** [env] is the name given to the environment where tests are run. *)
   non_det : Label.non_det option;
 }
 
 type include_value = {
   header : Header.t option;
   file_included : string;
-  (** [file_included] is the name of the file to synchronize with. *)
+      (** [file_included] is the name of the file to synchronize with. *)
   part_included : string option;
-  (** [part_included] is the part of the file to synchronize with.
+      (** [part_included] is the part of the file to synchronize with.
       If lines is not specified synchronize the whole file. *)
 }
 
-type raw_value = {
-  header : Header.t option;
-}
+type raw_value = { header : Header.t option }
 
-type error_value = {
-  header : Header.t option;
-  errors : string list;
-}
+type error_value = { header : Header.t option; errors : string list }
 
 (** The type for block values. *)
 type value =
@@ -75,7 +70,6 @@ type value =
 type section = int * string
 (** The type for sections. *)
 
-(** The type for supported code blocks. *)
 type t = {
   line : int;
   file : string;
@@ -86,21 +80,22 @@ type t = {
   labels : Label.t list;
   contents : string list;
   skip : bool;
-  version_enabled: bool;
-  (** Whether the current OCaml version complies with the block's version. *)
+  version_enabled : bool;
+      (** Whether the current OCaml version complies with the block's version. *)
   set_variables : (string * string) list;
   unset_variables : string list;
   value : value;
 }
+(** The type for supported code blocks. *)
 
-val mk:
-  line:int
-  -> file:string
-  -> section:section option
-  -> labels:Label.t list
-  -> header:Header.t option
-  -> contents:string list
-  -> (t, [`Msg of string]) Result.result
+val mk :
+  line:int ->
+  file:string ->
+  section:section option ->
+  labels:Label.t list ->
+  header:Header.t option ->
+  contents:string list ->
+  (t, [ `Msg of string ]) Result.result
 
 (** {2 Printers} *)
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -157,9 +157,6 @@ val value : t -> value
 val section : t -> section option
 (** [section t] is [t]'s section. *)
 
-val header : t -> Header.t option
-(** [header t] is [t]'s header. *)
-
 val executable_contents : t -> string list
 (** [executable_contents t] is either [t]'s contents if [t] is a raw
    or a cram block, or [t]'s commands if [t] is a toplevel fragments

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -45,20 +45,14 @@ type toplevel_value = {
   non_det : Label.non_det option;
 }
 
-type include_value =
-  | Include_OCaml of {
-      file_included : string;
-      (** [file_included] is the name of the file to synchronize with. *)
-      part_included : string option;
-      (** [part_included] is the part of the file to synchronize with.
-          If lines is not specified synchronize the whole file. *)
-    }
-  | Include_other of {
-      header : Header.t option;
-      (** [header] cannot be equal to [OCaml] here. *)
-      file_included : string;
-      (** [file_included] is the name of the file to synchronize with. *)
-    }
+type include_value = {
+  header : Header.t option;
+  file_included : string;
+  (** [file_included] is the name of the file to synchronize with. *)
+  part_included : string option;
+  (** [part_included] is the part of the file to synchronize with.
+      If lines is not specified synchronize the whole file. *)
+}
 
 type raw_value = {
   header : Header.t option;

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -26,11 +26,7 @@ end
 
 (** Code blocks. *)
 
-type cram_value = {
-  pad : int;
-  tests : Cram.t list;
-  non_det : Label.non_det option;
-}
+type cram_value = { non_det : Label.non_det option }
 
 type ocaml_value = {
   env : string;
@@ -39,7 +35,6 @@ type ocaml_value = {
 }
 
 type toplevel_value = {
-  phrases : Toplevel.t list;
   env : string;
       (** [env] is the name given to the environment where tests are run. *)
   non_det : Label.non_det option;

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -45,14 +45,20 @@ type toplevel_value = {
   non_det : Label.non_det option;
 }
 
-type include_value = {
-  header : Header.t option;
-  file_included : string;
-  (** [file_included] is the name of the file to synchronize with. *)
-  part_included : string option;
-  (** [part_included] is the part of the file to synchronize with.
-      If lines is not specified synchronize the whole file. *)
-}
+type include_value =
+  | Include_OCaml of {
+      file_included : string;
+      (** [file_included] is the name of the file to synchronize with. *)
+      part_included : string option;
+      (** [part_included] is the part of the file to synchronize with.
+          If lines is not specified synchronize the whole file. *)
+    }
+  | Include_other of {
+      header : Header.t option;
+      (** [header] cannot be equal to [OCaml] here. *)
+      file_included : string;
+      (** [file_included] is the name of the file to synchronize with. *)
+    }
 
 type raw_value = {
   header : Header.t option;

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -86,7 +86,7 @@ type t = {
   labels : Label.t list;
   contents : string list;
   skip : bool;
-  version : (Label.Relation.t * Ocaml_version.t) option;
+  version_enabled: bool;
   set_variables : (string * string) list;
   unset_variables : string list;
   value : value;

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -131,9 +131,7 @@ val executable_contents : t -> string list
    or a cram block, or [t]'s commands if [t] is a toplevel fragments
    (e.g. the phrase result is discarded). *)
 
-val version_enabled : t -> bool
-(** [version_supported t] if the current OCaml version complies with [t]'s
-    version. *)
+val is_active : ?section:string -> t -> bool
 
 (** {2 Evaluation} *)
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -133,10 +133,6 @@ val source_trees : t -> string list
 val file : t -> string option
 (** [file t] is the name of the file to synchronize [t] with. *)
 
-val environment : t -> string
-(** [environment t] is the name given to the environment where [t] tests
-    are run. *)
-
 val set_variables : t -> (string * string) list
 (** [set_variable t] is the list of environment variable to set and their values *)
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -60,13 +60,10 @@ type include_value = {
 
 type raw_value = { header : Header.t option }
 
-type error_value = { header : Header.t option; errors : string list }
-
 (** The type for block values. *)
 type value =
   | Raw of raw_value
   | OCaml of ocaml_value
-  | Error of error_value
   | Cram of cram_value
   | Toplevel of toplevel_value
   | Include of include_value

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -74,6 +74,7 @@ type t = {
   labels : Label.t list;
   header : Header.t option;
   contents : string list;
+  skip : bool;
   value : value;
 }
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -70,6 +70,7 @@ type t = {
   line : int;
   file : string;
   section : section option;
+  dir : string option;
   labels : Label.t list;
   header : Header.t option;
   contents : string list;

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -115,10 +115,6 @@ val pp_line_directive : (string * int) Fmt.t
 
 (** {2 Accessors} *)
 
-val line: t -> int
-
-val filename : t -> string
-
 val section : t -> section option
 (** [section t] is [t]'s section. *)
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -45,13 +45,22 @@ type toplevel_value = {
   non_det : Label.non_det option;
 }
 
-type include_value = {
-  header : Header.t option;
-  file_included : string;
-      (** [file_included] is the name of the file to synchronize with. *)
+type include_ocaml_file = {
   part_included : string option;
       (** [part_included] is the part of the file to synchronize with.
-      If lines is not specified synchronize the whole file. *)
+          If lines is not specified synchronize the whole file. *)
+}
+
+type include_other_file = { header : Header.t option }
+
+type include_file_kind =
+  | Fk_ocaml of include_ocaml_file
+  | Fk_other of include_other_file
+
+type include_value = {
+  file_included : string;
+      (** [file_included] is the name of the file to synchronize with. *)
+  file_kind : include_file_kind;
 }
 
 type raw_value = { header : Header.t option }

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -40,7 +40,20 @@ type section = int * string
 (** The type for sections. *)
 
 (** The type for supported code blocks. *)
-type raw = {
+type ocaml_block = {
+  line    : int;
+  file    : string;
+  section : section option;
+  labels  : Label.t list;
+  header  : Header.t option;
+  contents: string list;
+  value   : value;
+  non_det : [`Output | `Command] option;
+  env     : string;
+  (** [env] is the name given to the environment where tests are run. *)
+}
+
+type shell_block = {
   line    : int;
   file    : string;
   section : section option;
@@ -67,10 +80,10 @@ type include_block = {
 }
 
 type t =
-  | Toplevel of raw
-  | Shell of raw
+  | Toplevel of ocaml_block
+  | Shell of shell_block
   | Include of include_block
-  | OCaml of raw
+  | OCaml of ocaml_block
 
 val mk:
   line:int

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -52,9 +52,6 @@ val mk:
   -> value:value
   -> t
 
-val empty : t
-(** [empty] is the empty block. *)
-
 (** {2 Printers} *)
 
 val dump : t Fmt.t

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -71,6 +71,7 @@ type t = {
   file : string;
   section : section option;
   dir : string option;
+  source_trees : string list;
   labels : Label.t list;
   header : Header.t option;
   contents : string list;

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -14,6 +14,16 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+(** Code blocks headers. *)
+
+module Header : sig
+  type t = Shell | OCaml | Other of string
+
+  val pp : Format.formatter -> t -> unit
+
+  val of_string : string -> t option
+end
+
 (** Code blocks. *)
 
 type cram_value = { pad : int; tests : Cram.t list }
@@ -34,7 +44,7 @@ type t = {
   file : string;
   section : section option;
   labels : Label.t list;
-  header : string option;
+  header : Header.t option;
   contents : string list;
   value : value;
 }
@@ -49,7 +59,7 @@ val dump : t Fmt.t
 (** [dump] is the printer for dumping code blocks. Useful for debugging. *)
 
 val pp_header : ?syntax:Syntax.t -> t Fmt.t
-(** [pp_header] pretty-prints block headers. *)
+(** [pp_header] pretty-prints full block headers with the labels. *)
 
 val pp_contents : ?syntax:Syntax.t -> t Fmt.t
 (** [pp_contents] pretty-prints block contents. *)
@@ -110,9 +120,6 @@ val value : t -> value
 
 val section : t -> section option
 (** [section t] is [t]'s section. *)
-
-val header : t -> string option
-(** [header t] is [t]'s header. *)
 
 val executable_contents : t -> string list
 (** [executable_contents t] is either [t]'s contents if [t] is a raw

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -39,8 +39,37 @@ type value =
 type section = int * string
 (** The type for sections. *)
 
-type t
 (** The type for supported code blocks. *)
+type raw = {
+  line    : int;
+  file    : string;
+  section : section option;
+  labels  : Label.t list;
+  header  : Header.t option;
+  contents: string list;
+  value   : value;
+}
+
+type include_block = {
+  line : int;
+  file : string;
+  section : section option;
+  labels : Label.t list;
+  header : Header.t option;
+  contents : string list;
+  value : value;
+  file_included : string;
+  (** [file_included] is the name of the file to synchronize with. *)
+  part_included : string option;
+  (** [part_included] is the part of the file to synchronize with.
+      If lines is not specified synchronize the whole file. *)
+}
+
+type t =
+  | Toplevel of raw
+  | Shell of raw
+  | Include of include_block
+  | OCaml of raw
 
 val mk:
   line:int
@@ -99,10 +128,6 @@ val source_trees : t -> string list
 
 val file : t -> string option
 (** [file t] is the name of the file to synchronize [t] with. *)
-
-val part : t -> string option
-(** [part t] is the part of the file to synchronize [t] with.
-    If lines is not specified synchronize the whole file. *)
 
 val environment : t -> string
 (** [environment t] is the name given to the environment where [t] tests

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -72,6 +72,7 @@ type t = {
   section : section option;
   dir : string option;
   source_trees : string list;
+  required_packages : string list;
   labels : Label.t list;
   header : Header.t option;
   contents : string list;

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -92,7 +92,6 @@ val mk:
   -> labels:Label.t list
   -> header:Header.t option
   -> contents:string list
-  -> value:value
   -> (t, [`Msg of string]) Result.result
 
 (** {2 Printers} *)
@@ -171,12 +170,6 @@ val executable_contents : t -> string list
    (e.g. the phrase result is discarded). *)
 
 val is_active : ?section:string -> t -> bool
-
-(** {2 Evaluation} *)
-
-val eval : t -> t
-(** [eval t] is the same as [t] but with it's value replaced by either
-   [Cram] or [Toplevel] blocks, depending on [t]'s header. *)
 
 (** {2 Parsers} *)
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -48,6 +48,7 @@ type raw = {
   header  : Header.t option;
   contents: string list;
   value   : value;
+  non_det : Label.non_det option;
 }
 
 type include_block = {
@@ -79,7 +80,7 @@ val mk:
   -> header:Header.t option
   -> contents:string list
   -> value:value
-  -> t
+  -> (t, [`Msg of string]) Result.result
 
 (** {2 Printers} *)
 
@@ -116,7 +117,7 @@ val contents : t -> string list
 val value : t -> value
 (** [value t] is [t]'s value. *)
 
-val mode : t -> [ `Non_det of Label.non_det | `Normal ]
+val mode : t -> Label.non_det option
 (** [mode t] is [t]'s mode. *)
 
 val directory : t -> string option

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -75,6 +75,7 @@ type t = {
   header : Header.t option;
   contents : string list;
   skip : bool;
+  version : (Label.Relation.t * Ocaml_version.t) option;
   value : value;
 }
 

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -34,8 +34,14 @@ rule text section = parse
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         newline lexbuf;
-        `Block (Block.mk ~file ~line ~section ~header ~contents ~labels ~value)
-        :: text section lexbuf }
+        let block =
+          match
+            Block.mk ~file ~line ~section ~header ~contents ~labels ~value
+          with
+          | Ok block -> block
+          | Error (`Msg msg) -> failwith msg
+        in
+        `Block block :: text section lexbuf }
   | ([^'\n']* as str) eol
       { newline lexbuf;
         `Text str :: text section lexbuf }
@@ -61,7 +67,14 @@ and cram_text section = parse
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
-        `Block (Block.mk ~file ~line ~section ~header ~contents ~labels ~value)
+        let block =
+          match
+            Block.mk ~file ~line ~section ~header ~contents ~labels ~value
+          with
+          | Ok block -> block
+          | Error (`Msg msg) -> failwith msg
+        in
+        `Block block
         :: (if requires_empty_line then `Text "" :: rest else rest) }
   | "<-- non-deterministic" ws* ([^'\n']* as choice) eol
       { let header = Some Block.Header.Shell in
@@ -77,7 +90,14 @@ and cram_text section = parse
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
-        `Block (Block.mk ~file ~line ~section ~header ~contents ~labels ~value)
+        let block =
+          match
+            Block.mk ~file ~line ~section ~header ~contents ~labels ~value
+          with
+          | Ok block -> block
+          | Error (`Msg msg) -> failwith msg
+        in
+        `Block block
         :: (if requires_empty_line then `Text "" :: rest else rest) }
   | ([^'\n']* as str) eol
       { newline lexbuf;

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -34,7 +34,7 @@ rule text section = parse
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         newline lexbuf;
-        `Block { Block.file; line; section; header; contents; labels; value }
+        `Block (Block.mk ~file ~line ~section ~header ~contents ~labels ~value)
         :: text section lexbuf }
   | ([^'\n']* as str) eol
       { newline lexbuf;
@@ -61,7 +61,7 @@ and cram_text section = parse
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
-        `Block { Block.file; line; section; header; contents; labels; value }
+        `Block (Block.mk ~file ~line ~section ~header ~contents ~labels ~value)
         :: (if requires_empty_line then `Text "" :: rest else rest) }
   | "<-- non-deterministic" ws* ([^'\n']* as choice) eol
       { let header = Some Block.Header.Shell in
@@ -77,7 +77,7 @@ and cram_text section = parse
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
-        `Block { Block.file; line; section; header; contents; labels; value }
+        `Block (Block.mk ~file ~line ~section ~header ~contents ~labels ~value)
         :: (if requires_empty_line then `Text "" :: rest else rest) }
   | ([^'\n']* as str) eol
       { newline lexbuf;

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -28,16 +28,13 @@ rule text section = parse
             let msg = String.concat ~sep:" " msgs in
             failwith msg
         in
-        let value = Block.Raw in
         let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
         newline lexbuf;
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         newline lexbuf;
         let block =
-          match
-            Block.mk ~file ~line ~section ~header ~contents ~labels ~value
-          with
+          match Block.mk ~file ~line ~section ~header ~contents ~labels with
           | Ok block -> block
           | Error (`Msg msg) -> failwith msg
         in
@@ -62,15 +59,12 @@ and cram_text section = parse
         let requires_empty_line, contents = cram_block lexbuf in
         let contents = first_line :: contents in
         let labels = [] in
-        let value = Block.Raw in
         let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
         let block =
-          match
-            Block.mk ~file ~line ~section ~header ~contents ~labels ~value
-          with
+          match Block.mk ~file ~line ~section ~header ~contents ~labels with
           | Ok block -> block
           | Error (`Msg msg) -> failwith msg
         in
@@ -84,16 +78,13 @@ and cram_text section = parse
           | Ok label -> [label]
           | Error (`Msg msg) -> failwith msg
         in
-        let value = Block.Raw in
         let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
         newline lexbuf;
         let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
         let block =
-          match
-            Block.mk ~file ~line ~section ~header ~contents ~labels ~value
-          with
+          match Block.mk ~file ~line ~section ~header ~contents ~labels with
           | Ok block -> block
           | Error (`Msg msg) -> failwith msg
         in

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -19,7 +19,7 @@ rule text section = parse
         newline lexbuf;
         `Section section :: text (Some section) lexbuf }
   | "```" ([^' ' '\n']* as h) ws* ([^'\n']* as l) eol
-      { let header = if h = "" then None else Some h in
+      { let header = Block.Header.of_string h in
         let contents = block lexbuf in
         let labels = match Label.of_string l with
           | Ok labels -> labels
@@ -52,7 +52,7 @@ and cram_text section = parse
         newline lexbuf;
         `Section section :: cram_text (Some section) lexbuf }
   | "  " ([^'\n']* as first_line) eol
-      { let header = Syntax.cram_default_header in
+      { let header = Some Block.Header.Shell in
         let requires_empty_line, contents = cram_block lexbuf in
         let contents = first_line :: contents in
         let labels = [] in
@@ -64,7 +64,7 @@ and cram_text section = parse
         `Block { Block.file; line; section; header; contents; labels; value }
         :: (if requires_empty_line then `Text "" :: rest else rest) }
   | "<-- non-deterministic" ws* ([^'\n']* as choice) eol
-      { let header = Syntax.cram_default_header in
+      { let header = Some Block.Header.Shell in
         let requires_empty_line, contents = cram_block lexbuf in
         let labels =
           match Label.interpret "non-deterministic" (Some (Eq, choice)) with

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -70,18 +70,11 @@ let dump_line ppf (l : line) =
 
 let dump = Fmt.Dump.list dump_line
 
-let eval = function
-  | (Section _ | Text _) as x -> x
-  | Block t as x ->
-      let t' = Block.eval t in
-      if t == t' then x else Block t'
-
 type expect_result = Identical | Differs
 
 let run_str ~syntax ~f file =
   let file_contents, lexbuf = Misc.init file in
   let items = parse_lexbuf syntax lexbuf in
-  let items = List.map eval items in
   Log.debug (fun l -> l "run @[%a@]" dump items);
   let corrected = f file_contents items in
   let result = if corrected <> file_contents then Differs else Identical in

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -36,7 +36,7 @@ include Document
 let section_of_line = function
   | Section s -> Some s
   | Text _ -> None
-  | Block b -> Block.section b
+  | Block b -> b.section
 
 let filter_section re (t : t) =
   match

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -36,7 +36,7 @@ include Document
 let section_of_line = function
   | Section s -> Some s
   | Text _ -> None
-  | Block b -> b.section
+  | Block b -> Block.section b
 
 let filter_section re (t : t) =
   match

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -2,8 +2,6 @@ open Compat
 
 type t = Normal | Cram
 
-let cram_default_header = Some "sh" (* FIXME: bash? *)
-
 let pp fs = function
   | Normal -> Fmt.string fs "normal"
   | Cram -> Fmt.string fs "cram"

--- a/lib/top/mdx_top.mli
+++ b/lib/top/mdx_top.mli
@@ -29,4 +29,4 @@ val eval : t -> string list -> (string list, string list) result
 (** [eval t p] evaluates the toplevel phrase [p] (possibly spawning on
     mulitple lines) with the configuration value [t]. *)
 
-val in_env : string -> (unit -> unit) -> unit
+val in_env : string -> (unit -> 'a) -> 'a

--- a/test/bin/mdx-test/failure/in-toplevel/test-case.md.expected
+++ b/test/bin/mdx-test/failure/in-toplevel/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the code block in test-case.md at line 4:
+Error in the OCaml file include code block in test-case.md at line 4:
 ./not_found.ml: No such file or directory

--- a/test/bin/mdx-test/failure/in-toplevel/test-case.md.expected
+++ b/test/bin/mdx-test/failure/in-toplevel/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the toplevel code block in test-case.md at line 4:
+Error in the code block in test-case.md at line 4:
 ./not_found.ml: No such file or directory

--- a/test/bin/mdx-test/failure/ml-file-not-found/test-case.md.expected
+++ b/test/bin/mdx-test/failure/ml-file-not-found/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the OCaml code block in test-case.md at line 4:
+Error in the code block in test-case.md at line 4:
 ./not_found.ml: No such file or directory

--- a/test/bin/mdx-test/failure/ml-file-not-found/test-case.md.expected
+++ b/test/bin/mdx-test/failure/ml-file-not-found/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the code block in test-case.md at line 4:
+Error in the OCaml file include code block in test-case.md at line 4:
 ./not_found.ml: No such file or directory

--- a/test/bin/mdx-test/failure/part-not-ended/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-not-ended/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the OCaml code block in test-case.md at line 3:
+Error in the code block in test-case.md at line 3:
 In file ./parts-begin-end.ml, line 18: Part toto has no end.

--- a/test/bin/mdx-test/failure/part-not-ended/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-not-ended/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the code block in test-case.md at line 3:
+Error in the OCaml file include code block in test-case.md at line 3:
 In file ./parts-begin-end.ml, line 18: Part toto has no end.

--- a/test/bin/mdx-test/failure/part-not-found/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-not-found/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the OCaml code block in test-case.md at line 4:
+Error in the code block in test-case.md at line 4:
 Cannot find part "part1" in ./part_not_found.ml

--- a/test/bin/mdx-test/failure/part-not-found/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-not-found/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the code block in test-case.md at line 4:
+Error in the OCaml file include code block in test-case.md at line 4:
 Cannot find part "part1" in ./part_not_found.ml

--- a/test/bin/mdx-test/failure/part-not-opened/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-not-opened/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the code block in test-case.md at line 3:
+Error in the OCaml file include code block in test-case.md at line 3:
 In file ./parts-begin-end.ml, line 6: There is no part to end.

--- a/test/bin/mdx-test/failure/part-not-opened/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-not-opened/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the OCaml code block in test-case.md at line 3:
+Error in the code block in test-case.md at line 3:
 In file ./parts-begin-end.ml, line 6: There is no part to end.

--- a/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
@@ -1,1 +1,1 @@
-File "test-case.md", line 5, character 0: invalid code block: Parts are not supported for non-OCaml code blocks.
+File "test-case.md", line 3, character 36: invalid code block: `part` is not supported for non-OCaml code blocks.

--- a/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
@@ -1,2 +1,1 @@
-Error in the code block in test-case.md at line 4:
-Parts are not supported for non-OCaml code blocks.
+File "test-case.md", line 5, character 0: invalid code block: Parts are not supported for non-OCaml code blocks.

--- a/test/lib/test_dep.ml
+++ b/test/lib/test_dep.ml
@@ -21,12 +21,18 @@ let test_of_block =
   in
   let block_with_labels s =
     match Mdx.Label.of_string s with
-    | Ok labels -> { Mdx.Block.empty with labels }
+    | Ok labels -> (
+        match
+          Mdx.Block.mk
+            ~line:0 ~file:"" ~section:None ~labels ~header:None ~contents:[]
+        with
+        | Ok block -> block
+        | Error _ -> assert false )
     | Error _ -> assert false
   in
-  [
-    make_test ~block_des:"Empty" ~block:Mdx.Block.empty ~expected:None ();
-    make_test ~block_des:"file:toto.ml"
+  [ make_test ~block_des:"Empty" ~block:(block_with_labels "") ~expected:None ()
+  ; make_test
+      ~block_des:"file:toto.ml"
       ~block:(block_with_labels "file=toto.ml")
       ~expected:(Some (File "toto.ml")) ();
     make_test ~block_des:"dir:tata/"

--- a/test/lib/test_dep.ml
+++ b/test/lib/test_dep.ml
@@ -23,16 +23,16 @@ let test_of_block =
     match Mdx.Label.of_string s with
     | Ok labels -> (
         match
-          Mdx.Block.mk
-            ~line:0 ~file:"" ~section:None ~labels ~header:None ~contents:[]
+          Mdx.Block.mk ~line:0 ~file:"" ~section:None ~labels ~header:None
+            ~contents:[]
         with
         | Ok block -> block
         | Error _ -> assert false )
     | Error _ -> assert false
   in
-  [ make_test ~block_des:"Empty" ~block:(block_with_labels "") ~expected:None ()
-  ; make_test
-      ~block_des:"file:toto.ml"
+  [
+    make_test ~block_des:"Empty" ~block:(block_with_labels "") ~expected:None ();
+    make_test ~block_des:"file:toto.ml"
       ~block:(block_with_labels "file=toto.ml")
       ~expected:(Some (File "toto.ml")) ();
     make_test ~block_des:"dir:tata/"


### PR DESCRIPTION
Fix #216

new checks done when building blocks at parsing time:
- `env` should only be set for toplevel and ocaml blocks
- `non-deterministic` should not be set for for include blocks
- `part` requires a `file` label, and only for OCaml files

Further improvements: (in another PR?)
- ~It can be further simplified if we manage to merge the block types and block values, but we would need a `Raw` bock type~ done
- ~move all labels in the block type records and remove the `labels` field, so far the block-specific labels are already moved to the records~ done