### PR TITLE
Upgrade to dune lang 2

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,3 @@
-(lang dune 1.11)
-(name mdx)
+(lang dune 2.0)
 
-(using fmt 1.2)
+(name mdx)

--- a/mdx.opam
+++ b/mdx.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {>= "1.11"}
+  "dune" {>= "2.0"}
   "ocamlfind"
   "fmt"
   "cppo" {build}

--- a/test/bin/gen_rule_helpers/gen_rule_helpers.ml
+++ b/test/bin/gen_rule_helpers/gen_rule_helpers.ml
@@ -86,8 +86,8 @@ let dir dir_name =
 
 let pr_runtest_alias dir =
   Fmt.pr {|
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff %s/%s %s)))
 |} dir.dir_name
     dir.expected_file dir.target_file

--- a/test/bin/mdx-pp/expect/dune
+++ b/test/bin/mdx-pp/expect/dune
@@ -9,7 +9,7 @@
    %{target}
    (run ../gen_dune_rules.exe test_expect))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff dune.inc dune.gen)))

--- a/test/bin/mdx-pp/expect/dune.inc
+++ b/test/bin/mdx-pp/expect/dune.inc
@@ -7,8 +7,8 @@
    (chdir section-option
     (run ocaml-mdx pp --section Valuable test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff section-option/test_case.ml.expected section-option.actual)))
 
 (rule
@@ -19,8 +19,8 @@
    (chdir spaces
     (run ocaml-mdx pp test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff spaces/test_case.ml.expected spaces.actual)))
 
 (rule
@@ -31,6 +31,6 @@
    (chdir toplevel
     (run ocaml-mdx pp test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff toplevel/test_case.ml.expected toplevel.actual)))

--- a/test/bin/mdx-pp/misc/compile/dune
+++ b/test/bin/mdx-pp/misc/compile/dune
@@ -1,10 +1,15 @@
 (executable
  (name test_case)
- (preprocess (action (run ocaml-mdx pp %{input-file}))))
+ (preprocess
+  (action
+   (run ocaml-mdx pp %{input-file}))))
 
 (rule
- (with-stdout-to output.actual (run ./test_case.exe)))
+ (with-stdout-to
+  output.actual
+  (run ./test_case.exe)))
 
-(alias
- (name runtest)
- (action (diff output.expected output.actual)))
+(rule
+ (alias runtest)
+ (action
+  (diff output.expected output.actual)))

--- a/test/bin/mdx-pp/misc/compile/dune-project
+++ b/test/bin/mdx-pp/misc/compile/dune-project
@@ -1,7 +1,12 @@
-(lang dune 1.11)
+(lang dune 2.0)
+
 (name mdx-pp-test)
 
 (dialect
  (name md)
- (implementation (extension md))
- (interface (extension mdi)))
+ (implementation
+  (extension md))
+ (interface
+  (extension mdi)))
+
+(formatting disabled)

--- a/test/bin/mdx-rule/misc/duniverse-mode/dune
+++ b/test/bin/mdx-rule/misc/duniverse-mode/dune
@@ -6,7 +6,7 @@
    (run ocaml-mdx rule --duniverse-mode --prelude %{dep:prelude.ml}
      --prelude-str "#require \"prelude-str\"" %{dep:duniverse-mode.md}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff %{dep:dune.gen.expected} %{dep:dune.gen})))

--- a/test/bin/mdx-test/expect/dune
+++ b/test/bin/mdx-test/expect/dune
@@ -9,7 +9,7 @@
    %{target}
    (run ../gen_dune_rules.exe test_expect))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff dune.inc dune.gen)))

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -7,8 +7,8 @@
    (chdir casual-file-inc
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff casual-file-inc/test-case.md.expected casual-file-inc.actual)))
 
 (rule
@@ -19,8 +19,8 @@
    (chdir code
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff code/test-case.md code.actual)))
 
 (rule
@@ -31,8 +31,8 @@
    (chdir cram
     (run ocaml-mdx test --output - --syntax=cram test-case.t)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff cram/test-case.t cram.actual)))
 
 (rule
@@ -43,8 +43,8 @@
    (chdir ellipsis
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ellipsis/test-case.md ellipsis.actual)))
 
 (rule
@@ -55,8 +55,8 @@
    (chdir ellipsis-updates
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ellipsis-updates/test-case.md.expected ellipsis-updates.actual)))
 
 (rule
@@ -67,8 +67,8 @@
    (chdir empty-line
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff empty-line/test-case.md empty-line.actual)))
 
 (rule
@@ -79,8 +79,8 @@
    (chdir empty-lines
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff empty-lines/test-case.md.expected empty-lines.actual)))
 
 (rule
@@ -91,8 +91,8 @@
    (chdir environment-variable
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff environment-variable/test-case.md environment-variable.actual)))
 
 (rule
@@ -103,8 +103,8 @@
    (chdir environment-variable-set
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff environment-variable-set/test-case.md environment-variable-set.actual)))
 
 (rule
@@ -115,8 +115,8 @@
    (chdir environment-variable-unset
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff environment-variable-unset/test-case.md environment-variable-unset.actual)))
 
 (rule
@@ -127,8 +127,8 @@
    (chdir envs
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff envs/test-case.md envs.actual)))
 
 (rule
@@ -139,8 +139,8 @@
    (chdir errors
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff errors/test-case.md errors.actual)))
 
 (rule
@@ -151,8 +151,8 @@
    (chdir exit
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff exit/test-case.md exit.actual)))
 
 (rule
@@ -163,8 +163,8 @@
    (chdir heredoc
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff heredoc/test-case.md heredoc.actual)))
 
 (rule
@@ -175,8 +175,8 @@
    (chdir lines
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff lines/test-case.md lines.actual)))
 
 (rule
@@ -187,8 +187,8 @@
    (chdir lwt
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff lwt/test-case.md lwt.actual)))
 
 (rule
@@ -199,8 +199,8 @@
    (chdir mlt
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff mlt/test-case.md mlt.actual)))
 
 (rule
@@ -211,8 +211,8 @@
    (chdir multilines
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff multilines/test-case.md multilines.actual)))
 
 (rule
@@ -223,8 +223,8 @@
    (chdir non-det
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff non-det/test-case.md non-det.actual)))
 
 (rule
@@ -235,8 +235,8 @@
    (chdir non-det-default-preserved
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff non-det-default-preserved/test-case.md non-det-default-preserved.actual)))
 
 (rule
@@ -247,8 +247,8 @@
    (chdir ocaml-408-syntax
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ocaml-408-syntax/test-case.md ocaml-408-syntax.actual)))
 
 (rule
@@ -259,8 +259,8 @@
    (chdir padding
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff padding/test-case.md padding.actual)))
 
 (rule
@@ -271,8 +271,8 @@
    (chdir parts-begin-end
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff parts-begin-end/test-case.md.expected parts-begin-end.actual)))
 
 (rule
@@ -283,8 +283,8 @@
    (chdir prelude
     (run ocaml-mdx test --output - --prelude-str "#require \"lwt\"" --prelude-str "toto:let x = \"42\"" test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff prelude/test-case.md prelude.actual)))
 
 (rule
@@ -295,8 +295,8 @@
    (chdir prelude-file
     (run ocaml-mdx test --output - --prelude prelude.ml test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff prelude-file/test-case.md prelude-file.actual)))
 
 (rule
@@ -307,8 +307,8 @@
    (chdir root-option
     (run ocaml-mdx test --output - --root=somedir test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff root-option/test-case.md.expected root-option.actual)))
 
 (rule
@@ -319,8 +319,8 @@
    (chdir section
     (run ocaml-mdx test --output - -s Testing test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff section/test-case.md.expected section.actual)))
 
 (rule
@@ -331,8 +331,8 @@
    (chdir semisemi
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff semisemi/test-case.md semisemi.actual)))
 
 (rule
@@ -343,8 +343,8 @@
    (chdir shell-file-inc
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff shell-file-inc/test-case.md.expected shell-file-inc.actual)))
 
 (rule
@@ -355,8 +355,8 @@
    (chdir spaces
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff spaces/test-case.md spaces.actual)))
 
 (rule
@@ -367,8 +367,8 @@
    (chdir sync-from-subdir
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff sync-from-subdir/test-case.md.expected sync-from-subdir.actual)))
 
 (rule
@@ -379,8 +379,8 @@
    (chdir sync-to-md
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff sync-to-md/test-case.md.expected sync-to-md.actual)))
 
 (rule
@@ -391,8 +391,8 @@
    (chdir toploop-getvalue
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff toploop-getvalue/test-case.md toploop-getvalue.actual)))
 
 (rule
@@ -403,6 +403,6 @@
    (chdir trailing-whitespaces
     (run ocaml-mdx test --output - test-case.md)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff trailing-whitespaces/test-case.md.expected trailing-whitespaces.actual)))

--- a/test/bin/mdx-test/failure/dune
+++ b/test/bin/mdx-test/failure/dune
@@ -9,7 +9,7 @@
    %{targets}
    (run ../gen_dune_rules.exe test_failure))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff dune.inc dune.gen)))

--- a/test/bin/mdx-test/failure/dune.inc
+++ b/test/bin/mdx-test/failure/dune.inc
@@ -7,8 +7,8 @@
    (chdir both-prelude
     (system "! ocaml-mdx test --prelude=a --prelude-str=b test-case.md")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff both-prelude/test-case.md.expected both-prelude.actual)))
 
 (rule
@@ -19,8 +19,8 @@
    (chdir in-toplevel
     (system "! ocaml-mdx test test-case.md")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff in-toplevel/test-case.md.expected in-toplevel.actual)))
 
 (rule
@@ -31,8 +31,8 @@
    (chdir invalid-label
     (system "! ocaml-mdx test test-case.md")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff invalid-label/test-case.md.expected invalid-label.actual)))
 
 (rule
@@ -43,8 +43,8 @@
    (chdir invalid-label-value
     (system "! ocaml-mdx test test-case.md")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff invalid-label-value/test-case.md.expected invalid-label-value.actual)))
 
 (rule
@@ -55,8 +55,8 @@
    (chdir ml-file-not-found
     (system "! ocaml-mdx test test-case.md")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ml-file-not-found/test-case.md.expected ml-file-not-found.actual)))
 
 (rule
@@ -67,8 +67,8 @@
    (chdir part-not-ended
     (system "! ocaml-mdx test test-case.md")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff part-not-ended/test-case.md.expected part-not-ended.actual)))
 
 (rule
@@ -79,8 +79,8 @@
    (chdir part-not-found
     (system "! ocaml-mdx test test-case.md")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff part-not-found/test-case.md.expected part-not-found.actual)))
 
 (rule
@@ -91,8 +91,8 @@
    (chdir part-not-opened
     (system "! ocaml-mdx test test-case.md")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff part-not-opened/test-case.md.expected part-not-opened.actual)))
 
 (rule
@@ -103,6 +103,6 @@
    (chdir part-unsupported
     (system "! ocaml-mdx test test-case.md")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff part-unsupported/test-case.md.expected part-unsupported.actual)))

--- a/test/bin/mdx-test/misc/non-det-env-var/dune
+++ b/test/bin/mdx-test/misc/non-det-env-var/dune
@@ -8,7 +8,7 @@
    true
    (run ocaml-mdx test --force-output %{dep:test-case.md}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff test-case.md.expected test-case.md.corrected)))

--- a/test/bin/mdx-test/misc/output-option/dune
+++ b/test/bin/mdx-test/misc/output-option/dune
@@ -8,8 +8,8 @@
    %{target}
    (run ocaml-mdx test --output - %{md}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (:expected test-case.md)
   (:actual std-out.corrected))
@@ -24,8 +24,8 @@
  (action
   (run ocaml-mdx test --force-output --output %{target} %{md})))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (:expected test-case.md)
   (:actual explicit-outfile.corrected))
@@ -40,8 +40,8 @@
  (action
   (run ocaml-mdx test --force-output %{md})))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (:expected test-case.md)
   (:actual test-case.md.corrected))

--- a/test/bin/mdx-test/misc/syntax/dune
+++ b/test/bin/mdx-test/misc/syntax/dune
@@ -6,8 +6,8 @@
  (action
   (run ocaml-mdx test --output %{target} %{md})))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (:expected test-case.md)
   (:actual test-case.md.corrected))
@@ -22,8 +22,8 @@
  (action
   (run ocaml-mdx test --output %{target} %{md})))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (:expected test-case.t)
   (:actual test-case.t.corrected))
@@ -38,8 +38,8 @@
  (action
   (run ocaml-mdx test %{md} --output %{target} --syntax markdown)))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (:expected test-case-md.ext)
   (:actual test-case-md.ext.corrected))
@@ -54,8 +54,8 @@
  (action
   (run ocaml-mdx test %{md} --output %{target} --syntax cram)))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (:expected test-case-cram.ext)
   (:actual test-case-cram.ext.corrected))

--- a/test/bin/misc-test-cases/mdx-deps/dune
+++ b/test/bin/misc-test-cases/mdx-deps/dune
@@ -7,7 +7,7 @@
    %{target}
    (run ocaml-mdx deps %{dep:deps.md}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff %{dep:deps.txt.expected} %{dep:deps.txt})))

--- a/test/bin/misc-test-cases/mdx-pp-execute/dune
+++ b/test/bin/misc-test-cases/mdx-pp-execute/dune
@@ -17,8 +17,8 @@
   section.out
   (run ./section.exe)))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (:x section.out)
   (:y section.out.expected))

--- a/test/bin/misc-test-cases/mdx-pp/dune
+++ b/test/bin/misc-test-cases/mdx-pp/dune
@@ -8,8 +8,8 @@
    %{targets}
    (run ocaml-mdx pp %{x}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (:x skip.ml)
   (:y skip.ml.expected))

--- a/test/bin/misc-test-cases/mdx-test-require-local-package/private_lib/dune-project
+++ b/test/bin/misc-test-cases/mdx-test-require-local-package/private_lib/dune-project
@@ -1,2 +1,5 @@
-(lang dune 1.11)
+(lang dune 2.0)
+
 (name example_lib)
+
+(formatting disabled)


### PR DESCRIPTION
This PR updates the `dune-lang` version to the latest 2.3.1

It was done using the experimental [new `dune upgrade` script](https://github.com/ocaml/dune/pull/3174) (🎉).