### PR TITLE
Support underscores in enviroment variables

### DIFF
--- a/lib/label.ml
+++ b/lib/label.ml
@@ -51,7 +51,7 @@ module Relation = struct
     @@ seq
          [
            bos;
-           group (rep (alt [ alnum; char '-' ]));
+           group (rep (alt [ alnum; char '-'; char '_' ]));
            group
              (alt [ str "<="; str ">="; str "<>"; str "<"; str ">"; str "=" ]);
            group (rep any);

--- a/test/bin/mdx-test/expect/environment-variable-set/test-case.md
+++ b/test/bin/mdx-test/expect/environment-variable-set/test-case.md
@@ -38,3 +38,11 @@ And the variable stays available in subsequent blocks.
   $ echo $BOO
   far
 ```
+
+Environment variables can contain underscores
+
+<!-- $MDX set-TWO_WORDS=success -->
+```sh
+  $ echo $TWO_WORDS
+  success
+```

--- a/test/lib/test_label.ml
+++ b/test/lib/test_label.ml
@@ -26,6 +26,8 @@ let test_raw_parse =
     make_test ~input:"foo<=bar" ~expected:("foo", Some (Le, "bar"));
     make_test ~input:"foo>bar" ~expected:("foo", Some (Gt, "bar"));
     make_test ~input:">=" ~expected:("", Some (Ge, ""));
+    make_test ~input:"FOO_BAR=foo_bar"
+      ~expected:("FOO_BAR", Some (Eq, "foo_bar"));
   ]
 
 let test_interpret =


### PR DESCRIPTION
Closes #254

The last two commits are just tidying up which I assumed would be useful given

1. The explanation in https://github.com/realworldocaml/mdx/issues/255#issuecomment-617164205 that the HTML comment-based notation is now the preferred way to set flags
2. The presence of an `.ocamlformat` file.

Let me know if you'd rather I drop those commits :)
