### PR TITLE
Preserve indentation of included file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@
 
 - Avoid adding newlines to empty blocks (#253, @gpetiot)
 
+- Preserve the indentation of included files (#259, @gpetiot)
+
 #### Removed
 
 #### Security

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -230,7 +230,8 @@ let read_part file part =
         file
   | Some lines ->
       let contents = String.concat ~sep:"\n" lines in
-      String.trim contents ~drop:(function '\n' -> true | _ -> false)
+      String.drop contents ~rev:true ~sat:Char.Ascii.is_white
+      |> String.drop ~sat:(function '\n' -> true | _ -> false)
 
 let write_parts ~force_output file parts =
   let output_file = file ^ ".corrected" in

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -230,7 +230,7 @@ let read_part file part =
         file
   | Some lines ->
       let contents = String.concat ~sep:"\n" lines in
-      String.trim contents
+      String.trim contents ~drop:(function '\n' -> true | _ -> false)
 
 let write_parts ~force_output file parts =
   let output_file = file ^ ".corrected" in

--- a/test/bin/mdx-test/expect/parts-begin-end/parts-begin-end.ml
+++ b/test/bin/mdx-test/expect/parts-begin-end/parts-begin-end.ml
@@ -32,5 +32,5 @@ let () =
 let () =
 (* $MDX part-begin=indented *)
   let () = fooooooooooooooooooooooooooooooooooooooooooo in
-  if not fooooooooo then foooooooooooo
+  if not fooooooooo then foooooooooooo  
 (* $MDX part-end *)

--- a/test/bin/mdx-test/expect/parts-begin-end/parts-begin-end.ml
+++ b/test/bin/mdx-test/expect/parts-begin-end/parts-begin-end.ml
@@ -28,3 +28,9 @@ let () =
   f x print_int;
 (* $MDX part-end *)
   ()
+
+let () =
+(* $MDX part-begin=indented *)
+  let () = fooooooooooooooooooooooooooooooooooooooooooo in
+  if not fooooooooo then foooooooooooo
+(* $MDX part-end *)

--- a/test/bin/mdx-test/expect/parts-begin-end/test-case.md
+++ b/test/bin/mdx-test/expect/parts-begin-end/test-case.md
@@ -30,3 +30,6 @@ val x : int = 2
 3
 - : unit = ()
 ```
+
+```ocaml file=parts-begin-end.ml,part=indented
+```

--- a/test/bin/mdx-test/expect/parts-begin-end/test-case.md.expected
+++ b/test/bin/mdx-test/expect/parts-begin-end/test-case.md.expected
@@ -49,6 +49,10 @@ let () =
 let () =
   f x print_int;
   ()
+
+let () =
+  let () = fooooooooooooooooooooooooooooooooooooooooooo in
+  if not fooooooooo then foooooooooooo
 ```
 
 ```ocaml
@@ -57,4 +61,9 @@ val x : int = 2
 # print_int x;;
 2
 - : unit = ()
+```
+
+```ocaml file=parts-begin-end.ml,part=indented
+  let () = fooooooooooooooooooooooooooooooooooooooooooo in
+  if not fooooooooo then foooooooooooo
 ```


### PR DESCRIPTION
Fix #258 
I chose to keep the indentation as is. Removing it completely is a bad solution (as all lines don't necessarily have the same indentation level). The solution of decreasing the indentation of all lines by the minimum indentation among all lines (not necessary the first) is more complicated.

Also keeping it as-is allows to have a better understanding of how the code is related to other code blocks (maybe more obvious if the indentation is printed as a special character or something)