### PR TITLE
Fix toplevel parsing when phrases contain tabs 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 
 - Errors of OCaml blocks are displayed in `mdx-error` blocks, that are immediately following the `ocaml` blocks they are attached to (#238, @gpetiot)
 
+- Fix toplevel parsing when phrases contain tabs (#240, @gpetiot)
+
 #### Removed
 
 #### Security

--- a/lib/lexer_top.mll
+++ b/lib/lexer_top.mll
@@ -12,7 +12,7 @@ rule token = parse
  | _ as c        { failwith (Printf.sprintf "unexpected character '%c'. Did you forget a space after the '#' at the start of the line?" c) }
 
 and phrase acc buf = parse
-  | ("\n"* as nl) "\n  "
+  | ("\n"* as nl) "\n" ws+
       { Lexing.new_line lexbuf;
         let nl = Compat.List.init (String.length nl) (fun _ -> "") in
         phrase (nl @ Buffer.contents buf :: acc) (Buffer.create 8) lexbuf }

--- a/lib/lexer_top.mll
+++ b/lib/lexer_top.mll
@@ -12,7 +12,7 @@ rule token = parse
  | _ as c        { failwith (Printf.sprintf "unexpected character '%c'. Did you forget a space after the '#' at the start of the line?" c) }
 
 and phrase acc buf = parse
-  | ("\n"* as nl) "\n" ws+
+  | ("\n"* as nl) "\n" ("  " | "\t")
       { Lexing.new_line lexbuf;
         let nl = Compat.List.init (String.length nl) (fun _ -> "") in
         phrase (nl @ Buffer.contents buf :: acc) (Buffer.create 8) lexbuf }

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -444,6 +444,18 @@
  (action (diff sync-to-md/test-case.md.expected sync-to-md.actual)))
 
 (rule
+ (target tabs.actual)
+ (deps (package mdx) (source_tree tabs))
+ (action
+  (with-stdout-to %{target}
+   (chdir tabs
+    (run ocaml-mdx test --output - test-case.md)))))
+
+(rule
+ (alias runtest)
+ (action (diff tabs/test-case.md.expected tabs.actual)))
+
+(rule
  (target toploop-getvalue.actual)
  (deps (package mdx) (source_tree toploop-getvalue))
  (action

--- a/test/bin/mdx-test/expect/tabs/test-case.md
+++ b/test/bin/mdx-test/expect/tabs/test-case.md
@@ -1,0 +1,8 @@
+Code indented using tabulations will be reindented using spaces:
+
+```ocaml
+# let foo =
+	let bar = 14 in
+	[ bar ];;
+val foo : int list = [14]
+```

--- a/test/bin/mdx-test/expect/tabs/test-case.md.expected
+++ b/test/bin/mdx-test/expect/tabs/test-case.md.expected
@@ -1,0 +1,8 @@
+Code indented using tabulations will be reindented using spaces:
+
+```ocaml
+# let foo =
+  let bar = 14 in
+  [ bar ];;
+val foo : int list = [14]
+```


### PR DESCRIPTION
fix #179 
The phrases were not correctly split into Command/Output because of the tabs, there is no point in having a parsing error here. Other errors are correctly printed after the toplevel command they are attached to, but for that we need to correctly split the Command/Output lines.

The change of indentation is obvious when promoting the new block (no warning needs to be emitted).