### PR TITLE
Use create_process instead of execvp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 - Report `#require` directive errors (#276, @gpetiot)
 - Handle no such file exception: the input file and the values of options `--root` and `--prelude` are checked (#292, @gpetiot)
 - Keep locations from parsing instead of recomputing the lines, providing better error messages (#241, @gpetiot)
+- Use `create_process` instead of `execvp` to call `mdx-test` from `mdx`. This fixes running mdx from dune on Windows (#299, @emillon)
 
 #### Security
 

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -41,7 +41,9 @@ let run (`Setup ()) _ _ _ _ _ _ _ _ _ _ =
   let argv = Array.sub Sys.argv 1 (Array.length Sys.argv - 1) in
   argv.(0) <- cmd;
   Log.debug (fun l -> l "executing %a" Fmt.(Dump.array string) argv);
-  Unix.execvp cmd argv
+  let pid = Unix.create_process cmd argv Unix.stdin Unix.stdout Unix.stderr in
+  let code = Mdx.Util.Process.wait ~pid in
+  exit code
 
 open Cmdliner
 

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -81,7 +81,7 @@ let run_test ?root blacklist temp_file t =
         Unix.create_process_env "sh" [| "sh"; "-c"; cmd |] env Unix.stdin fd fd)
   in
   Unix.close fd;
-  match snd (Unix.waitpid [] pid) with WEXITED n -> n | _ -> 255
+  Util.Process.wait ~pid
 
 let root_dir ?root ?block () =
   match (block : Block.t option) with

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -104,3 +104,8 @@ module Array = struct
     let start_index, length = (from, to_ - from + 1) in
     Array.sub t start_index length
 end
+
+module Process = struct
+  let wait ~pid =
+    match snd (Unix.waitpid [] pid) with WEXITED n -> n | _ -> 255
+end

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -71,3 +71,10 @@ end
 module Array : sig
   val slice : 'a array -> from:int -> to_:int -> 'a array
 end
+
+module Process : sig
+  val wait : pid:int -> int
+  (** Wait for the given process and return an exit code.
+      Exit code is the same as the child process if it exits normally, or 255
+      otherwise. *)
+end


### PR DESCRIPTION
On Windows, execvp creates a separate process, which can confuse dune when it is waiting for the mdx process. This causes it to miss that the output file has been created. This affects mdx's test suite and possibly users of the mdx stanza. Instead we create a process and immediately wait for it in the parent.

See #295, ocaml/dune#3849.