### PR TITLE
Add labels to explicitly set block type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 #### Added
 
+- Allow to explicitly set the kind of blocks in labels: `ocaml`, `cram`, `toplevel` or `include`. (#237, @gpetiot)
+
 #### Changed
 
 #### Deprecated

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -16,6 +16,7 @@
 
 open Result
 open Compat
+open Util.Result.Infix
 
 module Header = struct
   type t = Shell of [ `Sh | `Bash ] | OCaml | Other of string
@@ -287,13 +288,19 @@ let executable_contents ~syntax b =
 
 let version_enabled version =
   let open Util.Result.Infix in
-  Ocaml_version.of_string Sys.ocaml_version >>= fun curr_version ->
+  Ocaml_version.of_string Sys.ocaml_version >>| fun curr_version ->
   match version with
   | Some (op, v) ->
-      Ok (Label.Relation.compare op (Ocaml_version.compare curr_version v) 0)
-  | None -> Ok true
+      Label.Relation.compare op (Ocaml_version.compare curr_version v) 0
+  | None -> true
 
 let get_label f (labels : Label.t list) = Util.List.find_map f labels
+
+let label_not_allowed ~label ~kind =
+  Util.Result.errorf "`%s` label is not allowed for %s blocks." label kind
+
+let label_required ~label ~kind =
+  Util.Result.errorf "`%s` label is required for %s blocks." label kind
 
 let check_not_set msg = function
   | Some _ -> Util.Result.errorf msg
@@ -304,96 +311,156 @@ let check_no_errors = function
   | _ :: _ ->
       Util.Result.errorf "error block cannot be attached to a non-OCaml block"
 
-let mk ~line ~file ~column ~section ~labels ~legacy_labels ~header ~contents
-    ~errors =
-  let non_det =
-    get_label
-      (function
-        | Non_det (Some x) -> Some x
-        | Non_det None -> Some Label.default_non_det
-        | _ -> None)
-      labels
-  in
-  let part = get_label (function Part x -> Some x | _ -> None) labels in
-  let env = get_label (function Env x -> Some x | _ -> None) labels in
-  let dir = get_label (function Dir x -> Some x | _ -> None) labels in
-  let skip = List.exists (function Label.Skip -> true | _ -> false) labels in
-  let version =
-    get_label (function Version (x, y) -> Some (x, y) | _ -> None) labels
-  in
-  let source_trees =
-    List.filter_map
-      (function Label.Source_tree x -> Some x | _ -> None)
-      labels
-  in
-  let required_packages =
-    List.filter_map
-      (function Label.Require_package x -> Some x | _ -> None)
-      labels
-  in
-  let set_variables =
-    List.filter_map
-      (function Label.Set (v, x) -> Some (v, x) | _ -> None)
-      labels
-  in
-  let unset_variables =
-    List.filter_map (function Label.Unset x -> Some x | _ -> None) labels
-  in
-  let file_inc = get_label (function File x -> Some x | _ -> None) labels in
-  let open Util.Result.Infix in
-  ( match file_inc with
-  | Some file_included -> (
-      check_not_set
-        "`non-deterministic` label cannot be used with a `file` label." non_det
-      >>= fun () ->
-      check_not_set "`env` label cannot be used with a `file` label." env
-      >>= fun () ->
+type block_config = {
+  non_det : Label.non_det option;
+  part : string option;
+  env : string option;
+  dir : string option;
+  skip : bool;
+  version : (Label.Relation.t * Ocaml_version.t) option;
+  source_trees : string list;
+  required_packages : string list;
+  set_variables : (string * string) list;
+  unset_variables : string list;
+  file_inc : string option;
+}
+
+let get_block_config l =
+  {
+    non_det =
+      get_label
+        (function
+          | Non_det (Some x) -> Some x
+          | Non_det None -> Some Label.default_non_det
+          | _ -> None)
+        l;
+    part = get_label (function Part x -> Some x | _ -> None) l;
+    env = get_label (function Env x -> Some x | _ -> None) l;
+    dir = get_label (function Dir x -> Some x | _ -> None) l;
+    skip = List.exists (function Label.Skip -> true | _ -> false) l;
+    version = get_label (function Version (x, y) -> Some (x, y) | _ -> None) l;
+    source_trees =
+      List.filter_map (function Label.Source_tree x -> Some x | _ -> None) l;
+    required_packages =
+      List.filter_map
+        (function Label.Require_package x -> Some x | _ -> None)
+        l;
+    set_variables =
+      List.filter_map (function Label.Set (v, x) -> Some (v, x) | _ -> None) l;
+    unset_variables =
+      List.filter_map (function Label.Unset x -> Some x | _ -> None) l;
+    file_inc = get_label (function File x -> Some x | _ -> None) l;
+  }
+
+let mk_ocaml ~config ~contents ~errors =
+  let kind = "OCaml" in
+  match config with
+  | { file_inc = None; part = None; env; non_det; _ } -> (
+      match guess_ocaml_kind contents with
+      | `Code -> Ok (OCaml { env = Ocaml_env.mk env; non_det; errors })
+      | `Toplevel ->
+          Util.Result.errorf "toplevel syntax is not allowed in OCaml blocks." )
+  | { file_inc = Some _; _ } -> label_not_allowed ~label:"file" ~kind
+  | { part = Some _; _ } -> label_not_allowed ~label:"part" ~kind
+
+let mk_cram ?language ~config ~header ~errors () =
+  let kind = "shell" in
+  match config with
+  | { file_inc = None; part = None; env = None; non_det; _ } ->
+      check_no_errors errors >>| fun () ->
+      let language =
+        Util.Option.value language
+          ~default:
+            ( match header with
+            | Some (Header.Shell language) -> language
+            | _ -> `Sh )
+      in
+      Cram { language; non_det }
+  | { file_inc = Some _; _ } -> label_not_allowed ~label:"file" ~kind
+  | { part = Some _; _ } -> label_not_allowed ~label:"part" ~kind
+  | { env = Some _; _ } -> label_not_allowed ~label:"env" ~kind
+
+let mk_toplevel ~config ~contents ~errors =
+  let kind = "toplevel" in
+  match config with
+  | { file_inc = None; part = None; env; non_det; _ } -> (
+      match guess_ocaml_kind contents with
+      | `Code ->
+          Util.Result.errorf "invalid toplevel syntax in toplevel blocks."
+      | `Toplevel ->
+          check_no_errors errors >>| fun () ->
+          Toplevel { env = Ocaml_env.mk env; non_det } )
+  | { file_inc = Some _; _ } -> label_not_allowed ~label:"file" ~kind
+  | { part = Some _; _ } -> label_not_allowed ~label:"part" ~kind
+
+let mk_include ~config ~header ~errors =
+  let kind = "include" in
+  match config with
+  | { file_inc = Some file_included; part; non_det = None; env = None; _ } -> (
       check_no_errors errors >>= fun () ->
       match header with
       | Some Header.OCaml ->
           let file_kind = Fk_ocaml { part_included = part } in
           Ok (Include { file_included; file_kind })
-      | _ ->
-          check_not_set "`part` is not supported for non-OCaml code blocks."
-            part
-          >>= fun () ->
-          let file_kind = Fk_other { header } in
-          Ok (Include { file_included; file_kind }) )
-  | None -> (
-      check_not_set "`part` label requires a `file` label." part >>= fun () ->
+      | _ -> (
+          match part with
+          | None ->
+              let file_kind = Fk_other { header } in
+              Ok (Include { file_included; file_kind })
+          | Some _ -> label_not_allowed ~label:"part" ~kind:"non-OCaml include"
+          ) )
+  | { file_inc = None; _ } -> label_required ~label:"file" ~kind
+  | { non_det = Some _; _ } ->
+      label_not_allowed ~label:"non-deterministic" ~kind
+  | { env = Some _; _ } -> label_not_allowed ~label:"env" ~kind
+
+let infer_block ~config ~header ~contents ~errors =
+  match config with
+  | { file_inc = Some _; _ } -> mk_include ~config ~header ~errors
+  | { file_inc = None; part; _ } -> (
       match header with
       | Some (Header.Shell language) ->
-          check_no_errors errors >>= fun () ->
-          check_not_set "`env` label cannot be used with a `shell` header." env
-          >>= fun () -> Ok (Cram { language; non_det })
+          mk_cram ~language ~config ~header ~errors ()
       | Some Header.OCaml -> (
-          let env = Ocaml_env.mk env in
           match guess_ocaml_kind contents with
-          | `Code -> Ok (OCaml { env; non_det; errors })
-          | `Toplevel ->
-              check_no_errors errors >>= fun () ->
-              Ok (Toplevel { env; non_det }) )
-      | _ -> check_no_errors errors >>= fun () -> Ok (Raw { header }) ) )
+          | `Code -> mk_ocaml ~config ~contents ~errors
+          | `Toplevel -> mk_toplevel ~config ~contents ~errors )
+      | _ ->
+          check_not_set "`part` label requires a `file` label." part
+          >>= fun () ->
+          check_no_errors errors >>| fun () -> Raw { header } )
+
+let mk ~line ~file ~column ~section ~labels ~legacy_labels ~header ~contents
+    ~errors =
+  let block_kind =
+    get_label (function Block_kind x -> Some x | _ -> None) labels
+  in
+  let config = get_block_config labels in
+  ( match block_kind with
+  | Some OCaml -> mk_ocaml ~config ~contents ~errors
+  | Some Cram -> mk_cram ~config ~header ~errors ()
+  | Some Toplevel -> mk_toplevel ~config ~contents ~errors
+  | Some Include -> mk_include ~config ~header ~errors
+  | None -> infer_block ~config ~header ~contents ~errors )
   >>= fun value ->
-  version_enabled version >>= fun version_enabled ->
-  Ok
-    {
-      line;
-      file;
-      column;
-      section;
-      dir;
-      source_trees;
-      required_packages;
-      labels;
-      legacy_labels;
-      contents;
-      skip;
-      version_enabled;
-      set_variables;
-      unset_variables;
-      value;
-    }
+  version_enabled config.version >>| fun version_enabled ->
+  {
+    line;
+    file;
+    column;
+    section;
+    dir = config.dir;
+    source_trees = config.source_trees;
+    required_packages = config.required_packages;
+    labels;
+    legacy_labels;
+    contents;
+    skip = config.skip;
+    version_enabled;
+    set_variables = config.set_variables;
+    unset_variables = config.unset_variables;
+    value;
+  }
 
 let is_active ?section:s t =
   let active =

--- a/lib/label.ml
+++ b/lib/label.ml
@@ -74,6 +74,8 @@ type non_det = Nd_output | Nd_command
 
 let default_non_det = Nd_output
 
+type block_kind = OCaml | Cram | Toplevel | Include
+
 type t =
   | Dir of string
   | Source_tree of string
@@ -86,6 +88,13 @@ type t =
   | Require_package of string
   | Set of string * string
   | Unset of string
+  | Block_kind of block_kind
+
+let pp_block_kind ppf = function
+  | OCaml -> Fmt.string ppf "ocaml"
+  | Cram -> Fmt.string ppf "cram"
+  | Toplevel -> Fmt.string ppf "toplevel"
+  | Include -> Fmt.string ppf "include"
 
 let pp ppf = function
   | Dir d -> Fmt.pf ppf "dir=%s" d
@@ -102,6 +111,7 @@ let pp ppf = function
   | Require_package p -> Fmt.pf ppf "require-package=%s" p
   | Set (v, x) -> Fmt.pf ppf "set-%s=%s" v x
   | Unset x -> Fmt.pf ppf "unset-%s" x
+  | Block_kind bk -> pp_block_kind ppf bk
 
 let is_prefix ~prefix s =
   let len_prefix = String.length prefix in
@@ -140,6 +150,10 @@ let requires_eq_value ~label ~value f =
 let interpret label value =
   match label with
   | "skip" -> doesnt_accept_value ~label ~value Skip
+  | "ocaml" -> doesnt_accept_value ~label ~value (Block_kind OCaml)
+  | "cram" -> doesnt_accept_value ~label ~value (Block_kind Cram)
+  | "toplevel" -> doesnt_accept_value ~label ~value (Block_kind Toplevel)
+  | "include" -> doesnt_accept_value ~label ~value (Block_kind Include)
   | v when is_prefix ~prefix:"unset-" v ->
       doesnt_accept_value ~label ~value
         (Unset (split_prefix ~prefix:"unset-" v))

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -30,6 +30,8 @@ type non_det = Nd_output | Nd_command
 
 val default_non_det : non_det
 
+type block_kind = OCaml | Cram | Toplevel | Include
+
 type t =
   | Dir of string
   | Source_tree of string
@@ -42,6 +44,7 @@ type t =
   | Require_package of string
   | Set of string * string
   | Unset of string
+  | Block_kind of block_kind
 
 val pp : Format.formatter -> t -> unit
 

--- a/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
@@ -1,1 +1,1 @@
-[mdx] Fatal error: File "test-case.md", lines 3-5: invalid code block: `part` is not supported for non-OCaml code blocks.
+[mdx] Fatal error: File "test-case.md", lines 3-5: invalid code block: `part` label is not allowed for non-OCaml include blocks.

--- a/test/lib/testable.ml
+++ b/test/lib/testable.ml
@@ -19,3 +19,16 @@ let ocaml_delimiter =
     | Part_end -> Fmt.string fs "Part_end"
   in
   Alcotest.testable pp ( = )
+
+let library_set =
+  let open Mdx.Library in
+  let equal = Set.equal in
+  let pp fmt set =
+    let l = Set.elements set in
+    Fmt.string fmt "[ ";
+    Fmt.(list ~sep:(const string "; ") pp) fmt l;
+    Fmt.string fmt " ]"
+  in
+  Alcotest.testable pp equal
+
+let block = Alcotest.testable Mdx.Block.dump ( = )

--- a/test/lib/testable.mli
+++ b/test/lib/testable.mli
@@ -3,3 +3,7 @@ val sexp : Mdx.Util.Sexp.t Alcotest.testable
 val msg : [ `Msg of string ] Alcotest.testable
 
 val ocaml_delimiter : Mdx.Ocaml_delimiter.t Alcotest.testable
+
+val library_set : Mdx.Library.Set.t Alcotest.testable
+
+val block : Mdx.Block.t Alcotest.testable


### PR DESCRIPTION
Fix #164 
This adds an intermediary step checking what is guessed vs what is enforced with this new label. Some blocks (ocaml, cram, toplevel) can be forced into a raw block (when it may be invalid on purpose, but the markdown header is set for highlighting)