### PR TITLE
Fix a bug with non-deterministic label printing

### DIFF
--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -284,16 +284,16 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
     (* The command is not active, skip it. *)
     | false, _, _, _, _
     (* the command is active but non-deterministic so skip everything *)
-    | true, false, _, `Non_det `Command, _ -> print_block ()
+    | true, false, _, `Non_det Nd_command, _ -> print_block ()
     (* the command is active but it's output is
        non-deterministic; run it but keep the old output. *)
-    | true, false, _, `Non_det `Output, Cram { tests; _ } ->
+    | true, false, _, `Non_det Nd_output, Cram { tests; _ } ->
       print_block ();
       let blacklist = Block.unset_variables t in
       List.iter (fun t ->
           let _: int = run_test ?root blacklist temp_file t in ()
         ) tests
-    | true, false, _, `Non_det `Output, Toplevel tests ->
+    | true, false, _, `Non_det Nd_output, Toplevel tests ->
       assert (syntax <> Some Cram);
       print_block ();
       List.iter (fun test ->

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -97,8 +97,9 @@ let pp_header ?syntax ppf t =
     assert (t.header = Syntax.cram_default_header);
     begin match t.labels with
     | [] -> ()
-    | [Non_det `Output] -> Fmt.pf ppf "<-- non-deterministic output\n"
-    | [Non_det `Command] -> Fmt.pf ppf "<-- non-deterministic command\n"
+    | [Non_det None] -> Fmt.pf ppf "<-- non-deterministic\n"
+    | [Non_det (Some Nd_output)] -> Fmt.pf ppf "<-- non-deterministic output\n"
+    | [Non_det (Some Nd_command)] -> Fmt.pf ppf "<-- non-deterministic command\n"
     | _ ->
       let err =
         Fmt.strf "Block.pp_header: [ %a ]" pp_labels t.labels
@@ -136,8 +137,13 @@ let source_trees t =
   List.filter_map (function Label.Source_tree x -> Some x | _ -> None) t.labels
 
 let mode t =
-  get_label_or (function Label.Non_det mode -> Some (`Non_det mode) | _ -> None)
-    ~default:`Normal t
+  get_label_or
+    (function
+      | Non_det (Some mode) -> Some (`Non_det mode)
+      | Non_det None -> Some (`Non_det Label.default_non_det)
+      | _ -> None)
+    ~default:`Normal
+    t
 
 let skip t = List.exists (function Label.Skip -> true | _ -> false) t.labels
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -66,7 +66,7 @@ val pp_line_directive: (string * int) Fmt.t
 
 (** {2 Accessors} *)
 
-val mode: t -> [`Non_det of [`Command|`Output] | `Normal]
+val mode: t -> [`Non_det of Label.non_det | `Normal]
 (** [mode t] is [t]'s mode. *)
 
 val directory: t -> string option

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -26,6 +26,12 @@ module Relation : sig
       the associated value. *)
 end
 
+type non_det =
+  | Nd_output
+  | Nd_command
+
+val default_non_det : non_det
+
 type t =
   | Dir of string
   | Source_tree of string
@@ -33,7 +39,7 @@ type t =
   | Part of string
   | Env of string
   | Skip
-  | Non_det of [`Output | `Command]
+  | Non_det of non_det option
   | Version of Relation.t * Ocaml_version.t
   | Require_package of string
   | Set of string * string

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -228,6 +228,18 @@
  (action (diff non-det/test-case.md non-det.actual)))
 
 (rule
+ (target non-det-default-preserved.actual)
+ (deps (package mdx) (source_tree non-det-default-preserved))
+ (action
+  (with-stdout-to %{target}
+   (chdir non-det-default-preserved
+    (run ocaml-mdx test --output - test-case.md)))))
+
+(alias
+ (name runtest)
+ (action (diff non-det-default-preserved/test-case.md non-det-default-preserved.actual)))
+
+(rule
  (target ocaml-408-syntax.actual)
  (deps (package mdx) (source_tree ocaml-408-syntax))
  (action

--- a/test/bin/mdx-test/expect/non-det-default-preserved/test-case.md
+++ b/test/bin/mdx-test/expect/non-det-default-preserved/test-case.md
@@ -1,0 +1,6 @@
+When using the `non-deterministic` label in default mode
+(i.e. without passing a value), mdx should preserve that in the output.
+
+```sh non-deterministic
+$ echo "paf"
+```

--- a/test/bin/mdx-test/misc/non-det-env-var/test-case.md.expected
+++ b/test/bin/mdx-test/misc/non-det-env-var/test-case.md.expected
@@ -1,7 +1,7 @@
 The `--non-deterministic` option can also be set through the `MDX_RUN_NON_DETERMINISTIC` env
 variable.
 
-```sh non-deterministic=output
+```sh non-deterministic
 $ echo "lol"
 lol
 ```


### PR DESCRIPTION
When changing the way we handle the labels we introduced a bug where the user would use the default non-det label:
```
``sh non-deterministic
```
and mdx would discard this information, resolve it to the default `output` value and reprint it as:
```
``sh non-deterministic=output
```
ultimately making the default value unusable since the files would always differ.

We have to be more careful about this kind of breakage in the future, in particular when we break an existing test case we need to take the time to understand whether it is acceptable or not.