### PR TITLE
Fix mdx rule's handling of `--syntax`

### DIFF
--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -168,11 +168,6 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax)
     (`Prelude prelude) (`Prelude_str prelude_str) (`Root root)
     (`Duniverse_mode duniverse_mode) (`Locks locks) =
   let open Mdx.Util.Result.Infix in
-  let syntax =
-    match syntax with
-    | Some syntax -> Some syntax
-    | None -> Mdx.Syntax.infer ~file:md_file
-  in
   let active =
     let section = match section with
       | None   -> None
@@ -244,7 +239,7 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax)
       print_format_dune_rules pp_rules;
       file_contents
   in
-  Mdx.run md_file ~f:on_file;
+  Mdx.run ?syntax md_file ~f:on_file;
   0
 
 open Cmdliner

--- a/test/bin/mdx-rule/misc/duniverse-mode/dune.gen.expected
+++ b/test/bin/mdx-rule/misc/duniverse-mode/dune.gen.expected
@@ -10,5 +10,5 @@
  (action
   (progn
    (run ocaml-mdx test --prelude=prelude.ml --prelude-str
-     "#require \"prelude-str\"" --syntax=normal %{x})
+     "#require \"prelude-str\"" %{x})
    (diff? %{x} %{x}.corrected))))


### PR DESCRIPTION
The --syntax option should only be passed to the generated `mdx test` invocation if it was passed to `mdx rule` as well, otherwise it should use syntax inference.

This change in behaviour is a breaking change so we should fix it before releasing!