### PR TITLE
Fix unit tests on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,10 +9,6 @@
 
 - Improve error message of cram test exceptions due to empty lines in a block (#270, @pitag-ha)
 
-#### Fixed
-
-- Fix the unit tests on Windows (#301 @tmattio)
-
 #### Deprecated
 
 #### Removed
@@ -22,6 +18,7 @@
 - Report `#require` directive errors (#276, @gpetiot)
 - Handle no such file exception: the input file and the values of options `--root` and `--prelude` are checked (#292, @gpetiot)
 - Keep locations from parsing instead of recomputing the lines, providing better error messages (#241, @gpetiot)
+- Fix the unit tests on Windows (#301 @tmattio)
 
 #### Security
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@
 - Report `#require` directive errors (#276, @gpetiot)
 - Handle no such file exception: the input file and the values of options `--root` and `--prelude` are checked (#292, @gpetiot)
 - Keep locations from parsing instead of recomputing the lines, providing better error messages (#241, @gpetiot)
-- Fix the unit tests on Windows (#301 @tmattio)
+- Use with-accepted-exit-codes in tests instead of system (#301 @tmattio)
 
 #### Security
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,6 @@
 - Report `#require` directive errors (#276, @gpetiot)
 - Handle no such file exception: the input file and the values of options `--root` and `--prelude` are checked (#292, @gpetiot)
 - Keep locations from parsing instead of recomputing the lines, providing better error messages (#241, @gpetiot)
-- Use with-accepted-exit-codes in tests instead of system (#301 @tmattio)
 
 #### Security
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@
 
 - Improve error message of cram test exceptions due to empty lines in a block (#270, @pitag-ha)
 
+#### Fixed
+
+- Fix the unit tests on Windows (#301 @tmattio)
+
 #### Deprecated
 
 #### Removed

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.0)
+(lang dune 2.2)
 
 (name mdx)

--- a/mdx.opam
+++ b/mdx.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.2"}
   "ocamlfind"
   "fmt"
   "cppo" {build}

--- a/test/bin/mdx-pp/gen_dune_rules.ml
+++ b/test/bin/mdx-pp/gen_dune_rules.ml
@@ -16,9 +16,10 @@ let pp_expect_action fmt dir =
 let pp_failure_action fmt dir =
   Fmt.pf fmt
     {|
-  (with-outputs-to %%{target}
-   (chdir %s
-    (system "! ocaml-mdx pp %a%s")))|}
+  (with-accepted-exit-codes 1
+   (with-outputs-to %%{target}
+    (chdir %s
+     (run %%{bin:ocaml-mdx} test %a%s))))|}
     dir.dir_name pp_options dir.options dir.test_file
 
 let () = run { pp_expect_action; pp_failure_action }

--- a/test/bin/mdx-test/failure/dune.inc
+++ b/test/bin/mdx-test/failure/dune.inc
@@ -3,9 +3,10 @@
  (target both-prelude.actual)
  (deps (package mdx) (source_tree both-prelude))
  (action
-  (with-outputs-to %{target}
-   (chdir both-prelude
-    (system "! ocaml-mdx test --prelude=a --prelude-str=b test-case.md")))))
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir both-prelude
+     (run %{bin:ocaml-mdx} test --prelude=a --prelude-str=b test-case.md))))))
 
 (rule
  (alias runtest)
@@ -15,9 +16,10 @@
  (target cram-command-syntax.actual)
  (deps (package mdx) (source_tree cram-command-syntax))
  (action
-  (with-outputs-to %{target}
-   (chdir cram-command-syntax
-    (system "! ocaml-mdx test test-case.t")))))
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir cram-command-syntax
+     (run %{bin:ocaml-mdx} test test-case.t))))))
 
 (rule
  (alias runtest)
@@ -27,9 +29,10 @@
  (target cram-empty-line.actual)
  (deps (package mdx) (source_tree cram-empty-line))
  (action
-  (with-outputs-to %{target}
-   (chdir cram-empty-line
-    (system "! ocaml-mdx test test-case.t")))))
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir cram-empty-line
+     (run %{bin:ocaml-mdx} test test-case.t))))))
 
 (rule
  (alias runtest)
@@ -39,9 +42,10 @@
  (target in-toplevel.actual)
  (deps (package mdx) (source_tree in-toplevel))
  (action
-  (with-outputs-to %{target}
-   (chdir in-toplevel
-    (system "! ocaml-mdx test test-case.md")))))
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir in-toplevel
+     (run %{bin:ocaml-mdx} test test-case.md))))))
 
 (rule
  (alias runtest)
@@ -51,9 +55,10 @@
  (target invalid-label.actual)
  (deps (package mdx) (source_tree invalid-label))
  (action
-  (with-outputs-to %{target}
-   (chdir invalid-label
-    (system "! ocaml-mdx test test-case.md")))))
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir invalid-label
+     (run %{bin:ocaml-mdx} test test-case.md))))))
 
 (rule
  (alias runtest)
@@ -63,9 +68,10 @@
  (target invalid-label-value.actual)
  (deps (package mdx) (source_tree invalid-label-value))
  (action
-  (with-outputs-to %{target}
-   (chdir invalid-label-value
-    (system "! ocaml-mdx test test-case.md")))))
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir invalid-label-value
+     (run %{bin:ocaml-mdx} test test-case.md))))))
 
 (rule
  (alias runtest)
@@ -75,9 +81,10 @@
  (target mixed-label-syntax.actual)
  (deps (package mdx) (source_tree mixed-label-syntax))
  (action
-  (with-outputs-to %{target}
-   (chdir mixed-label-syntax
-    (system "! ocaml-mdx test test-case.md")))))
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir mixed-label-syntax
+     (run %{bin:ocaml-mdx} test test-case.md))))))
 
 (rule
  (alias runtest)
@@ -87,9 +94,10 @@
  (target ml-file-not-found.actual)
  (deps (package mdx) (source_tree ml-file-not-found))
  (action
-  (with-outputs-to %{target}
-   (chdir ml-file-not-found
-    (system "! ocaml-mdx test test-case.md")))))
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir ml-file-not-found
+     (run %{bin:ocaml-mdx} test test-case.md))))))
 
 (rule
  (alias runtest)
@@ -99,9 +107,10 @@
  (target part-not-ended.actual)
  (deps (package mdx) (source_tree part-not-ended))
  (action
-  (with-outputs-to %{target}
-   (chdir part-not-ended
-    (system "! ocaml-mdx test test-case.md")))))
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir part-not-ended
+     (run %{bin:ocaml-mdx} test test-case.md))))))
 
 (rule
  (alias runtest)
@@ -111,9 +120,10 @@
  (target part-not-found.actual)
  (deps (package mdx) (source_tree part-not-found))
  (action
-  (with-outputs-to %{target}
-   (chdir part-not-found
-    (system "! ocaml-mdx test test-case.md")))))
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir part-not-found
+     (run %{bin:ocaml-mdx} test test-case.md))))))
 
 (rule
  (alias runtest)
@@ -123,9 +133,10 @@
  (target part-not-opened.actual)
  (deps (package mdx) (source_tree part-not-opened))
  (action
-  (with-outputs-to %{target}
-   (chdir part-not-opened
-    (system "! ocaml-mdx test test-case.md")))))
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir part-not-opened
+     (run %{bin:ocaml-mdx} test test-case.md))))))
 
 (rule
  (alias runtest)
@@ -135,9 +146,10 @@
  (target part-unsupported.actual)
  (deps (package mdx) (source_tree part-unsupported))
  (action
-  (with-outputs-to %{target}
-   (chdir part-unsupported
-    (system "! ocaml-mdx test test-case.md")))))
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir part-unsupported
+     (run %{bin:ocaml-mdx} test test-case.md))))))
 
 (rule
  (alias runtest)

--- a/test/bin/mdx-test/gen_dune_rules.ml
+++ b/test/bin/mdx-test/gen_dune_rules.ml
@@ -32,9 +32,10 @@ let pp_expect_action fmt dir =
 let pp_failure_action fmt dir =
   Fmt.pf fmt
     {|
-  (with-outputs-to %%{target}
-   (chdir %s
-    (system "! ocaml-mdx test %a%s")))|}
+  (with-accepted-exit-codes 1
+   (with-outputs-to %%{target}
+    (chdir %s
+     (run %%{bin:ocaml-mdx} test %a%s))))|}
     dir.dir_name pp_options dir.options dir.test_file
 
 let () = run { pp_expect_action; pp_failure_action }


### PR DESCRIPTION
The failure tests in `test/bin/mdx-test` used `system "! ocaml-mdx ..."` to ensure that the exit code is not `0`. This does not work on Windows where `!` is not available. To solve this, we use the `with-accepted-exit-codes` stanza introduced in dune 2.2 and test that the exit code is `1`.

This works on macOS, but as the goal is to fix the unit tests on Windows, I'm setting up a VM to try and run the tests on it. Will update the PR if there are any other failures.

cc @emillon 