### PR TITLE
Keep locations from parsing instead of recomputing the lines, providing better error messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 
 - Report `#require` directive errors (#276, @gpetiot)
 - Handle no such file exception: the input file and the values of options `--root` and `--prelude` are checked (#292, @gpetiot)
+- Keep locations from parsing instead of recomputing the lines, providing better error messages (#241, @gpetiot)
 
 #### Security
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -75,9 +75,7 @@ type section = int * string
 (** The type for sections. *)
 
 type t = {
-  line : int;
-  column : int;
-  file : string;
+  loc : Location.t;
   section : section option;
   dir : string option;
   source_trees : string list;
@@ -95,9 +93,7 @@ type t = {
 (** The type for supported code blocks. *)
 
 val mk :
-  line:int ->
-  file:string ->
-  column:int ->
+  loc:Location.t ->
   section:section option ->
   labels:Label.t list ->
   legacy_labels:bool ->
@@ -107,9 +103,7 @@ val mk :
   (t, [ `Msg of string ]) Result.result
 
 val mk_include :
-  line:int ->
-  file:string ->
-  column:int ->
+  loc:Location.t ->
   section:section option ->
   labels:Label.t list ->
   (t, [ `Msg of string ]) Result.result

--- a/lib/lexer_mdx.mll
+++ b/lib/lexer_mdx.mll
@@ -5,11 +5,7 @@ open Migrate_ast
 
 type token = [ `Block of Block.t | `Section of int * string | `Text of string ]
 
-let line_ref = ref 1
-
-let newline lexbuf =
-  Lexing.new_line lexbuf;
-  incr line_ref
+let newline lexbuf = Lexing.new_line lexbuf
 
 let labels l =
   match Label.of_string l with
@@ -48,15 +44,13 @@ rule text section = parse
                 | "..." -> `Ellipsis
                 | _ -> `Output x) e
         in
-        let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
-        let column = lexbuf.Lexing.lex_start_p.Lexing.pos_cnum in
         newline lexbuf;
-        let line = !line_ref in
         List.iter (fun _ -> newline lexbuf) contents;
+        let loc = Location.curr lexbuf in
         newline lexbuf;
         let block =
           match
-            Block.mk ~file ~line ~column ~section ~header ~contents ~labels
+            Block.mk ~loc ~section ~header ~contents ~labels
               ~legacy_labels ~errors
           with
           | Ok block -> block
@@ -71,13 +65,10 @@ rule text section = parse
         `Block block :: text section lexbuf }
   | "<!--" ws* "$MDX" ws* ([^' ' '\n']* as label_cmt) ws* "-->" ws* eol
       { let labels = labels label_cmt in
-        let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
-        let column = lexbuf.Lexing.lex_start_p.Lexing.pos_cnum in
         newline lexbuf;
-        let line = !line_ref in
-        newline lexbuf;
+        let loc = Location.curr lexbuf in
         let block =
-          match Block.mk_include ~file ~line ~column ~section ~labels with
+          match Block.mk_include ~loc ~section ~labels with
           | Ok block -> block
           | Error (`Msg msg) -> failwith msg
         in
@@ -105,14 +96,12 @@ and cram_text section = parse
         let contents = first_line :: contents in
         let labels = [] in
         let legacy_labels = false in
-        let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
-        let column = lexbuf.Lexing.lex_start_p.Lexing.pos_cnum in
-        let line = !line_ref in
+        let loc = Location.curr lexbuf in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
         let block =
           match
-            Block.mk ~file ~line ~column ~section ~header ~contents ~labels
+            Block.mk ~loc ~section ~header ~contents ~labels
               ~legacy_labels ~errors:[]
           with
           | Ok block -> block
@@ -129,15 +118,13 @@ and cram_text section = parse
           | Error (`Msg msg) -> failwith msg
         in
         let legacy_labels = false in
-        let file = lexbuf.Lexing.lex_start_p.Lexing.pos_fname in
-        let column = lexbuf.Lexing.lex_start_p.Lexing.pos_cnum in
         newline lexbuf;
-        let line = !line_ref in
+        let loc = Location.curr lexbuf in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
         let block =
           match
-            Block.mk ~file ~line ~column ~section ~header ~contents ~labels
+            Block.mk ~loc ~section ~header ~contents ~labels
               ~legacy_labels ~errors:[]
           with
           | Ok block -> block

--- a/lib/lexer_top.mll
+++ b/lib/lexer_top.mll
@@ -1,29 +1,35 @@
+{
+let newline lexbuf = Lexing.new_line lexbuf
+}
+
 let eol = '\n' | eof
 let ws = ' ' | '\t'
 
 rule token = parse
  | eof           { [] }
- | "..." ws* eol { `Ellipsis :: token lexbuf }
- | '\n'          { `Output "" :: token lexbuf }
- | "# "          { let c = phrase [] (Buffer.create 8) lexbuf in
-                   `Command c :: token lexbuf }
+ | "..." ws* eol { newline lexbuf; `Ellipsis :: token lexbuf }
+ | '\n'          { newline lexbuf; `Output "" :: token lexbuf }
+ | "# "          { let loc = Location.curr lexbuf in
+                   let c = phrase [] (Buffer.create 8) lexbuf in
+                   `Command (c, loc) :: token lexbuf }
  | ([^'#' '\n'] [^'\n']* as str) eol
-                 { `Output str :: token lexbuf }
+                 { newline lexbuf; `Output str :: token lexbuf }
  | _ as c        { failwith (Printf.sprintf "unexpected character '%c'. Did you forget a space after the '#' at the start of the line?" c) }
 
 and phrase acc buf = parse
   | ("\n"* as nl) "\n" ("  " | "\t")
-      { Lexing.new_line lexbuf;
+      { newline lexbuf;
+        for _ = 1 to (String.length nl) do
+          newline lexbuf
+        done;
         let nl = Compat.List.init (String.length nl) (fun _ -> "") in
         phrase (nl @ Buffer.contents buf :: acc) (Buffer.create 8) lexbuf }
-  | eol
-      { Lexing.new_line lexbuf;
-        List.rev (Buffer.contents buf :: acc) }
- | ";;" eol { List.rev ((Buffer.contents buf ^ ";;") :: acc) }
- | _ as c   { Buffer.add_char buf c; phrase acc buf lexbuf }
+  | eol      { newline lexbuf; List.rev (Buffer.contents buf :: acc) }
+  | ";;" eol { newline lexbuf; List.rev ((Buffer.contents buf ^ ";;") :: acc) }
+  | _ as c   { Buffer.add_char buf c; phrase acc buf lexbuf }
 
 {
 let token lexbuf =
-  try token lexbuf
+  try newline lexbuf; token lexbuf
   with Failure e -> Misc.err lexbuf "incomplete toplevel entry: %s" e
 }

--- a/lib/mli_parser.mli
+++ b/lib/mli_parser.mli
@@ -4,9 +4,5 @@ module Code_block : sig
   type t = { location : Odoc_model.Location_.span; contents : string }
 end
 
-val docstring_code_blocks : string -> Code_block.t list
-(** Parse an mli file as a string and return a list of the code blocks that appear inside
-    its docstrings. *)
-
 val parse_mli : string -> (Document.line list, [ `Msg of string ]) Result.result
 (** Slice an mli file into its [Text] and [Block] parts. *)

--- a/lib/toplevel.mli
+++ b/lib/toplevel.mli
@@ -19,7 +19,7 @@
 type t = {
   vpad : int;
   hpad : int;
-  line : int;
+  pos : Lexing.position;
   command : string list;
   output : Output.t list;
 }
@@ -41,21 +41,6 @@ val pp_command : t Fmt.t
 
 (** {2 Parser} *)
 
-val of_lines :
-  syntax:Syntax.t ->
-  file:string ->
-  line:int ->
-  column:int ->
-  string list ->
-  t list
-(** [of_lines ~file ~line ~column lines] is the list of toplevel blocks from
-   file [file] starting at line [line]. Return the vertical and
-   horizontal whitespace padding as well.*)
-
-(** {2 Accessors} *)
-
-val command : t -> string list
-(** [command t] is [t]'s command. *)
-
-val output : t -> Output.t list
-(** [output t] is [t]'s output. *)
+val of_lines : syntax:Syntax.t -> loc:Location.t -> string list -> t list
+(** [of_lines ~loc lines] is the list of toplevel blocks from location [loc].
+    Return the vertical and horizontal whitespace padding as well. *)

--- a/test/bin/mdx-pp/expect/spaces/test_case.ml.expected
+++ b/test/bin/mdx-pp/expect/spaces/test_case.ml.expected
@@ -1,4 +1,4 @@
-#5 "test-case.md"
+#7 "test-case.md"
 
 
 let x =

--- a/test/bin/mdx-test/failure/cram-command-syntax/test-case.t.expected
+++ b/test/bin/mdx-test/failure/cram-command-syntax/test-case.t.expected
@@ -1,2 +1,2 @@
-Error in the cram code block in test-case.t at line 3:
+File "test-case.t", line 3: Error in the cram code block
 Blocks must start with a command or similar, not with an output line. To indicate a line as a command, start it with a dollar followed by a space.

--- a/test/bin/mdx-test/failure/cram-empty-line/test-case.t.expected
+++ b/test/bin/mdx-test/failure/cram-empty-line/test-case.t.expected
@@ -1,2 +1,2 @@
-Error in the cram code block in test-case.t at line 5:
+File "test-case.t", line 5: Error in the cram code block
 Blocks must start with a command or similar, not with an output line. Please, make sure that there's no spare empty line, particularly between the output and its input.

--- a/test/bin/mdx-test/failure/in-toplevel/test-case.md.expected
+++ b/test/bin/mdx-test/failure/in-toplevel/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the OCaml file include code block in test-case.md at line 4:
+File "test-case.md", lines 3-5: Error in the OCaml file include code block
 ./not_found.ml: No such file or directory

--- a/test/bin/mdx-test/failure/ml-file-not-found/test-case.md.expected
+++ b/test/bin/mdx-test/failure/ml-file-not-found/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the OCaml file include code block in test-case.md at line 4:
+File "test-case.md", lines 3-4: Error in the OCaml file include code block
 ./not_found.ml: No such file or directory

--- a/test/bin/mdx-test/failure/part-not-ended/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-not-ended/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the OCaml file include code block in test-case.md at line 3:
+File "test-case.md", lines 2-3: Error in the OCaml file include code block
 In file ./parts-begin-end.ml, line 18: Part toto has no end.

--- a/test/bin/mdx-test/failure/part-not-found/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-not-found/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the OCaml file include code block in test-case.md at line 4:
+File "test-case.md", lines 3-4: Error in the OCaml file include code block
 Cannot find part "part1" in ./part_not_found.ml

--- a/test/bin/mdx-test/failure/part-not-opened/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-not-opened/test-case.md.expected
@@ -1,2 +1,2 @@
-Error in the OCaml file include code block in test-case.md at line 3:
+File "test-case.md", lines 2-3: Error in the OCaml file include code block
 In file ./parts-begin-end.ml, line 6: There is no part to end.

--- a/test/lib/test_block.ml
+++ b/test/lib/test_block.ml
@@ -53,7 +53,7 @@ let test_mk =
     let test_name = Printf.sprintf "mk: %S" name in
     let test_fun () =
       let actual =
-        Mdx.Block.mk ~line:0 ~file:"" ~column:0 ~section:None ~labels
+        Mdx.Block.mk ~loc:Location.none ~section:None ~labels
           ~legacy_labels:false ~header ~contents ~errors:[]
       in
       Alcotest.(check (result Testable.block Testable.msg))

--- a/test/lib/test_dep.ml
+++ b/test/lib/test_dep.ml
@@ -25,8 +25,8 @@ let test_of_block =
     match Mdx.Label.of_string s with
     | Ok labels -> (
         match
-          Mdx.Block.mk ~line:0 ~file:"" ~column:0 ~section:None ~labels
-            ~header:None ~contents:[] ~legacy_labels:false ~errors:[]
+          Mdx.Block.mk ~loc:Location.none ~section:None ~labels ~header:None
+            ~contents:[] ~legacy_labels:false ~errors:[]
         with
         | Ok block -> block
         | Error _ -> assert false )

--- a/test/lib/test_mli_parser.ml
+++ b/test/lib/test_mli_parser.ml
@@ -44,28 +44,26 @@ let test_parse_mli =
         (Ok
            {x|[Text "\n(** This is a doc comment with some code blocks in it:\n\n    ";
  Text "{[";
- Block {file: ; line: 4; column: 4; section: None; labels: [];
+ Block {loc: File "_none_", lines 4-7; section: None; labels: [];
         header: Some ocaml;
-                contents: ["# List.map (fun x -> x * x) [(1 + 9); 2; 3]";
-                           "- : int list = [100; 4; 9]"];
+        contents: ["# List.map (fun x -> x * x) [(1 + 9); 2; 3]";
+                   "- : int list = [100; 4; 9]"];
         value: Toplevel};
  Text "    ]}"; Text "\n\n    "; Text "{[";
- Block {file: ; line: 9; column: 4; section: None; labels: [];
+ Block {loc: File "_none_", line 9; section: None; labels: [];
         header: Some ocaml;
-                contents: ["List.map (fun x -> x * x) [1; 2; 3]"];
-        value: OCaml};
+        contents: ["List.map (fun x -> x * x) [1; 2; 3]"]; value: OCaml};
  Text "]}"; Text "\n\n    "; Text "{[";
- Block {file: ; line: 11; column: 4; section: None; labels: [];
+ Block {loc: File "_none_", lines 11-16; section: None; labels: [];
         header: Some ocaml;
-                contents: ["# List.map (fun x -> x * x) [(1 + 9); 2; 3]";
-                           "- : int list = [100; 4; 9]";
-                           "# List.map (fun x -> x * x) [1; 2; 3]";
-                           "- : int list = [1; 4; 9]"];
+        contents: ["# List.map (fun x -> x * x) [(1 + 9); 2; 3]";
+                   "- : int list = [100; 4; 9]";
+                   "# List.map (fun x -> x * x) [1; 2; 3]";
+                   "- : int list = [1; 4; 9]"];
         value: Toplevel};
  Text "    ]}"; Text "\n*)\nval foo : string\n\n(** "; Text "{[";
- Block {file: ; line: 20; column: 4; section: None; labels: [];
-        header: Some ocaml;
-                contents: ["1 + 1 = 3"]; value: OCaml};
+ Block {loc: File "_none_", line 20; section: None; labels: [];
+        header: Some ocaml; contents: ["1 + 1 = 3"]; value: OCaml};
  Text "]}";|x})
       ();
   ]


### PR DESCRIPTION
The idea was to remove the line computation that was taking place in `toplevel.ml` and avoid passing the pair (filename, line) from function to function, we have more precise locations from the parser.