### PR TITLE
Simplify --syntax test cases so that they don't randomly fail

### DIFF
--- a/test/bin/mdx-test/misc/syntax/test-case-cram.ext
+++ b/test/bin/mdx-test/misc/syntax/test-case-cram.ext
@@ -1,11 +1,4 @@
 The syntax of this file is `cram`, it can't be inferred by its file extension, so `--syntax=cram` is required.
 
-  $ cat <<EOF > foo \
-  > hello\
-  > world\
-  > EOF
-  $ cat foo
+  $ echo "hello"
   hello
-  world
-  $ echo foo
-  foo

--- a/test/bin/mdx-test/misc/syntax/test-case.t
+++ b/test/bin/mdx-test/misc/syntax/test-case.t
@@ -1,11 +1,4 @@
 The syntax of this file is `cram` and will be inferred by its file extension.
 
-  $ cat <<EOF > foo \
-  > hello\
-  > world\
-  > EOF
-  $ cat foo
+  $ echo "hello"
   hello
-  world
-  $ echo foo
-  foo


### PR DESCRIPTION
This test case randomly fails quite often in the CI or locally. I'm not sure why since I can't reproduce it but I'm willing to try anything to fix it and that's a start!