### PR TITLE
Unset test: set a variable instead of using HOME

### DIFF
--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -144,18 +144,6 @@
  (action (diff environment-variable-set/test-case.md environment-variable-set.actual)))
 
 (rule
- (target environment-variable-unset.actual)
- (deps (package mdx) (source_tree environment-variable-unset))
- (action
-  (with-stdout-to %{target}
-   (chdir environment-variable-unset
-    (run ocaml-mdx test --output - test-case.md)))))
-
-(rule
- (alias runtest)
- (action (diff environment-variable-unset/test-case.md environment-variable-unset.actual)))
-
-(rule
  (target envs.actual)
  (deps (package mdx) (source_tree envs))
  (action

--- a/test/bin/mdx-test/misc/environment-variable-unset/dune
+++ b/test/bin/mdx-test/misc/environment-variable-unset/dune
@@ -1,0 +1,16 @@
+(rule
+ (deps
+  (package mdx)
+  (source_tree environment-variable-unset))
+ (action
+  (with-stdout-to
+   test-case.output
+   (setenv
+    VAR
+    val
+    (run ocaml-mdx test --output - %{dep:test-case.md})))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff test-case.md test-case.output)))

--- a/test/bin/mdx-test/misc/environment-variable-unset/test-case.md
+++ b/test/bin/mdx-test/misc/environment-variable-unset/test-case.md
@@ -1,4 +1,4 @@
-Environment variables can be blacklisted in an shell and bash blocks.
+Environment variables can be unset in an shell and bash blocks.
 
 ```sh
   $ echo $VAR

--- a/test/bin/mdx-test/misc/environment-variable-unset/test-case.md
+++ b/test/bin/mdx-test/misc/environment-variable-unset/test-case.md
@@ -1,11 +1,11 @@
 Environment variables can be blacklisted in an shell and bash blocks.
 
 ```sh
-  $ echo $HOME
-  ...
+  $ echo $VAR
+  val
 ```
 
-```sh unset-HOME
-  $ echo $HOME
+```sh unset-VAR
+  $ echo $VAR
   
 ```


### PR DESCRIPTION
There are two drawbacks to using `HOME`:

- it is different between systems, so this requires an ellipsis
- in Cygwin, HOME is set by the runtime system when `sh` starts, so it continues to appear even when it has been removed from the environment.

Instead, we can use an explicit variable that we control.

In addition this improves the related language to use "unset variable".