### PR TITLE
Require at least cmdliner 1.0.0

### DIFF
--- a/mdx.opam
+++ b/mdx.opam
@@ -21,7 +21,7 @@ depends: [
   "cppo" {build}
   "astring"
   "logs"
-  "cmdliner"
+  "cmdliner" {>= "1.0.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-migrate-parsetree" {>= "1.0.6"}


### PR DESCRIPTION
Mdx uses `Arg.conv` which has been added in 1.0.0.