### PR TITLE
Parse mdx-error blocks to carry errors of OCaml blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 
 - Fix the environment selection for preludes (#225, @gpetiot)
 
+- Errors of OCaml blocks are displayed in `mdx-error` blocks, that are immediately following the `ocaml` blocks they are attached to (#238, @gpetiot)
+
 #### Removed
 
 #### Security

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -144,6 +144,20 @@ let eval_raw ?block ?root c ~line lines =
   | Ok _ -> ()
   | Error e -> err_eval ~cmd:lines e
 
+let eval_ocaml ~block ?root c ppf ~line lines =
+  let test =
+    Toplevel.{ vpad = 0; hpad = 0; line; command = lines; output = [] }
+  in
+  let update ~errors = function
+    | { Block.value = OCaml v; _ } as b ->
+        { b with value = OCaml { v with errors } }
+    (* [eval_ocaml] only called on OCaml blocks *)
+    | _ -> assert false
+  in
+  match eval_test ?root ~block c test with
+  | Ok _ -> Block.pp ppf (update ~errors:[] block)
+  | Error errors -> Block.pp ppf (update ~errors block)
+
 let lines = function Ok x | Error x -> x
 
 let split_lines lines =
@@ -270,12 +284,11 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
       | Include { file_included; file_kind = Fk_other _ } ->
           let new_content = read_part file_included None in
           update_block_content ppf t new_content
-      | OCaml { non_det; env } ->
+      | OCaml { non_det; env; _ } ->
           let det () =
             assert (syntax <> Some Cram);
             Mdx_top.in_env env (fun () ->
-                eval_raw ~block:t ?root c ~line:t.line t.contents);
-            Block.pp ppf t
+                eval_ocaml ~block:t ?root c ppf ~line:t.line t.contents)
           in
           with_non_det non_deterministic non_det ~command:print_block
             ~output:det ~det

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -144,7 +144,15 @@ let eval_raw ?block ?root c ~line lines =
   | Ok _ -> ()
   | Error e -> err_eval ~cmd:lines e
 
-let eval_ocaml ~block ?root c ppf ~line lines =
+let split_lines lines =
+  let aux acc s =
+    (* XXX(samoht) support windowns *)
+    let lines = String.cuts ~sep:"\n" s in
+    List.append lines acc
+  in
+  List.fold_left aux [] (List.rev lines)
+
+let eval_ocaml ~block ?root c ppf ~line lines errors =
   let test =
     Toplevel.{ vpad = 0; hpad = 0; line; command = lines; output = [] }
   in
@@ -156,17 +164,21 @@ let eval_ocaml ~block ?root c ppf ~line lines =
   in
   match eval_test ?root ~block c test with
   | Ok _ -> Block.pp ppf (update ~errors:[] block)
-  | Error errors -> Block.pp ppf (update ~errors block)
+  | Error lines ->
+      let errors =
+        let lines = split_lines lines in
+        let output = List.map output_from_line lines in
+        if Output.equal output errors then errors
+        else
+          List.map
+            (function
+              | `Ellipsis -> `Ellipsis
+              | `Output x -> `Output (ansi_color_strip x))
+            (Output.merge output errors)
+      in
+      Block.pp ppf (update ~errors block)
 
 let lines = function Ok x | Error x -> x
-
-let split_lines lines =
-  let aux acc s =
-    (* XXX(samoht) support windowns *)
-    let lines = String.cuts ~sep:"\n" s in
-    List.append lines acc
-  in
-  List.fold_left aux [] (List.rev lines)
 
 let run_toplevel_tests ?root c ppf tests t =
   Block.pp_header ppf t;
@@ -284,11 +296,11 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
       | Include { file_included; file_kind = Fk_other _ } ->
           let new_content = read_part file_included None in
           update_block_content ppf t new_content
-      | OCaml { non_det; env; _ } ->
+      | OCaml { non_det; env; errors } ->
           let det () =
             assert (syntax <> Some Cram);
             Mdx_top.in_env env (fun () ->
-                eval_ocaml ~block:t ?root c ppf ~line:t.line t.contents)
+                eval_ocaml ~block:t ?root c ppf ~line:t.line t.contents errors)
           in
           with_non_det non_deterministic non_det ~command:print_block
             ~output:det ~det

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -47,7 +47,7 @@ type cram_value = { non_det : Label.non_det option }
 type ocaml_value = {
   env : Env.t;
   non_det : Label.non_det option;
-  errors : string list;
+  errors : Output.t list;
 }
 
 type toplevel_value = { env : Env.t; non_det : Label.non_det option }
@@ -132,9 +132,9 @@ let pp_contents ?syntax ppf t = Fmt.pf ppf "%a\n" (pp_lines syntax) t.contents
 let pp_errors ppf t =
   match t.value with
   | OCaml { errors; _ } when List.length errors > 0 ->
-      Fmt.string ppf "```\n";
       Fmt.string ppf "```mdx-error\n";
-      Fmt.pf ppf "%a\n" Fmt.(list ~sep:(unit "\n") string) errors
+      Fmt.pf ppf "%a" Fmt.(list ~sep:nop Output.pp) errors;
+      Fmt.string ppf "```\n"
   | _ -> ()
 
 let pp_footer ?syntax ppf () =
@@ -172,8 +172,8 @@ let pp_header ?syntax ppf t =
 let pp ?syntax ppf b =
   pp_header ?syntax ppf b;
   pp_contents ?syntax ppf b;
-  pp_errors ppf b;
-  pp_footer ?syntax ppf ()
+  pp_footer ?syntax ppf ();
+  pp_errors ppf b
 
 let directory t = t.dir
 

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -44,7 +44,11 @@ type section = int * string
 
 type cram_value = { non_det : Label.non_det option }
 
-type ocaml_value = { env : Env.t; non_det : Label.non_det option }
+type ocaml_value = {
+  env : Env.t;
+  non_det : Label.non_det option;
+  errors : string list;
+}
 
 type toplevel_value = { env : Env.t; non_det : Label.non_det option }
 
@@ -125,6 +129,14 @@ let pp_lines syntax =
 
 let pp_contents ?syntax ppf t = Fmt.pf ppf "%a\n" (pp_lines syntax) t.contents
 
+let pp_errors ppf t =
+  match t.value with
+  | OCaml { errors; _ } when List.length errors > 0 ->
+      Fmt.string ppf "```\n";
+      Fmt.string ppf "```mdx-error\n";
+      Fmt.pf ppf "%a\n" Fmt.(list ~sep:(unit "\n") string) errors
+  | _ -> ()
+
 let pp_footer ?syntax ppf () =
   match syntax with Some Syntax.Cram -> () | _ -> Fmt.string ppf "```\n"
 
@@ -160,6 +172,7 @@ let pp_header ?syntax ppf t =
 let pp ?syntax ppf b =
   pp_header ?syntax ppf b;
   pp_contents ?syntax ppf b;
+  pp_errors ppf b;
   pp_footer ?syntax ppf ()
 
 let directory t = t.dir
@@ -267,7 +280,12 @@ let check_not_set msg = function
   | Some _ -> Util.Result.errorf msg
   | None -> Ok ()
 
-let mk ~line ~file ~section ~labels ~legacy_labels ~header ~contents =
+let check_no_errors = function
+  | [] -> Ok ()
+  | _ :: _ ->
+      Util.Result.errorf "error block cannot be attached to a non-OCaml block"
+
+let mk ~line ~file ~section ~labels ~legacy_labels ~header ~contents ~errors =
   let non_det =
     get_label
       (function
@@ -310,6 +328,7 @@ let mk ~line ~file ~section ~labels ~legacy_labels ~header ~contents =
       >>= fun () ->
       check_not_set "`env` label cannot be used with a `file` label." env
       >>= fun () ->
+      check_no_errors errors >>= fun () ->
       match header with
       | Some Header.OCaml ->
           let file_kind = Fk_ocaml { part_included = part } in
@@ -324,14 +343,17 @@ let mk ~line ~file ~section ~labels ~legacy_labels ~header ~contents =
       check_not_set "`part` label requires a `file` label." part >>= fun () ->
       match header with
       | Some Header.Shell ->
+          check_no_errors errors >>= fun () ->
           check_not_set "`env` label cannot be used with a `shell` header." env
           >>= fun () -> Ok (Cram { non_det })
       | Some Header.OCaml -> (
           let env = Env.mk env in
           match guess_ocaml_kind contents with
-          | `Code -> Ok (OCaml { env; non_det })
-          | `Toplevel -> Ok (Toplevel { env; non_det }) )
-      | _ -> Ok (Raw { header }) ) )
+          | `Code -> Ok (OCaml { env; non_det; errors })
+          | `Toplevel ->
+              check_no_errors errors >>= fun () ->
+              Ok (Toplevel { env; non_det }) )
+      | _ -> check_no_errors errors >>= fun () -> Ok (Raw { header }) ) )
   >>= fun value ->
   version_enabled version >>= fun version_enabled ->
   Ok

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -40,6 +40,7 @@ type ocaml_value = {
   env : Env.t;
       (** [env] is the name given to the environment where tests are run. *)
   non_det : Label.non_det option;
+  errors : string list;
 }
 
 type toplevel_value = {
@@ -106,6 +107,7 @@ val mk :
   legacy_labels:bool ->
   header:Header.t option ->
   contents:string list ->
+  errors:string list ->
   (t, [ `Msg of string ]) Result.result
 
 (** {2 Printers} *)

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -40,7 +40,7 @@ type ocaml_value = {
   env : Env.t;
       (** [env] is the name given to the environment where tests are run. *)
   non_det : Label.non_det option;
-  errors : string list;
+  errors : Output.t list;
 }
 
 type toplevel_value = {
@@ -107,7 +107,7 @@ val mk :
   legacy_labels:bool ->
   header:Header.t option ->
   contents:string list ->
-  errors:string list ->
+  errors:Output.t list ->
   (t, [ `Msg of string ]) Result.result
 
 (** {2 Printers} *)

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -39,7 +39,11 @@ rule text section = parse
         let errors =
           match error_block lexbuf with
           | exception _ -> []
-          | e -> e
+          | e ->
+            List.map (fun x ->
+                match String.trim x with
+                | "..." -> `Ellipsis
+                | _ -> `Output x) e
         in
         let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
         newline lexbuf;

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -288,6 +288,18 @@
  (action (diff ocaml-errors/test-case.md.expected ocaml-errors.actual)))
 
 (rule
+ (target ocaml-errors-ellipsis.actual)
+ (deps (package mdx) (source_tree ocaml-errors-ellipsis))
+ (action
+  (with-stdout-to %{target}
+   (chdir ocaml-errors-ellipsis
+    (run ocaml-mdx test --output - test-case.md)))))
+
+(rule
+ (alias runtest)
+ (action (diff ocaml-errors-ellipsis/test-case.md ocaml-errors-ellipsis.actual)))
+
+(rule
  (target padding.actual)
  (deps (package mdx) (source_tree padding))
  (action

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -276,6 +276,18 @@
  (action (diff ocaml-408-syntax/test-case.md ocaml-408-syntax.actual)))
 
 (rule
+ (target ocaml-errors.actual)
+ (deps (package mdx) (source_tree ocaml-errors))
+ (action
+  (with-stdout-to %{target}
+   (chdir ocaml-errors
+    (run ocaml-mdx test --output - test-case.md)))))
+
+(rule
+ (alias runtest)
+ (action (diff ocaml-errors/test-case.md.expected ocaml-errors.actual)))
+
+(rule
  (target padding.actual)
  (deps (package mdx) (source_tree padding))
  (action

--- a/test/bin/mdx-test/expect/ocaml-errors-ellipsis/test-case.md
+++ b/test/bin/mdx-test/expect/ocaml-errors-ellipsis/test-case.md
@@ -1,0 +1,23 @@
+It is possible to use ellipsis (`...`) in the error blocks attached to OCaml blocks, here it is useful as the error message depends on the OCaml version:
+
+```ocaml
+module Counter: Irmin.Contents.S with type t = int64 = struct
+ 	type t = int64
+ 	let t = Irmin.Type.int64
+```
+```mdx-error
+...
+Error: Syntax error: 'end' expected
+...
+```
+
+```ocaml
+module Counter: Irmin.Contents.S with type t = int64 = struct
+	type t = int64
+	let t = Irmin.Type.int64
+end
+```
+```mdx-error
+...
+Error: Unbound module Irmin
+```

--- a/test/bin/mdx-test/expect/ocaml-errors-ellipsis/test-case.md
+++ b/test/bin/mdx-test/expect/ocaml-errors-ellipsis/test-case.md
@@ -2,8 +2,8 @@ It is possible to use ellipsis (`...`) in the error blocks attached to OCaml blo
 
 ```ocaml
 module Counter: Irmin.Contents.S with type t = int64 = struct
- 	type t = int64
- 	let t = Irmin.Type.int64
+  type t = int64
+  let t = Irmin.Type.int64
 ```
 ```mdx-error
 ...
@@ -13,8 +13,8 @@ Error: Syntax error: 'end' expected
 
 ```ocaml
 module Counter: Irmin.Contents.S with type t = int64 = struct
-	type t = int64
-	let t = Irmin.Type.int64
+  type t = int64
+  let t = Irmin.Type.int64
 end
 ```
 ```mdx-error

--- a/test/bin/mdx-test/expect/ocaml-errors/test-case.md
+++ b/test/bin/mdx-test/expect/ocaml-errors/test-case.md
@@ -1,0 +1,61 @@
+The errors raised when evaluating OCaml blocks are displayed in a `mdx-error` block, that is immediately following the `ocaml` block it is attached to:
+
+```ocaml
+module Counter: Irmin.Contents.S with type t = int64 = struct
+	type t = int64
+	let t = Irmin.Type.int64
+```
+```mdx-error
+Line 4, characters 3-3:
+Error: Syntax error: 'end' expected
+Line 1, characters 56-62:
+  This 'struct' might be unmatched
+```
+
+Existing empty errors blocks are filled:
+
+```ocaml
+module Counter: Irmin.Contents.S with type t = int64 = struct
+	type t = int64
+	let t = Irmin.Type.int64
+end
+```
+```mdx-error
+```
+
+Or updated:
+
+```ocaml
+module Counter: Irmin.Contents.S with type t = int64 = struct
+	type t = int64
+	let t = Irmin.Type.int64
+end
+```
+```mdx-error
+Line 4, characters 3-3:
+Error: Syntax error: 'end' expected
+Line 1, characters 56-62:
+  This 'struct' might be unmatched
+```
+
+If no error is raised, no error block must be attached:
+
+```ocaml
+module Counter = struct
+	type t = int64
+end
+```
+
+Existing error blocks attached to a valid ocaml block are removed:
+
+```ocaml
+module Counter = struct
+	type t = int64
+end
+```
+```mdx-error
+Line 4, characters 3-3:
+Error: Syntax error: 'end' expected
+Line 1, characters 56-62:
+  This 'struct' might be unmatched
+```

--- a/test/bin/mdx-test/expect/ocaml-errors/test-case.md
+++ b/test/bin/mdx-test/expect/ocaml-errors/test-case.md
@@ -3,11 +3,11 @@ The errors raised when evaluating OCaml blocks are displayed in a `mdx-error` bl
 
 ```ocaml version<4.08
 module Counter: Irmin.Contents.S with type t = int64 = struct
-	type t = int64
-	let t = Irmin.Type.int64
+  type t = int64
+  let t = Irmin.Type.int64
 ```
 ```mdx-error
-Characters 110-110:
+Characters 112-112:
 Error: Syntax error: 'end' expected
 Characters 55-61:
 Error: This 'struct' might be unmatched
@@ -16,8 +16,8 @@ Error: This 'struct' might be unmatched
 
 ```ocaml version>=4.08
 module Counter: Irmin.Contents.S with type t = int64 = struct
-	type t = int64
-	let t = Irmin.Type.int64
+  type t = int64
+  let t = Irmin.Type.int64
 ```
 ```mdx-error
 Line 4, characters 3-3:
@@ -31,7 +31,7 @@ If no error is raised, no error block must be attached:
 
 ```ocaml
 module Counter = struct
-	type t = int64
+  type t = int64
 end
 ```
 
@@ -39,7 +39,7 @@ Existing error blocks attached to a valid ocaml block are removed:
 
 ```ocaml
 module Counter = struct
-	type t = int64
+  type t = int64
 end
 ```
 ```mdx-error

--- a/test/bin/mdx-test/expect/ocaml-errors/test-case.md
+++ b/test/bin/mdx-test/expect/ocaml-errors/test-case.md
@@ -1,6 +1,20 @@
 The errors raised when evaluating OCaml blocks are displayed in a `mdx-error` block, that is immediately following the `ocaml` block it is attached to:
 
-```ocaml
+
+```ocaml version<4.08
+module Counter: Irmin.Contents.S with type t = int64 = struct
+	type t = int64
+	let t = Irmin.Type.int64
+```
+```mdx-error
+Characters 110-110:
+Error: Syntax error: 'end' expected
+Characters 55-61:
+Error: This 'struct' might be unmatched
+```
+
+
+```ocaml version>=4.08
 module Counter: Irmin.Contents.S with type t = int64 = struct
 	type t = int64
 	let t = Irmin.Type.int64
@@ -12,31 +26,6 @@ Line 1, characters 56-62:
   This 'struct' might be unmatched
 ```
 
-Existing empty errors blocks are filled:
-
-```ocaml
-module Counter: Irmin.Contents.S with type t = int64 = struct
-	type t = int64
-	let t = Irmin.Type.int64
-end
-```
-```mdx-error
-```
-
-Or updated:
-
-```ocaml
-module Counter: Irmin.Contents.S with type t = int64 = struct
-	type t = int64
-	let t = Irmin.Type.int64
-end
-```
-```mdx-error
-Line 4, characters 3-3:
-Error: Syntax error: 'end' expected
-Line 1, characters 56-62:
-  This 'struct' might be unmatched
-```
 
 If no error is raised, no error block must be attached:
 

--- a/test/bin/mdx-test/expect/ocaml-errors/test-case.md.expected
+++ b/test/bin/mdx-test/expect/ocaml-errors/test-case.md.expected
@@ -1,0 +1,55 @@
+The errors raised when evaluating OCaml blocks are displayed in a `mdx-error` block, that is immediately following the `ocaml` block it is attached to:
+
+```ocaml
+module Counter: Irmin.Contents.S with type t = int64 = struct
+	type t = int64
+	let t = Irmin.Type.int64
+```
+```mdx-error
+Line 4, characters 3-3:
+Error: Syntax error: 'end' expected
+Line 1, characters 56-62:
+  This 'struct' might be unmatched
+```
+
+Existing empty errors blocks are filled:
+
+```ocaml
+module Counter: Irmin.Contents.S with type t = int64 = struct
+	type t = int64
+	let t = Irmin.Type.int64
+end
+```
+```mdx-error
+Line 3, characters 12-28:
+Error: Unbound module Irmin
+```
+
+Or updated:
+
+```ocaml
+module Counter: Irmin.Contents.S with type t = int64 = struct
+	type t = int64
+	let t = Irmin.Type.int64
+end
+```
+```mdx-error
+Line 3, characters 12-28:
+Error: Unbound module Irmin
+```
+
+If no error is raised, no error block must be attached:
+
+```ocaml
+module Counter = struct
+	type t = int64
+end
+```
+
+Existing error blocks attached to a valid ocaml block are removed:
+
+```ocaml
+module Counter = struct
+	type t = int64
+end
+```

--- a/test/bin/mdx-test/expect/ocaml-errors/test-case.md.expected
+++ b/test/bin/mdx-test/expect/ocaml-errors/test-case.md.expected
@@ -1,6 +1,20 @@
 The errors raised when evaluating OCaml blocks are displayed in a `mdx-error` block, that is immediately following the `ocaml` block it is attached to:
 
-```ocaml
+
+```ocaml version<4.08
+module Counter: Irmin.Contents.S with type t = int64 = struct
+	type t = int64
+	let t = Irmin.Type.int64
+```
+```mdx-error
+Characters 110-110:
+Error: Syntax error: 'end' expected
+Characters 55-61:
+Error: This 'struct' might be unmatched
+```
+
+
+```ocaml version>=4.08
 module Counter: Irmin.Contents.S with type t = int64 = struct
 	type t = int64
 	let t = Irmin.Type.int64
@@ -12,31 +26,6 @@ Line 1, characters 56-62:
   This 'struct' might be unmatched
 ```
 
-Existing empty errors blocks are filled:
-
-```ocaml
-module Counter: Irmin.Contents.S with type t = int64 = struct
-	type t = int64
-	let t = Irmin.Type.int64
-end
-```
-```mdx-error
-Line 3, characters 12-28:
-Error: Unbound module Irmin
-```
-
-Or updated:
-
-```ocaml
-module Counter: Irmin.Contents.S with type t = int64 = struct
-	type t = int64
-	let t = Irmin.Type.int64
-end
-```
-```mdx-error
-Line 3, characters 12-28:
-Error: Unbound module Irmin
-```
 
 If no error is raised, no error block must be attached:
 

--- a/test/bin/mdx-test/expect/ocaml-errors/test-case.md.expected
+++ b/test/bin/mdx-test/expect/ocaml-errors/test-case.md.expected
@@ -3,11 +3,11 @@ The errors raised when evaluating OCaml blocks are displayed in a `mdx-error` bl
 
 ```ocaml version<4.08
 module Counter: Irmin.Contents.S with type t = int64 = struct
-	type t = int64
-	let t = Irmin.Type.int64
+  type t = int64
+  let t = Irmin.Type.int64
 ```
 ```mdx-error
-Characters 110-110:
+Characters 112-112:
 Error: Syntax error: 'end' expected
 Characters 55-61:
 Error: This 'struct' might be unmatched
@@ -16,8 +16,8 @@ Error: This 'struct' might be unmatched
 
 ```ocaml version>=4.08
 module Counter: Irmin.Contents.S with type t = int64 = struct
-	type t = int64
-	let t = Irmin.Type.int64
+  type t = int64
+  let t = Irmin.Type.int64
 ```
 ```mdx-error
 Line 4, characters 3-3:
@@ -31,7 +31,7 @@ If no error is raised, no error block must be attached:
 
 ```ocaml
 module Counter = struct
-	type t = int64
+  type t = int64
 end
 ```
 
@@ -39,6 +39,6 @@ Existing error blocks attached to a valid ocaml block are removed:
 
 ```ocaml
 module Counter = struct
-	type t = int64
+  type t = int64
 end
 ```

--- a/test/lib/test_dep.ml
+++ b/test/lib/test_dep.ml
@@ -24,7 +24,7 @@ let test_of_block =
     | Ok labels -> (
         match
           Mdx.Block.mk ~line:0 ~file:"" ~section:None ~labels ~header:None
-            ~contents:[] ~legacy_labels:false
+            ~contents:[] ~legacy_labels:false ~errors:[]
         with
         | Ok block -> block
         | Error _ -> assert false )


### PR DESCRIPTION
Fix #219
I retained the `mdx-error` block solution, that is easily extensible to toplevel blocks (#179) if we choose to