### PR TITLE
Library csexp.1.2.2 fixes the 4.02.3 compatibility

### DIFF
--- a/mdx.opam
+++ b/mdx.opam
@@ -22,7 +22,7 @@ depends: [
   "astring"
   "logs"
   "cmdliner" {>= "1.0.3"}
-  "csexp" {>= "1.2.0"}
+  "csexp" {>= "1.2.2"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-migrate-parsetree" {>= "1.0.6"}


### PR DESCRIPTION
That will fix our CI
see: https://github.com/ocaml/opam-repository/pull/16707