### PR TITLE
Display OCaml warnings in mdx-error blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 #### Added
 
+- Display OCaml warnings in mdx-error blocks (#293, @gpetiot)
+
 #### Changed
 
 #### Deprecated

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -514,3 +514,15 @@
 (rule
  (alias runtest)
  (action (diff trailing-whitespaces/test-case.md.expected trailing-whitespaces.actual)))
+
+(rule
+ (target warnings.actual)
+ (deps (package mdx) (source_tree warnings))
+ (action
+  (with-stdout-to %{target}
+   (chdir warnings
+    (run ocaml-mdx test --output - test-case.md)))))
+
+(rule
+ (alias runtest)
+ (action (diff warnings/test-case.md warnings.actual)))

--- a/test/bin/mdx-test/expect/warnings/test-case.md
+++ b/test/bin/mdx-test/expect/warnings/test-case.md
@@ -1,0 +1,34 @@
+No warning is printed by default:
+
+```ocaml
+let () =
+  let f ~x:() = () in
+  f ();;
+let x = 4
+```
+
+Warning attributes must be set to print them:
+
+```ocaml version<4.12
+[@@@warning "+6"]
+let () =
+  let f ~x:() = () in
+  f ();;
+let x = 4
+```
+```mdx-error
+...
+Warning 6: label x was omitted in the application of this function.
+```
+
+```ocaml version>=4.12
+[@@@warning "+6"]
+let () =
+  let f ~x:() = () in
+  f ();;
+let x = 4
+```
+```mdx-error
+Line 4, characters 5-6:
+Warning 6 [labels-omitted]: label x was omitted in the application of this function.
+```


### PR DESCRIPTION
Fix #287 

I chose to filter the output to only display the "probable" (since we grep the keyword but that could be a variable name or something else) warnings