### PR TITLE
Preseve choice of `bash` versus `sh` in code fences

### DIFF
--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -308,7 +308,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
           in
           with_non_det non_deterministic non_det ~command:print_block
             ~output:det ~det
-      | Cram { header = _; non_det } ->
+      | Cram { language = _; non_det } ->
           let pad, tests = Cram.of_lines t.contents in
           with_non_det non_deterministic non_det ~command:print_block
             ~output:(fun () ->

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -308,7 +308,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
           in
           with_non_det non_deterministic non_det ~command:print_block
             ~output:det ~det
-      | Cram { non_det } ->
+      | Cram { header = _; non_det } ->
           let pad, tests = Cram.of_lines t.contents in
           with_non_det non_deterministic non_det ~command:print_block
             ~output:(fun () ->

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -44,7 +44,7 @@ end
 
 type section = int * string
 
-type cram_value = { header : Header.t option; non_det : Label.non_det option }
+type cram_value = { language : [ `Sh | `Bash ]; non_det : Label.non_det option }
 
 type ocaml_value = {
   env : Env.t;
@@ -99,7 +99,7 @@ let header t =
   match t.value with
   | Raw b -> b.header
   | OCaml _ -> Some Header.OCaml
-  | Cram { header; _ } -> header
+  | Cram { language; _ } -> Some (Header.Shell language)
   | Toplevel _ -> Some Header.OCaml
   | Include { file_kind = Fk_ocaml _; _ } -> Some Header.OCaml
   | Include { file_kind = Fk_other b; _ } -> b.header
@@ -377,10 +377,10 @@ let mk ~line ~file ~column ~section ~labels ~legacy_labels ~header ~contents
   | None -> (
       check_not_set "`part` label requires a `file` label." part >>= fun () ->
       match header with
-      | Some (Header.Shell _) ->
+      | Some (Header.Shell language) ->
           check_no_errors errors >>= fun () ->
           check_not_set "`env` label cannot be used with a `shell` header." env
-          >>= fun () -> Ok (Cram { header; non_det })
+          >>= fun () -> Ok (Cram { language; non_det })
       | Some Header.OCaml -> (
           let env = Env.mk env in
           match guess_ocaml_kind contents with

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -34,7 +34,7 @@ end
 
 (** Code blocks. *)
 
-type cram_value = { header : Header.t option; non_det : Label.non_det option }
+type cram_value = { language : [ `Bash | `Sh ]; non_det : Label.non_det option }
 
 type ocaml_value = {
   env : Env.t;

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -17,7 +17,7 @@
 (** Code blocks headers. *)
 
 module Header : sig
-  type t = Shell | OCaml | Other of string
+  type t = Shell of [ `Sh | `Bash ] | OCaml | Other of string
 
   val pp : Format.formatter -> t -> unit
 
@@ -34,7 +34,7 @@ end
 
 (** Code blocks. *)
 
-type cram_value = { non_det : Label.non_det option }
+type cram_value = { header : Header.t option; non_det : Label.non_det option }
 
 type ocaml_value = {
   env : Env.t;

--- a/lib/lexer_mdx.mll
+++ b/lib/lexer_mdx.mll
@@ -84,7 +84,7 @@ and cram_text section = parse
         newline lexbuf;
         `Section section :: cram_text (Some section) lexbuf }
   | "  " ([^'\n']* as first_line) eol
-      { let header = Some Block.Header.Shell in
+      { let header = Some (Block.Header.Shell `Sh) in
         let requires_empty_line, contents = cram_block lexbuf in
         let contents = first_line :: contents in
         let labels = [] in
@@ -105,7 +105,7 @@ and cram_text section = parse
         `Block block
         :: (if requires_empty_line then `Text "" :: rest else rest) }
   | "<-- non-deterministic" ws* ([^'\n']* as choice) eol
-      { let header = Some Block.Header.Shell in
+      { let header = Some (Block.Header.Shell `Sh) in
         let requires_empty_line, contents = cram_block lexbuf in
         let labels =
           match Label.interpret "non-deterministic" (Some (Eq, choice)) with

--- a/test/bin/mdx-test/expect/bash-fence/test-case.md
+++ b/test/bin/mdx-test/expect/bash-fence/test-case.md
@@ -7,3 +7,13 @@ $ echo 'bash block runs'
 ```sh
 $ echo 'sh block runs'
 ```
+
+Even when the blocks are skipped:
+
+<!-- $MDX skip -->
+```bash
+```
+
+<!-- $MDX skip -->
+```sh
+```

--- a/test/bin/mdx-test/expect/bash-fence/test-case.md
+++ b/test/bin/mdx-test/expect/bash-fence/test-case.md
@@ -1,0 +1,9 @@
+The choice of `bash` vs. `sh` code fences should be preserved:
+
+```bash
+$ echo 'bash block runs'
+```
+
+```sh
+$ echo 'sh block runs'
+```

--- a/test/bin/mdx-test/expect/bash-fence/test-case.md.expected
+++ b/test/bin/mdx-test/expect/bash-fence/test-case.md.expected
@@ -1,0 +1,11 @@
+The choice of `bash` vs. `sh` code fences should be preserved:
+
+```bash
+$ echo 'bash block runs'
+bash block runs
+```
+
+```sh
+$ echo 'sh block runs'
+sh block runs
+```

--- a/test/bin/mdx-test/expect/bash-fence/test-case.md.expected
+++ b/test/bin/mdx-test/expect/bash-fence/test-case.md.expected
@@ -9,3 +9,15 @@ bash block runs
 $ echo 'sh block runs'
 sh block runs
 ```
+
+Even when the blocks are skipped:
+
+<!-- $MDX skip -->
+```bash
+
+```
+
+<!-- $MDX skip -->
+```sh
+
+```

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -1,5 +1,17 @@
 
 (rule
+ (target bash-fence.actual)
+ (deps (package mdx) (source_tree bash-fence))
+ (action
+  (with-stdout-to %{target}
+   (chdir bash-fence
+    (run ocaml-mdx test --output - test-case.md)))))
+
+(rule
+ (alias runtest)
+ (action (diff bash-fence/test-case.md.expected bash-fence.actual)))
+
+(rule
  (target casual-file-inc.actual)
  (deps (package mdx) (source_tree casual-file-inc))
  (action


### PR DESCRIPTION
This resolves https://github.com/realworldocaml/mdx/issues/247.

- store shell language choice in block headers;
- track header information on cram blocks (if it exists).