### PR TITLE
Properly report parsing errors

### DIFF
--- a/bin/deps.ml
+++ b/bin/deps.ml
@@ -22,7 +22,7 @@ let run (`Setup ()) (`Syntax syntax) (`File file) =
     | Some s, _ | None, Some s -> s
     | None, None ->
         Printf.eprintf
-          "Fatal error: could not infer syntax from filename %s, use the \
+          "[mdx] Fatal error: could not infer syntax from filename %s, use the \
            --syntax option to specify a syntax.\n"
           file;
         exit 1

--- a/bin/deps.ml
+++ b/bin/deps.ml
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Mdx.Util.Result.Infix
+
 let run (`Setup ()) (`Syntax syntax) (`File file) =
   let syntax =
     match (syntax, Mdx.Syntax.infer ~file) with
@@ -25,15 +27,11 @@ let run (`Setup ()) (`Syntax syntax) (`File file) =
           file;
         exit 1
   in
-  match Mdx.parse_file syntax file with
-  | Ok doc ->
-      let deps = Mdx.Dep.of_lines doc in
-      let deps = List.map Mdx.Dep.to_sexp deps in
-      Printf.printf "%s" (Mdx.Util.Sexp.Canonical.to_string (List deps));
-      0
-  | Error (`Msg e) ->
-      Printf.eprintf "Fatal error while parsing file: %s" e;
-      1
+  Mdx.parse_file syntax file >>! fun doc ->
+  let deps = Mdx.Dep.of_lines doc in
+  let deps = List.map Mdx.Dep.to_sexp deps in
+  Printf.printf "%s" (Mdx.Util.Sexp.Canonical.to_string (List deps));
+  0
 
 let cmd =
   let open Cmdliner in

--- a/bin/deps.ml
+++ b/bin/deps.ml
@@ -25,11 +25,15 @@ let run (`Setup ()) (`Syntax syntax) (`File file) =
           file;
         exit 1
   in
-  let doc = Mdx.parse_file syntax file in
-  let deps = Mdx.Dep.of_lines doc in
-  let deps = List.map Mdx.Dep.to_sexp deps in
-  Printf.printf "%s" (Mdx.Util.Sexp.Canonical.to_string (List deps));
-  0
+  match Mdx.parse_file syntax file with
+  | Ok doc ->
+      let deps = Mdx.Dep.of_lines doc in
+      let deps = List.map Mdx.Dep.to_sexp deps in
+      Printf.printf "%s" (Mdx.Util.Sexp.Canonical.to_string (List deps));
+      0
+  | Error (`Msg e) ->
+      Printf.eprintf "Fatal error while parsing file: %s" e;
+      1
 
 let cmd =
   let open Cmdliner in

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -19,33 +19,39 @@ let src = Logs.Src.create "cram.pp"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let run (`Setup ()) (`File file) (`Section section) =
-  let t = Mdx.parse_file Normal file in
-  let t =
-    match section with
-    | None -> t
-    | Some s -> (
-        let re = Re.Perl.compile_pat s in
-        match Mdx.filter_section re t with None -> [] | Some t -> t )
-  in
-  match t with
-  | [] -> 1
-  | _ ->
-      List.iter
-        (function
-          | Mdx.Section _ | Text _ -> ()
-          | Block b ->
-              if not (Mdx.Block.skip b) then (
-                Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
-                let pp_lines = Fmt.(list ~sep:(unit "\n") string) in
-                let contents = Mdx.Block.executable_contents ~syntax:Normal b in
-                match b.value with
-                | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
-                | OCaml _ ->
-                    Fmt.pr "%a\n%a\n" Mdx.Block.pp_line_directive (file, b.line)
-                      pp_lines contents
-                | _ -> () ))
-        t;
-      0
+  match Mdx.parse_file Normal file with
+  | Ok t -> (
+      let t =
+        match section with
+        | None -> t
+        | Some s -> (
+            let re = Re.Perl.compile_pat s in
+            match Mdx.filter_section re t with None -> [] | Some t -> t )
+      in
+      match t with
+      | [] -> 1
+      | _ ->
+          List.iter
+            (function
+              | Mdx.Section _ | Text _ -> ()
+              | Block b ->
+                  if not (Mdx.Block.skip b) then (
+                    Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
+                    let pp_lines = Fmt.(list ~sep:(unit "\n") string) in
+                    let contents =
+                      Mdx.Block.executable_contents ~syntax:Normal b
+                    in
+                    match b.value with
+                    | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
+                    | OCaml _ ->
+                        Fmt.pr "%a\n%a\n" Mdx.Block.pp_line_directive
+                          (file, b.line) pp_lines contents
+                    | _ -> () ))
+            t;
+          0 )
+  | Error (`Msg e) ->
+      Printf.eprintf "Fatal error while parsing file: %s" e;
+      1
 
 open Cmdliner
 

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -244,11 +244,7 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax)
   in
   Mdx.Deprecated.warn "ocaml-mdx rule" ~since:"1.7.0"
     ~replacement:"the mdx stanza";
-  match Mdx.run ?syntax md_file ~f:on_file with
-  | Ok () -> 0
-  | Error (`Msg e) ->
-      Printf.eprintf "Fatal error while parsing file: %s" e;
-      1
+  Mdx.run ?syntax md_file ~f:on_file >>! fun () -> 0
 
 open Cmdliner
 

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -224,7 +224,7 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax)
     in
     match req_res with
     | Error s ->
-        Printf.eprintf "Fatal error while parsing block: %s" s;
+        Printf.eprintf "[mdx] Fatal error while parsing block: %s\n" s;
         exit 1
     | Ok (ml_files, dirs, nd, packages) ->
         let packages =

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -244,8 +244,11 @@ let run (`Setup ()) (`File md_file) (`Section section) (`Syntax syntax)
   in
   Mdx.Deprecated.warn "ocaml-mdx rule" ~since:"1.7.0"
     ~replacement:"the mdx stanza";
-  Mdx.run ?syntax md_file ~f:on_file;
-  0
+  match Mdx.run ?syntax md_file ~f:on_file with
+  | Ok () -> 0
+  | Error (`Msg e) ->
+      Printf.eprintf "Fatal error while parsing file: %s" e;
+      1
 
 open Cmdliner
 

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -18,6 +18,7 @@ open Mdx
 open Compat
 open Result
 open Astring
+open Mdx.Util.Result.Infix
 
 let src = Logs.Src.create "cram.test"
 
@@ -364,19 +365,14 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
     Format.pp_print_flush ppf ();
     Buffer.contents buf
   in
-  match
-    match (output : Cli.output option) with
-    | Some Stdout -> Mdx.run_to_stdout ?syntax ~f:gen_corrected file
-    | Some (File outfile) ->
-        Mdx.run_to_file ?syntax ~outfile ~f:gen_corrected file
-    | None -> Mdx.run ?syntax ~force_output ~f:gen_corrected file
-  with
-  | Ok () ->
-      Hashtbl.iter (write_parts ~force_output) files;
-      0
-  | Error (`Msg e) ->
-      Printf.eprintf "Fatal error while parsing file: %s" e;
-      1
+  ( match (output : Cli.output option) with
+  | Some Stdout -> Mdx.run_to_stdout ?syntax ~f:gen_corrected file
+  | Some (File outfile) ->
+      Mdx.run_to_file ?syntax ~outfile ~f:gen_corrected file
+  | None -> Mdx.run ?syntax ~force_output ~f:gen_corrected file )
+  >>! fun () ->
+  Hashtbl.iter (write_parts ~force_output) files;
+  0
 
 let report_error_in_block block msg =
   let kind =

--- a/lib/compat.ml
+++ b/lib/compat.ml
@@ -49,6 +49,10 @@ module String = struct
 
   let index_opt s c = index_rec_opt s (length s) 0 c
 #endif
+
+#if OCAML_VERSION < (4, 3, 0)
+  let capitalize_ascii = String.capitalize (* deprecated >= 4.3.0 *)
+#endif
 end
 
 module Filename = struct

--- a/lib/lexer_mdx.mli
+++ b/lib/lexer_mdx.mli
@@ -1,5 +1,6 @@
 type token = [ `Block of Block.t | `Section of int * string | `Text of string ]
 
-val markdown_token : Lexing.lexbuf -> (token list, [ `Msg of string ]) Result.t
+val markdown_token :
+  Lexing.lexbuf -> (token list, [ `Msg of string ]) Result.result
 
-val cram_token : Lexing.lexbuf -> (token list, [ `Msg of string ]) Result.t
+val cram_token : Lexing.lexbuf -> (token list, [ `Msg of string ]) Result.result

--- a/lib/lexer_mdx.mli
+++ b/lib/lexer_mdx.mli
@@ -1,0 +1,5 @@
+type token = [ `Block of Block.t | `Section of int * string | `Text of string ]
+
+val markdown_token : Lexing.lexbuf -> (token list, [ `Msg of string ]) Result.t
+
+val cram_token : Lexing.lexbuf -> (token list, [ `Msg of string ]) Result.t

--- a/lib/lexer_mdx.mll
+++ b/lib/lexer_mdx.mll
@@ -149,10 +149,16 @@ and cram_block = parse
     with
     | Failure e ->
       let loc = Location.curr lexbuf in
-      Util.Result.errorf "%a: invalid code block: %s" Location.print_loc loc e
+      let msg =
+        Format.asprintf "%a: invalid code block: %s" Location.print_loc loc e
+      in
+      Util.Result.errorf "%s" msg
     | exn ->
       let loc = Location.curr lexbuf in
-      Util.Result.errorf "%a: %s" Location.print_loc loc (Printexc.to_string exn)
+      let msg =
+        Format.asprintf "%a: %s" Location.print_loc loc (Printexc.to_string exn)
+      in
+      Util.Result.errorf "%s" msg
 
 
 let cram_token lexbuf =
@@ -160,8 +166,14 @@ let cram_token lexbuf =
     with
     | Failure e ->
       let loc = Location.curr lexbuf in
-      Util.Result.errorf "%a: invalid code block: %s" Location.print_loc loc e
+      let msg =
+        Format.asprintf "%a: invalid code block: %s" Location.print_loc loc e
+      in
+      Util.Result.errorf "%s" msg
     | exn ->
       let loc = Location.curr lexbuf in
-      Util.Result.errorf "%a: %s" Location.print_loc loc (Printexc.to_string exn)
+      let msg =
+        Format.asprintf "%a: %s" Location.print_loc loc (Printexc.to_string exn)
+      in
+      Util.Result.errorf "%s" msg
 }

--- a/lib/lexer_mdx.mll
+++ b/lib/lexer_mdx.mll
@@ -2,6 +2,8 @@
 open Result
 open Astring
 
+type token = [ `Block of Block.t | `Section of int * string | `Text of string ]
+
 let line_ref = ref 1
 
 let newline lexbuf =
@@ -142,12 +144,23 @@ and cram_block = parse
 
 {
   let markdown_token lexbuf =
-    try
-      text None lexbuf
-    with Failure e -> Misc.err lexbuf "invalid code block: %s" e
+    try Ok (text None lexbuf)
+    with
+    | Failure e ->
+      let loc = Location.curr lexbuf in
+      Util.Result.errorf "%a: invalid code block: %s" Location.print_loc loc e
+    | exn ->
+      let loc = Location.curr lexbuf in
+      Util.Result.errorf "%a: %s" Location.print_loc loc (Printexc.to_string exn)
+
 
 let cram_token lexbuf =
-    try
-      cram_text None lexbuf
-    with Failure e -> Misc.err lexbuf "invalid code block: %s" e
+    try Ok (cram_text None lexbuf)
+    with
+    | Failure e ->
+      let loc = Location.curr lexbuf in
+      Util.Result.errorf "%a: invalid code block: %s" Location.print_loc loc e
+    | exn ->
+      let loc = Location.curr lexbuf in
+      Util.Result.errorf "%a: %s" Location.print_loc loc (Printexc.to_string exn)
 }

--- a/lib/lexer_mdx.mll
+++ b/lib/lexer_mdx.mll
@@ -1,6 +1,7 @@
 {
 open Result
 open Astring
+open Migrate_ast
 
 type token = [ `Block of Block.t | `Section of int * string | `Text of string ]
 

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -48,15 +48,15 @@ val dump : line list Fmt.t
 
 (** {2 Document} *)
 
-val of_string : syntax -> string -> (t, [ `Msg of string ]) Result.t
+val of_string : syntax -> string -> (t, [ `Msg of string ]) Result.result
 (** [of_string syntax s] is the document [t] such that
     [to_string ~syntax t = s]. *)
 
-val parse_file : syntax -> string -> (t, [ `Msg of string ]) Result.t
+val parse_file : syntax -> string -> (t, [ `Msg of string ]) Result.result
 (** [parse_file s] is {!of_string} of [s]'s contents. *)
 
 val parse_lexbuf :
-  string -> syntax -> Lexing.lexbuf -> (t, [ `Msg of string ]) Result.t
+  string -> syntax -> Lexing.lexbuf -> (t, [ `Msg of string ]) Result.result
 (** [parse_lexbuf l] is {!of_string} of [l]'s contents. *)
 
 (** {2 Evaluation} *)
@@ -65,7 +65,7 @@ val run_to_stdout :
   ?syntax:syntax ->
   f:(string -> t -> string) ->
   string ->
-  (unit, [ `Msg of string ]) Result.t
+  (unit, [ `Msg of string ]) Result.result
 (** [run_to_stdout ?syntax ~f file] runs the callback [f] on the raw and
     structured content of [file], as specified  by [syntax] (defaults to [Normal]).
     The returned corrected version is then written to stdout. *)
@@ -75,7 +75,7 @@ val run_to_file :
   f:(string -> t -> string) ->
   outfile:string ->
   string ->
-  (unit, [ `Msg of string ]) Result.t
+  (unit, [ `Msg of string ]) Result.result
 (** Same as [run_to_stdout] but writes the corrected version to [outfile]*)
 
 val run :
@@ -83,7 +83,7 @@ val run :
   ?force_output:bool ->
   f:(string -> t -> string) ->
   string ->
-  (unit, [ `Msg of string ]) Result.t
+  (unit, [ `Msg of string ]) Result.result
 (** [run_to_file ?syntax ?force_output ~f ~outfile file] runs the callback [f]
     similarly to [run_to_stdout] to generate its corrected version. If
     [force_output] is [true] (defaults to [false]) or if the corrected version

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -48,20 +48,24 @@ val dump : line list Fmt.t
 
 (** {2 Document} *)
 
-val of_string : syntax -> string -> t
+val of_string : syntax -> string -> (t, [ `Msg of string ]) Result.t
 (** [of_string syntax s] is the document [t] such that
     [to_string ~syntax t = s]. *)
 
-val parse_file : syntax -> string -> t
+val parse_file : syntax -> string -> (t, [ `Msg of string ]) Result.t
 (** [parse_file s] is {!of_string} of [s]'s contents. *)
 
-val parse_lexbuf : string -> syntax -> Lexing.lexbuf -> t
+val parse_lexbuf :
+  string -> syntax -> Lexing.lexbuf -> (t, [ `Msg of string ]) Result.t
 (** [parse_lexbuf l] is {!of_string} of [l]'s contents. *)
 
 (** {2 Evaluation} *)
 
 val run_to_stdout :
-  ?syntax:syntax -> f:(string -> t -> string) -> string -> unit
+  ?syntax:syntax ->
+  f:(string -> t -> string) ->
+  string ->
+  (unit, [ `Msg of string ]) Result.t
 (** [run_to_stdout ?syntax ~f file] runs the callback [f] on the raw and
     structured content of [file], as specified  by [syntax] (defaults to [Normal]).
     The returned corrected version is then written to stdout. *)
@@ -71,7 +75,7 @@ val run_to_file :
   f:(string -> t -> string) ->
   outfile:string ->
   string ->
-  unit
+  (unit, [ `Msg of string ]) Result.t
 (** Same as [run_to_stdout] but writes the corrected version to [outfile]*)
 
 val run :
@@ -79,7 +83,7 @@ val run :
   ?force_output:bool ->
   f:(string -> t -> string) ->
   string ->
-  unit
+  (unit, [ `Msg of string ]) Result.t
 (** [run_to_file ?syntax ?force_output ~f ~outfile file] runs the callback [f]
     similarly to [run_to_stdout] to generate its corrected version. If
     [force_output] is [true] (defaults to [false]) or if the corrected version

--- a/lib/migrate_ast.ml
+++ b/lib/migrate_ast.ml
@@ -158,4 +158,51 @@ module Location = struct
   let width x = Position.distance x.loc_start x.loc_end
 
   let compare_width_decreasing l1 l2 = (width l2) - (width l1)
+
+  let print_loc ppf loc =
+    (*setup_colors ();*)
+    let file_valid = function
+      | "_none_" ->
+        (* This is a dummy placeholder, but we print it anyway to please editors
+           that parse locations in error messages (e.g. Emacs). *)
+        true
+      | "" | "//toplevel//" -> false
+      | _ -> true
+    in
+    let line_valid line = line > 0 in
+
+    let file =
+      (* According to the comment in location.mli, if [pos_fname] is "", we must
+         use [!input_name]. *)
+      if loc.loc_start.pos_fname = "" then !input_name
+      else loc.loc_start.pos_fname
+    in
+    let startline = loc.loc_start.pos_lnum in
+    let endline = loc.loc_end.pos_lnum in
+
+    let first = ref true in
+    let capitalize s =
+      if !first then (first := false; String.capitalize_ascii s)
+      else s in
+    let comma () =
+      if !first then () else Format.fprintf ppf ", " in
+
+    Format.fprintf ppf "@{<loc>";
+
+    if file_valid file then
+      Format.fprintf ppf "%s \"%a\"" (capitalize "file") print_filename file;
+
+    (* Print "line 1" in the case of a dummy line number. This is to please the
+       existing setup of editors that parse locations in error messages (e.g.
+       Emacs). *)
+    comma ();
+    let startline = if line_valid startline then startline else 1 in
+    let endline = if line_valid endline then endline else startline in
+    begin if startline = endline then
+        Format.fprintf ppf "%s %i" (capitalize "line") startline
+      else
+        Format.fprintf ppf "%s %i-%i" (capitalize "lines") startline endline
+    end;
+
+    Format.fprintf ppf "@}"
 end

--- a/lib/mli_parser.ml
+++ b/lib/mli_parser.ml
@@ -187,5 +187,5 @@ let parse_mli file_contents =
   else tokens
 
 let parse_mli file_contents =
-  try Ok (parse_mli file_contents)
+  try Result.Ok (parse_mli file_contents)
   with exn -> Util.Result.errorf "%s" (Printexc.to_string exn)

--- a/lib/mli_parser.ml
+++ b/lib/mli_parser.ml
@@ -185,3 +185,7 @@ let parse_mli file_contents =
     if not (Compat.String.equal remainder "") then tokens @ [ Text remainder ]
     else tokens
   else tokens
+
+let parse_mli file_contents =
+  try Ok (parse_mli file_contents)
+  with exn -> Util.Result.errorf "%s" (Printexc.to_string exn)

--- a/lib/mli_parser.mli
+++ b/lib/mli_parser.mli
@@ -8,5 +8,5 @@ val docstring_code_blocks : string -> Code_block.t list
 (** Parse an mli file as a string and return a list of the code blocks that appear inside
     its docstrings. *)
 
-val parse_mli : string -> Document.line list
+val parse_mli : string -> (Document.line list, [ `Msg of string ]) Result.t
 (** Slice an mli file into its [Text] and [Block] parts. *)

--- a/lib/mli_parser.mli
+++ b/lib/mli_parser.mli
@@ -8,5 +8,5 @@ val docstring_code_blocks : string -> Code_block.t list
 (** Parse an mli file as a string and return a list of the code blocks that appear inside
     its docstrings. *)
 
-val parse_mli : string -> (Document.line list, [ `Msg of string ]) Result.t
+val parse_mli : string -> (Document.line list, [ `Msg of string ]) Result.result
 (** Slice an mli file into its [Text] and [Block] parts. *)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -22,6 +22,13 @@ module Result = struct
     let ( >>= ) r f = match r with Ok x -> f x | Error _ as e -> e
 
     let ( >>| ) r f = match r with Ok x -> Ok (f x) | Error _ as e -> e
+
+    let ( >>! ) r f =
+      match r with
+      | Ok x -> f x
+      | Error (`Msg e) ->
+          Printf.eprintf "Fatal error: %s" e;
+          1
   end
 
   let errorf fmt = Format.kasprintf (fun s -> Error (`Msg s)) fmt

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -31,7 +31,7 @@ module Result = struct
           1
   end
 
-  let errorf fmt = Format.kasprintf (fun s -> Error (`Msg s)) fmt
+  let errorf fmt = Format.ksprintf (fun s -> Error (`Msg s)) fmt
 
   module List = struct
     open Infix

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -27,7 +27,7 @@ module Result = struct
       match r with
       | Ok x -> f x
       | Error (`Msg e) ->
-          Printf.eprintf "Fatal error: %s" e;
+          Printf.eprintf "[mdx] Fatal error: %s\n" e;
           1
   end
 

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -24,7 +24,7 @@ module Result = struct
     let ( >>| ) r f = match r with Ok x -> Ok (f x) | Error _ as e -> e
   end
 
-  let errorf fmt = Format.ksprintf (fun s -> Error (`Msg s)) fmt
+  let errorf fmt = Format.kasprintf (fun s -> Error (`Msg s)) fmt
 
   module List = struct
     open Infix

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -27,7 +27,7 @@ module Result : sig
   end
 
   val errorf :
-    ('a, Format.formatter, unit, ('b, [> `Msg of string ]) result) format4 -> 'a
+    ('a, unit, string, ('b, [> `Msg of string ]) result) format4 -> 'a
 
   module List : sig
     val fold :

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -22,6 +22,8 @@ module Result : sig
       ('a, 'err) result -> ('a -> ('b, 'err) result) -> ('b, 'err) result
 
     val ( >>| ) : ('a, 'err) result -> ('a -> 'b) -> ('b, 'err) result
+
+    val ( >>! ) : ('a, [ `Msg of string ]) result -> ('a -> int) -> int
   end
 
   val errorf :

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -25,7 +25,7 @@ module Result : sig
   end
 
   val errorf :
-    ('a, unit, string, ('b, [> `Msg of string ]) result) format4 -> 'a
+    ('a, Format.formatter, unit, ('b, [> `Msg of string ]) result) format4 -> 'a
 
   module List : sig
     val fold :

--- a/test/bin/mdx-test/failure/invalid-label-value/test-case.md.expected
+++ b/test/bin/mdx-test/failure/invalid-label-value/test-case.md.expected
@@ -1,1 +1,1 @@
-File "test-case.md", line 3, character 50: invalid code block: "bar" is not a valid value for label `non-deterministic`. Valid values are <none>, "command" and "output". Label `skip` does not allow a value.
+Fatal error while parsing file: File "test-case.md", line 3, characters 50-54: invalid code block: "bar" is not a valid value for label `non-deterministic`. Valid values are <none>, "command" and "output". Label `skip` does not allow a value.

--- a/test/bin/mdx-test/failure/invalid-label-value/test-case.md.expected
+++ b/test/bin/mdx-test/failure/invalid-label-value/test-case.md.expected
@@ -1,1 +1,1 @@
-Fatal error: File "test-case.md", line 3, characters 50-54: invalid code block: "bar" is not a valid value for label `non-deterministic`. Valid values are <none>, "command" and "output". Label `skip` does not allow a value.
+Fatal error: File "test-case.md", line 3: invalid code block: "bar" is not a valid value for label `non-deterministic`. Valid values are <none>, "command" and "output". Label `skip` does not allow a value.

--- a/test/bin/mdx-test/failure/invalid-label-value/test-case.md.expected
+++ b/test/bin/mdx-test/failure/invalid-label-value/test-case.md.expected
@@ -1,1 +1,1 @@
-Fatal error: File "test-case.md", line 3: invalid code block: "bar" is not a valid value for label `non-deterministic`. Valid values are <none>, "command" and "output". Label `skip` does not allow a value.
+[mdx] Fatal error: File "test-case.md", line 3: invalid code block: "bar" is not a valid value for label `non-deterministic`. Valid values are <none>, "command" and "output". Label `skip` does not allow a value.

--- a/test/bin/mdx-test/failure/invalid-label-value/test-case.md.expected
+++ b/test/bin/mdx-test/failure/invalid-label-value/test-case.md.expected
@@ -1,1 +1,1 @@
-Fatal error while parsing file: File "test-case.md", line 3, characters 50-54: invalid code block: "bar" is not a valid value for label `non-deterministic`. Valid values are <none>, "command" and "output". Label `skip` does not allow a value.
+Fatal error: File "test-case.md", line 3, characters 50-54: invalid code block: "bar" is not a valid value for label `non-deterministic`. Valid values are <none>, "command" and "output". Label `skip` does not allow a value.

--- a/test/bin/mdx-test/failure/invalid-label/test-case.md.expected
+++ b/test/bin/mdx-test/failure/invalid-label/test-case.md.expected
@@ -1,1 +1,1 @@
-Fatal error: File "test-case.md", line 3, characters 25-29: invalid code block: `toto` is not a valid label.
+Fatal error: File "test-case.md", line 3: invalid code block: `toto` is not a valid label.

--- a/test/bin/mdx-test/failure/invalid-label/test-case.md.expected
+++ b/test/bin/mdx-test/failure/invalid-label/test-case.md.expected
@@ -1,1 +1,1 @@
-File "test-case.md", line 3, character 25: invalid code block: `toto` is not a valid label.
+Fatal error while parsing file: File "test-case.md", line 3, characters 25-29: invalid code block: `toto` is not a valid label.

--- a/test/bin/mdx-test/failure/invalid-label/test-case.md.expected
+++ b/test/bin/mdx-test/failure/invalid-label/test-case.md.expected
@@ -1,1 +1,1 @@
-Fatal error while parsing file: File "test-case.md", line 3, characters 25-29: invalid code block: `toto` is not a valid label.
+Fatal error: File "test-case.md", line 3, characters 25-29: invalid code block: `toto` is not a valid label.

--- a/test/bin/mdx-test/failure/invalid-label/test-case.md.expected
+++ b/test/bin/mdx-test/failure/invalid-label/test-case.md.expected
@@ -1,1 +1,1 @@
-Fatal error: File "test-case.md", line 3: invalid code block: `toto` is not a valid label.
+[mdx] Fatal error: File "test-case.md", line 3: invalid code block: `toto` is not a valid label.

--- a/test/bin/mdx-test/failure/mixed-label-syntax/test-case.md.expected
+++ b/test/bin/mdx-test/failure/mixed-label-syntax/test-case.md.expected
@@ -1,1 +1,1 @@
-Fatal error: File "test-case.md", line 3, characters 100-104: invalid code block: cannot mix both block labels syntax
+Fatal error: File "test-case.md", line 3: invalid code block: cannot mix both block labels syntax

--- a/test/bin/mdx-test/failure/mixed-label-syntax/test-case.md.expected
+++ b/test/bin/mdx-test/failure/mixed-label-syntax/test-case.md.expected
@@ -1,1 +1,1 @@
-File "test-case.md", line 3, character 100: invalid code block: cannot mix both block labels syntax
+Fatal error while parsing file: File "test-case.md", line 3, characters 100-104: invalid code block: cannot mix both block labels syntax

--- a/test/bin/mdx-test/failure/mixed-label-syntax/test-case.md.expected
+++ b/test/bin/mdx-test/failure/mixed-label-syntax/test-case.md.expected
@@ -1,1 +1,1 @@
-Fatal error while parsing file: File "test-case.md", line 3, characters 100-104: invalid code block: cannot mix both block labels syntax
+Fatal error: File "test-case.md", line 3, characters 100-104: invalid code block: cannot mix both block labels syntax

--- a/test/bin/mdx-test/failure/mixed-label-syntax/test-case.md.expected
+++ b/test/bin/mdx-test/failure/mixed-label-syntax/test-case.md.expected
@@ -1,1 +1,1 @@
-Fatal error: File "test-case.md", line 3: invalid code block: cannot mix both block labels syntax
+[mdx] Fatal error: File "test-case.md", line 3: invalid code block: cannot mix both block labels syntax

--- a/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
@@ -1,1 +1,1 @@
-File "test-case.md", line 3, character 36: invalid code block: `part` is not supported for non-OCaml code blocks.
+Fatal error while parsing file: File "test-case.md", lines 3-5, characters 36-0: invalid code block: `part` is not supported for non-OCaml code blocks.

--- a/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
@@ -1,1 +1,1 @@
-Fatal error: File "test-case.md", lines 3-5, characters 36-0: invalid code block: `part` is not supported for non-OCaml code blocks.
+Fatal error: File "test-case.md", lines 3-5: invalid code block: `part` is not supported for non-OCaml code blocks.

--- a/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
@@ -1,1 +1,1 @@
-Fatal error while parsing file: File "test-case.md", lines 3-5, characters 36-0: invalid code block: `part` is not supported for non-OCaml code blocks.
+Fatal error: File "test-case.md", lines 3-5, characters 36-0: invalid code block: `part` is not supported for non-OCaml code blocks.

--- a/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
@@ -1,1 +1,1 @@
-Fatal error: File "test-case.md", lines 3-5: invalid code block: `part` is not supported for non-OCaml code blocks.
+[mdx] Fatal error: File "test-case.md", lines 3-5: invalid code block: `part` is not supported for non-OCaml code blocks.

--- a/test/lib/test_mli_parser.ml
+++ b/test/lib/test_mli_parser.ml
@@ -1,3 +1,5 @@
+open Mdx.Util.Result.Infix
+
 let mli =
   {|
 (** This is a doc comment with some code blocks in it:
@@ -27,17 +29,20 @@ let test_parse_mli =
     let test_fun () =
       let buffer = Buffer.create 256 in
       let fmt = Format.formatter_of_buffer buffer in
-      let actual = Mdx.Mli_parser.parse_mli mli in
-      Mdx.dump fmt actual;
-      let actual = Buffer.contents buffer in
-      Alcotest.(check string) test_name expected actual
+      let actual =
+        Mdx.Mli_parser.parse_mli mli >>| fun lines ->
+        Mdx.dump fmt lines;
+        Buffer.contents buffer
+      in
+      Alcotest.(check (result string Testable.msg)) test_name expected actual
     in
     (test_name, `Quick, test_fun)
   in
   [
     make_test ~test_name:"mli" ~mli
       ~expected:
-        {x|[Text "\n(** This is a doc comment with some code blocks in it:\n\n    ";
+        (Ok
+           {x|[Text "\n(** This is a doc comment with some code blocks in it:\n\n    ";
  Text "{[";
  Block {file: ; line: 4; column: 4; section: None; labels: [];
         header: Some ocaml;
@@ -61,7 +66,7 @@ let test_parse_mli =
  Block {file: ; line: 20; column: 4; section: None; labels: [];
         header: Some ocaml;
                 contents: ["1 + 1 = 3"]; value: OCaml};
- Text "]}";|x}
+ Text "]}";|x})
       ();
   ]
 


### PR DESCRIPTION
First step of #264

Use a Result type instead of exception for parsing errors, so far I only did the work for mdx and mli parsing, cram and toplevel parsing should be modified as well but the change is more involved.
