### PR TITLE
Make dune dependency implicit

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,8 +21,6 @@
  (depends
   (ocaml
    (>= 4.02.3))
-  (dune
-   (>= 2.0))
   ocamlfind
   fmt
   (cppo :build)

--- a/mdx.opam
+++ b/mdx.opam
@@ -21,8 +21,8 @@ license: "ISC"
 homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
   "dune" {>= "2.2"}
+  "ocaml" {>= "4.02.3"}
   "ocamlfind"
   "fmt"
   "cppo" {build}


### PR DESCRIPTION
This way it is added automatically with the right bound when generating the opam file.