### PR TITLE
Preview of ocamlformat.0.16.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version=0.15.0
+version=0.16.0
 profile=conventional

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -34,7 +34,7 @@ let run (`Setup ()) (`File file) (`Section section) =
     | None -> t
     | Some s -> (
         let re = Re.Perl.compile_pat s in
-        match Mdx.filter_section re t with None -> [] | Some t -> t )
+        match Mdx.filter_section re t with None -> [] | Some t -> t)
   in
   match t with
   | [] -> 1
@@ -56,7 +56,7 @@ let run (`Setup ()) (`File file) (`Section section) =
                     let line = b.loc.loc_start.pos_lnum + !rvpad in
                     Fmt.pr "%a\n%a\n" Mdx.Block.pp_line_directive (file, line)
                       pp_lines contents
-                | _ -> () ))
+                | _ -> ()))
         t;
       0
 

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -60,7 +60,7 @@ let with_dir root f =
         r
       with e ->
         Sys.chdir old_d;
-        raise e )
+        raise e)
 
 let get_env blacklist =
   let env = Array.to_list (Unix.environment ()) in
@@ -90,7 +90,7 @@ let root_dir ?root ?block () =
   | Some { dir = Some d; loc = { loc_start = { pos_fname; _ }; _ }; _ } -> (
       match root with
       | Some r -> Some (r / d)
-      | None -> Some (Filename.dirname pos_fname / d) )
+      | None -> Some (Filename.dirname pos_fname / d))
   | None -> root
 
 let resolve_root file dir root =
@@ -212,7 +212,7 @@ let read_parts file =
     | parts ->
         let f = { first = parts; current = parts } in
         Hashtbl.add files file f;
-        f )
+        f)
 
 let read_part file part =
   let parts = read_parts file in
@@ -357,16 +357,16 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
         | Block t -> (
             List.iter (fun (k, v) -> Unix.putenv k v) (Block.set_variables t);
             try test_block ~ppf ~temp_file t
-            with Failure msg -> raise (Test_block_failure (t, msg)) ))
+            with Failure msg -> raise (Test_block_failure (t, msg))))
       items;
     Format.pp_print_flush ppf ();
     Buffer.contents buf
   in
-  ( match (output : Cli.output option) with
+  (match (output : Cli.output option) with
   | Some Stdout -> Mdx.run_to_stdout ?syntax ~f:gen_corrected file
   | Some (File outfile) ->
       Mdx.run_to_file ?syntax ~outfile ~f:gen_corrected file
-  | None -> Mdx.run ?syntax ~force_output ~f:gen_corrected file )
+  | None -> Mdx.run ?syntax ~force_output ~f:gen_corrected file)
   >>! fun () ->
   Hashtbl.iter (write_parts ~force_output) files;
   0

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -180,7 +180,7 @@ let pp_header ?syntax ppf t =
           Fmt.pf ppf "<-- non-deterministic output\n"
       | [ Non_det (Some Nd_command) ] ->
           Fmt.pf ppf "<-- non-deterministic command\n"
-      | _ -> failwith "cannot happen: checked during parsing" )
+      | _ -> failwith "cannot happen: checked during parsing")
   | Some Syntax.Mli -> ()
   | _ ->
       if t.legacy_labels then
@@ -363,7 +363,7 @@ let mk_ocaml ~config ~contents ~errors =
       match guess_ocaml_kind contents with
       | `Code -> Ok (OCaml { env = Ocaml_env.mk env; non_det; errors })
       | `Toplevel ->
-          Util.Result.errorf "toplevel syntax is not allowed in OCaml blocks." )
+          Util.Result.errorf "toplevel syntax is not allowed in OCaml blocks.")
   | { file_inc = Some _; _ } -> label_not_allowed ~label:"file" ~kind
   | { part = Some _; _ } -> label_not_allowed ~label:"part" ~kind
 
@@ -375,9 +375,9 @@ let mk_cram ?language ~config ~header ~errors () =
       let language =
         Util.Option.value language
           ~default:
-            ( match header with
+            (match header with
             | Some (Header.Shell language) -> language
-            | _ -> `Sh )
+            | _ -> `Sh)
       in
       Cram { language; non_det }
   | { file_inc = Some _; _ } -> label_not_allowed ~label:"file" ~kind
@@ -393,7 +393,7 @@ let mk_toplevel ~config ~contents ~errors =
           Util.Result.errorf "invalid toplevel syntax in toplevel blocks."
       | `Toplevel ->
           check_no_errors errors >>| fun () ->
-          Toplevel { env = Ocaml_env.mk env; non_det } )
+          Toplevel { env = Ocaml_env.mk env; non_det })
   | { file_inc = Some _; _ } -> label_not_allowed ~label:"file" ~kind
   | { part = Some _; _ } -> label_not_allowed ~label:"part" ~kind
 
@@ -411,8 +411,8 @@ let mk_include ~config ~header ~errors =
           | None ->
               let file_kind = Fk_other { header } in
               Ok (Include { file_included; file_kind })
-          | Some _ -> label_not_allowed ~label:"part" ~kind:"non-OCaml include"
-          ) )
+          | Some _ -> label_not_allowed ~label:"part" ~kind:"non-OCaml include")
+      )
   | { file_inc = None; _ } -> label_required ~label:"file" ~kind
   | { non_det = Some _; _ } ->
       label_not_allowed ~label:"non-deterministic" ~kind
@@ -428,23 +428,23 @@ let infer_block ~config ~header ~contents ~errors =
       | Some Header.OCaml -> (
           match guess_ocaml_kind contents with
           | `Code -> mk_ocaml ~config ~contents ~errors
-          | `Toplevel -> mk_toplevel ~config ~contents ~errors )
+          | `Toplevel -> mk_toplevel ~config ~contents ~errors)
       | _ ->
           check_not_set "`part` label requires a `file` label." part
           >>= fun () ->
-          check_no_errors errors >>| fun () -> Raw { header } )
+          check_no_errors errors >>| fun () -> Raw { header })
 
 let mk ~loc ~section ~labels ~legacy_labels ~header ~contents ~errors =
   let block_kind =
     get_label (function Block_kind x -> Some x | _ -> None) labels
   in
   let config = get_block_config labels in
-  ( match block_kind with
+  (match block_kind with
   | Some OCaml -> mk_ocaml ~config ~contents ~errors
   | Some Cram -> mk_cram ~config ~header ~errors ()
   | Some Toplevel -> mk_toplevel ~config ~contents ~errors
   | Some Include -> mk_include ~config ~header ~errors
-  | None -> infer_block ~config ~header ~contents ~errors )
+  | None -> infer_block ~config ~header ~contents ~errors)
   >>= fun value ->
   version_enabled config.version >>| fun version_enabled ->
   {
@@ -477,7 +477,7 @@ let is_active ?section:s t =
     | Some p -> (
         match t.section with
         | Some s -> Re.execp (Re.Perl.compile_pat p) (snd s)
-        | None -> Re.execp (Re.Perl.compile_pat p) "" )
+        | None -> Re.execp (Re.Perl.compile_pat p) "")
     | None -> true
   in
   active && t.version_enabled && not t.skip

--- a/lib/document.ml
+++ b/lib/document.ml
@@ -27,7 +27,7 @@ let pp_line ?syntax ppf (l : line) =
   | Text s -> (
       match syntax with
       | Some Mli -> Fmt.pf ppf "%s" s
-      | _ -> Fmt.pf ppf "%s\n" s )
+      | _ -> Fmt.pf ppf "%s\n" s)
 
 let pp ?syntax ppf t =
   Fmt.pf ppf "%a\n" Fmt.(list ~sep:(unit "\n") (pp_line ?syntax)) t
@@ -41,6 +41,6 @@ let envs t =
       | Block b -> (
           match b.value with
           | OCaml { env; _ } | Toplevel { env; _ } -> Ocaml_env.Set.add env acc
-          | Raw _ | Cram _ | Include _ -> acc )
+          | Raw _ | Cram _ | Include _ -> acc)
       | Section _ | Text _ -> acc)
     Ocaml_env.Set.empty t

--- a/lib/label.ml
+++ b/lib/label.ml
@@ -67,7 +67,7 @@ module Relation = struct
           let op = of_string (Re.Group.get g 2) in
           let value = Re.Group.get g 3 in
           (label, Some (op, value))
-        with Not_found -> (s, None) )
+        with Not_found -> (s, None))
 end
 
 type non_det = Nd_output | Nd_command
@@ -171,7 +171,7 @@ let interpret label value =
       | Some (Relation.Eq, v) ->
           let allowed_values = [ "<none>"; {|"command"|}; {|"output"|} ] in
           invalid_value ~label ~allowed_values v
-      | Some _ -> non_eq_op ~label )
+      | Some _ -> non_eq_op ~label)
   | "dir" -> requires_eq_value ~label ~value (fun x -> Dir x)
   | "source-tree" -> requires_eq_value ~label ~value (fun x -> Source_tree x)
   | "file" -> requires_eq_value ~label ~value (fun x -> File x)
@@ -199,4 +199,4 @@ let of_string s =
       let split = String.split_on_char ',' s in
       match List.fold_left f (Ok []) split with
       | Ok labels -> Ok (List.rev labels)
-      | Error msgs -> Error (List.rev msgs) )
+      | Error msgs -> Error (List.rev msgs))

--- a/lib/mli_parser.ml
+++ b/lib/mli_parser.ml
@@ -109,7 +109,7 @@ let extract_code_blocks ~(location : Lexing.position) ~docstring =
           | `Return blocks -> acc blocks
           | `See (_, _, blocks) -> acc blocks
           | `Before (_, blocks) -> acc blocks
-          | _ -> [] )
+          | _ -> [])
       | `Heading _ -> [])
     parsed.value
   |> List.concat

--- a/lib/ocaml_delimiter.ml
+++ b/lib/ocaml_delimiter.ml
@@ -74,7 +74,7 @@ let parse_attr line =
       let payload = Re.Group.get g 3 in
       match name with
       | "part" -> Some (Part_begin (Attr, { indent; payload }))
-      | _ -> None )
+      | _ -> None)
   | None -> None
 
 let parse_cmt line =
@@ -93,7 +93,7 @@ let parse_cmt line =
                  '(* $MDX part-end *)' instead."
           | _ ->
               Util.Result.errorf "'%s' is not a valid ocaml delimiter for mdx."
-                line ) )
+                line))
   | None -> Ok None
 
 let parse line =

--- a/lib/output.ml
+++ b/lib/output.ml
@@ -48,8 +48,8 @@ let equal a b =
   let rec aux x y =
     match (x, y) with
     | [], [] | [ `Ellipsis ], _ | _, [ `Ellipsis ] -> true
-    | (`Ellipsis :: a as x), (_ :: b as y) | (_ :: b as y), (`Ellipsis :: a as x)
-      ->
+    | (`Ellipsis :: a as x), (_ :: b as y)
+    | (_ :: b as y), (`Ellipsis :: a as x) ->
         aux x b
         || (* n+ matches: skip y's head *)
         aux a y

--- a/lib/part.ml
+++ b/lib/part.ml
@@ -75,12 +75,12 @@ module Parse_parts = struct
                 | Part_begin (syntax, { indent; payload }) -> (
                     match syntax with
                     | Attr -> Compat_attr (payload, indent)
-                    | Cmt -> Part_begin (payload, indent) )
-                | Part_end -> Part_end )
-            | None -> Normal line )
+                    | Cmt -> Part_begin (payload, indent))
+                | Part_end -> Part_end)
+            | None -> Normal line)
         | Error (`Msg msg) ->
             Fmt.epr "Warning: %s\n" msg;
-            Normal line )
+            Normal line)
 
   let input_line_err i =
     match input_line i with
@@ -135,7 +135,7 @@ let find file ~part =
   | Some part -> (
       match List.find_opt (fun p -> String.equal (Part.name p) part) file with
       | Some p -> Some [ Part.body p ]
-      | None -> None )
+      | None -> None)
   | None ->
       List.fold_left (fun acc p -> Part.body p :: acc) [] file |> List.rev
       |> fun x -> Some x

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -126,14 +126,14 @@ module Phrase = struct
             | Some error ->
                 Location.Error (Lexbuf.shift_location_error startpos error)
           in
-          ( if lexbuf.Lexing.lex_last_action <> Lexbuf.semisemi_action then
-            let rec aux () =
-              match Lexer.token lexbuf with
-              | Parser.SEMISEMI | Parser.EOF -> ()
-              | exception Lexer.Error (_, _) -> ()
-              | _ -> aux ()
-            in
-            aux () );
+          (if lexbuf.Lexing.lex_last_action <> Lexbuf.semisemi_action then
+           let rec aux () =
+             match Lexer.token lexbuf with
+             | Parser.SEMISEMI | Parser.EOF -> ()
+             | exception Lexer.Error (_, _) -> ()
+             | _ -> aux ()
+           in
+           aux ());
           Error exn
     in
     let endpos = lexbuf.Lexing.lex_curr_p in
@@ -214,7 +214,7 @@ module Rewrite = struct
     | { Types.type_manifest = Some ty; _ } -> (
         match Ctype.expand_head env ty with
         | { Types.desc = Types.Tconstr (path, _, _); _ } -> path
-        | _ -> path )
+        | _ -> path)
     | _ -> path
 
   let is_persistent_value env longident =
@@ -244,7 +244,7 @@ module Rewrite = struct
         Typedtree.Tstr_eval ({ Typedtree.exp_type = typ; _ }, _) ) -> (
         match (Ctype.repr typ).Types.desc with
         | Types.Tconstr (path, _, _) -> apply ts env pstr_item path e
-        | _ -> pstr_item )
+        | _ -> pstr_item)
     | _ -> pstr_item
 
   let active_rewriters () =
@@ -273,7 +273,7 @@ module Rewrite = struct
             with _ -> pstr
           in
           Btype.backtrack snap;
-          Ptop_def pstr )
+          Ptop_def pstr)
     | _ -> phrase
 
   let preload verbose ppf =
@@ -407,14 +407,14 @@ let eval t cmd =
     in
     Oprint.out_phrase := out_phrase;
     let restore () = Oprint.out_phrase := out_phrase' in
-    ( match toplevel_exec_phrase t ppf phrase with
+    (match toplevel_exec_phrase t ppf phrase with
     | ok ->
         errors := (not ok) || !errors;
         restore ()
     | exception exn ->
         errors := true;
         restore ();
-        Location.report_exception ppf exn );
+        Location.report_exception ppf exn);
     Format.pp_print_flush ppf ();
     capture ();
     if
@@ -558,7 +558,7 @@ let monkey_patch (type a) (m : a) (type b) (prj : unit -> b) (v : b) =
         if Obj.field m i == v' then (
           Obj.set_field m i v;
           if Obj.repr (prj ()) == v then raise Exit;
-          Obj.set_field m i v' )
+          Obj.set_field m i v')
       done;
       invalid_arg "monkey_patch: field not found"
     with Exit -> ()
@@ -679,7 +679,7 @@ let in_env e f =
     (* We will start from the *correct* initial environment with
        everything loaded, for each environment. *)
     default_env := !Toploop.toplevel_env;
-    first_call := false );
+    first_call := false);
   let env, names, objs =
     try Hashtbl.find envs env_name with Not_found -> env_deps !default_env
   in

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -94,7 +94,7 @@ module List = struct
   let find_map f l =
     let rec aux = function
       | [] -> None
-      | h :: t -> ( match f h with Some x -> Some x | None -> aux t )
+      | h :: t -> ( match f h with Some x -> Some x | None -> aux t)
     in
     aux l
 end

--- a/test/lib/test_dep.ml
+++ b/test/lib/test_dep.ml
@@ -29,7 +29,7 @@ let test_of_block =
             ~contents:[] ~legacy_labels:false ~errors:[]
         with
         | Ok block -> block
-        | Error _ -> assert false )
+        | Error _ -> assert false)
     | Error _ -> assert false
   in
   [

--- a/test/lib/testable.ml
+++ b/test/lib/testable.ml
@@ -11,9 +11,9 @@ let ocaml_delimiter =
   let pp fs = function
     | Part_begin (src, { indent; payload }) ->
         Fmt.string fs "Part_begin";
-        ( match src with
+        (match src with
         | Cmt -> Fmt.string fs "Cmt"
-        | Attr -> Fmt.string fs "Attr" );
+        | Attr -> Fmt.string fs "Attr");
         Fmt.fmt "indent:%s" fs indent;
         Fmt.fmt "payload:%s" fs payload
     | Part_end -> Fmt.string fs "Part_end"


### PR DESCRIPTION
This pull-request is a preview of the soon to be released ocamlformat.0.16.0. The main change in the diff is that `indicate-multiline-delimiters` option has now be switched to `no` on the conventional profile to improve consistency and minimize the diffs in the future.
Let me now if you notice any regressions.