### PR TITLE
Adopt new dune rule syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ To test that the code blocks of `file.md` stay consistent, one can use
 dune's `diff?` stanza:
 
 ```
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (deps (:test file.md))
   (action (progn
            (run ocaml-mdx test %{test})
@@ -366,8 +366,8 @@ $ ocaml-mdx rule test/dune_rules.md
 
 generates the following `dune` rules on the standard output:
 ```
-(alias
- (name   runtest)
+(rule
+ (alias   runtest)
  (deps   (:x test/dune_rules.md)
          (:y1 dune_rules_1.ml)
          (:y0 dune_rules_2.ml)

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -79,8 +79,8 @@ let pp_rules ~nd ~prelude ~md_file ~ml_files ~dirs ~root ~packages ~locks fmt
   in
   let pp fmt name arg =
     Fmt.pf fmt
-      "(alias@\n\
-      \ (name   %s)@\n\
+      "(rule@\n\
+      \ (alias   %s)@\n\
       \ (deps   @[<v>%a@])@\n\
        %a (action @[<hv 2>(progn@ %a)@]))@\n"
       name

--- a/test/bin/mdx-rule/misc/duniverse-mode/dune.gen.expected
+++ b/test/bin/mdx-rule/misc/duniverse-mode/dune.gen.expected
@@ -1,5 +1,5 @@
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (:x duniverse-mode.md)
   (package block)


### PR DESCRIPTION
Updating mdx rule command to use the syntax required in newer dune versions (tested with dune 2.4.0)