### PR TITLE
Cram test exception due to empty line: improve msg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 #### Changed
 
+- Improve error message of cram test exceptions due to empty lines in a block (#270, @pitag-ha)
+
 #### Deprecated
 
 #### Removed

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -105,6 +105,17 @@ let of_lines t =
       (pad, aux cmd [] [] t)
   | `Command cmd :: t -> (pad, aux [ cmd ] [] [] t)
   | [] -> (0, [])
+  | `Output line :: _ ->
+      if String.length line > 0 && line.[0] = '$' then
+        failwith
+          "Blocks must start with a command or similar, not with an output \
+           line. To indicate a line as a command, start it with a dollar \
+           followed by a space."
+      else
+        failwith
+          "Blocks must start with a command or similar, not with an output \
+           line. Please, make sure that there's no spare empty line, \
+           particularly between the output and its input."
   | _ -> Fmt.failwith "invalid cram block: %a" Fmt.(Dump.list dump_line) lines
 
 let exit_code t = t.exit_code

--- a/test/bin/mdx-test/failure/cram-command-syntax/test-case.t
+++ b/test/bin/mdx-test/failure/cram-command-syntax/test-case.t
@@ -1,0 +1,4 @@
+Missing empty space after dollar
+
+  $echo hi
+  hi

--- a/test/bin/mdx-test/failure/cram-command-syntax/test-case.t.expected
+++ b/test/bin/mdx-test/failure/cram-command-syntax/test-case.t.expected
@@ -1,0 +1,2 @@
+Error in the cram code block in test-case.t at line 3:
+Blocks must start with a command or similar, not with an output line. To indicate a line as a command, start it with a dollar followed by a space.

--- a/test/bin/mdx-test/failure/cram-empty-line/test-case.t
+++ b/test/bin/mdx-test/failure/cram-empty-line/test-case.t
@@ -1,0 +1,5 @@
+Empty line between input and output
+
+  $ echo hi
+
+  hi

--- a/test/bin/mdx-test/failure/cram-empty-line/test-case.t.expected
+++ b/test/bin/mdx-test/failure/cram-empty-line/test-case.t.expected
@@ -1,0 +1,2 @@
+Error in the cram code block in test-case.t at line 5:
+Blocks must start with a command or similar, not with an output line. Please, make sure that there's no spare empty line, particularly between the output and its input.

--- a/test/bin/mdx-test/failure/dune.inc
+++ b/test/bin/mdx-test/failure/dune.inc
@@ -12,6 +12,30 @@
  (action (diff both-prelude/test-case.md.expected both-prelude.actual)))
 
 (rule
+ (target cram-command-syntax.actual)
+ (deps (package mdx) (source_tree cram-command-syntax))
+ (action
+  (with-outputs-to %{target}
+   (chdir cram-command-syntax
+    (system "! ocaml-mdx test test-case.t")))))
+
+(rule
+ (alias runtest)
+ (action (diff cram-command-syntax/test-case.t.expected cram-command-syntax.actual)))
+
+(rule
+ (target cram-empty-line.actual)
+ (deps (package mdx) (source_tree cram-empty-line))
+ (action
+  (with-outputs-to %{target}
+   (chdir cram-empty-line
+    (system "! ocaml-mdx test test-case.t")))))
+
+(rule
+ (alias runtest)
+ (action (diff cram-empty-line/test-case.t.expected cram-empty-line.actual)))
+
+(rule
  (target in-toplevel.actual)
  (deps (package mdx) (source_tree in-toplevel))
  (action


### PR DESCRIPTION
Before, when there was an empty line between an input and its output, the error message was ``invalid cram block: [`Output "(...)"; (...)]``. Now, it is more informative.