### PR TITLE
Add a command that generates test code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 #### Added
 
+- Add a new `dune-gen` subcommand that generates testing code for Dune to build
+  and run with the new `mdx` stanza. (#305, @voodoos)
+
 #### Changed
 
 #### Deprecated

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -95,6 +95,12 @@ let prelude_str =
     (fun x -> `Prelude_str x)
     Arg.(value & opt_all string [] & info [ "prelude-str" ] ~doc ~docv:"STR")
 
+let directories =
+  let doc = "A list of directories to load for the #directory directive." in
+  named
+    (fun x -> `Directories x)
+    Arg.(value & opt_all string [] & info [ "directory" ] ~doc ~docv:"STR")
+
 let root =
   let doc = "The directory to run the tests from." in
   named

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -22,6 +22,8 @@ val prelude : [> `Prelude of string list ] t
 
 val prelude_str : [> `Prelude_str of string list ] t
 
+val directories : [> `Directories of string list ] t
+
 val root : [> `Root of string option ] t
 
 val force_output : [> `Force_output of bool ] t

--- a/bin/dune_gen.ml
+++ b/bin/dune_gen.ml
@@ -1,0 +1,61 @@
+(*
+ * Copyright (c) 2020 Ulysse Gérard <ulysse@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+let run (`Setup ()) (`Prelude prelude) (`Directories dirs) =
+  let buffer = Buffer.create 1024 in
+  let line fmt = Printf.bprintf buffer (fmt ^^ "\n") in
+  let list l =
+    Printf.sprintf "[%s]\n"
+      (String.concat ";" (List.map (Printf.sprintf "%S") l))
+  in
+  line "let run_exn_defaults =";
+  line "  let open Mdx_test in";
+  line "  let packages =";
+  line "    Package.[";
+  line "      unix;";
+  line "      findlib_top;";
+  line "      findlib_internal;";
+  line "      compilerlibs_toplevel;";
+  line "    ]";
+  line "  in";
+  line "  let predicates = Predicate.[ byte; toploop ] in";
+  line "  run_exn ~packages ~predicates ~prelude_str:[]";
+  line "    ~non_deterministic:false";
+  line "    ~silent_eval:false ~record_backtrace:false";
+  line "    ~syntax:None ~silent:false";
+  line "    ~verbose_findlib:false ~section:None";
+  line "    ~root:None ~force_output:false";
+  line "    ~output:(Some `Stdout)";
+
+  line "let file = Sys.argv.(1)";
+  line "let prelude = %s" (list prelude);
+  line "let directives = List.map (fun path ->";
+  line "  Mdx_top.Directory path) %s" (list dirs);
+  line "let _ = run_exn_defaults";
+  line "  ~file";
+  line "  ~prelude";
+  line "  ~directives";
+  Buffer.output_buffer stdout buffer;
+  0
+
+let cmd =
+  let open Cmdliner in
+  let doc =
+    "Generate the source for a specialized testing binary. This command is \
+     meant to be used by dune only. There are no stability guarantees."
+  in
+  ( Term.(pure run $ Cli.setup $ Cli.prelude $ Cli.directories),
+    Term.info "dune-gen" ~doc )

--- a/bin/dune_gen.mli
+++ b/bin/dune_gen.mli
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2018 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2020 Ulysse Gérard <ulysse@tarides.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -16,25 +16,4 @@
 
 open Cmdliner
 
-let cmds = [ Test.cmd; Pp.cmd; Rule.cmd; Deps.cmd; Dune_gen.cmd ]
-
-let main (`Setup ()) = `Help (`Pager, None)
-
-let main =
-  let doc = "Execute markdown files." in
-  let exits = Term.default_exits in
-  let man = [] in
-  ( Term.(ret (const main $ Cli.setup)),
-    Term.info "ocaml-mdx" ~version:"%%VERSION%%" ~doc ~exits ~man )
-
-let main () = Term.(exit_status @@ eval_choice main cmds)
-
-let main () =
-  if String.compare Sys.argv.(0) "mdx" == 0 then
-    Format.eprintf
-      "\x1b[0;1mWarning\x1b[0m: 'mdx' is deprecated and will one day be removed.\n\
-      \    Use 'ocaml-mdx' instead\n\
-       %!";
-  main ()
-
-let () = main ()
+val cmd : int Term.t * Term.info

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -28,7 +28,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
     | Some (File outfile) -> Some (`File outfile)
     | None -> None
   in
-  let dirs = [] in
+  let directives = [] in
   let packages =
     [
       Mdx_test.Package.unix;
@@ -40,7 +40,7 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
   let predicates = [ Mdx_test.Predicate.byte; Mdx_test.Predicate.toploop ] in
   Mdx_test.run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax
     ~silent ~verbose_findlib ~prelude ~prelude_str ~file ~section ~root
-    ~force_output ~output ~dirs ~packages ~predicates
+    ~force_output ~output ~directives ~packages ~predicates
 
 let report_error_in_block block msg =
   let kind =

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -268,13 +268,13 @@ let preludes ~prelude ~prelude_str =
 
 let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
     ~verbose_findlib ~prelude ~prelude_str ~file ~section ~root ~force_output
-    ~output ~dirs ~packages ~predicates =
+    ~output ~directives ~packages ~predicates =
   Printexc.record_backtrace record_backtrace;
   let syntax =
     match syntax with Some syntax -> Some syntax | None -> Syntax.infer ~file
   in
   let c =
-    Mdx_top.init ~verbose:(not silent_eval) ~silent ~verbose_findlib ~dirs
+    Mdx_top.init ~verbose:(not silent_eval) ~silent ~verbose_findlib ~directives
       ~packages ~predicates ()
   in
   let preludes = preludes ~prelude ~prelude_str in

--- a/lib/test/mdx_test.mli
+++ b/lib/test/mdx_test.mli
@@ -30,7 +30,7 @@ val run_exn :
   root:string option ->
   force_output:bool ->
   output:[ `File of string | `Stdout ] option ->
-  dirs:string list ->
+  directives:Mdx_top.directive list ->
   packages:string list ->
   predicates:string list ->
   int

--- a/lib/top/mdx_top.mli
+++ b/lib/top/mdx_top.mli
@@ -22,11 +22,15 @@ open Result
 type t
 (** The type for configuration values. *)
 
+type directive =
+  | Directory of string
+  | Load of string  (** The type for toplevel directives *)
+
 val init :
   verbose:bool ->
   silent:bool ->
   verbose_findlib:bool ->
-  dirs:string list ->
+  directives:directive list ->
   packages:string list ->
   predicates:string list ->
   unit ->

--- a/test/bin/mdx-dune-gen/misc/.ocamlformat
+++ b/test/bin/mdx-dune-gen/misc/.ocamlformat
@@ -1,0 +1,1 @@
+disable=true

--- a/test/bin/mdx-dune-gen/misc/basic/dune
+++ b/test/bin/mdx-dune-gen/misc/basic/dune
@@ -1,0 +1,12 @@
+(rule
+ (target dune_gen.ml)
+ (action
+  (with-stdout-to
+   %{target}
+   (run ocaml-mdx dune-gen --prelude %{dep:prelude.ml} --prelude
+     %{dep:prelude2.ml}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff %{dep:dune.gen.expected} %{dep:dune_gen.ml})))

--- a/test/bin/mdx-dune-gen/misc/basic/dune.gen.expected
+++ b/test/bin/mdx-dune-gen/misc/basic/dune.gen.expected
@@ -1,0 +1,28 @@
+let run_exn_defaults =
+  let open Mdx_test in
+  let packages =
+    Package.[
+      unix;
+      findlib_top;
+      findlib_internal;
+      compilerlibs_toplevel;
+    ]
+  in
+  let predicates = Predicate.[ byte; toploop ] in
+  run_exn ~packages ~predicates ~prelude_str:[]
+    ~non_deterministic:false
+    ~silent_eval:false ~record_backtrace:false
+    ~syntax:None ~silent:false
+    ~verbose_findlib:false ~section:None
+    ~root:None ~force_output:false
+    ~output:(Some `Stdout)
+let file = Sys.argv.(1)
+let prelude = ["prelude.ml";"prelude2.ml"]
+
+let directives = List.map (fun path ->
+  Mdx_top.Directory path) []
+
+let _ = run_exn_defaults
+  ~file
+  ~prelude
+  ~directives

--- a/test/bin/mdx-dune-gen/misc/basic/duniverse-mode.md
+++ b/test/bin/mdx-dune-gen/misc/basic/duniverse-mode.md
@@ -1,0 +1,13 @@
+In duniverse mode, the generated rule for this block should contain a `(package block)` dependency:
+
+```ocaml
+# #require "block";;
+# 1 + 2
+- int : 3
+```
+
+The generated rule should also contain `(package x)` deps for every require in the prelude, both
+`.ml` preludes and string ones.
+
+Finally it should have a `(package mdx)` dependency as well since with duniverse, mdx should be
+vendored!

--- a/test/bin/mdx-dune-gen/misc/basic/prelude.ml
+++ b/test/bin/mdx-dune-gen/misc/basic/prelude.ml
@@ -1,0 +1,1 @@
+#require "prelude-ml";;

--- a/test/bin/mdx-dune-gen/misc/basic/prelude2.ml
+++ b/test/bin/mdx-dune-gen/misc/basic/prelude2.ml
@@ -1,0 +1,1 @@
+#require "prelude-ml";;


### PR DESCRIPTION
This PR is part of the implementation of the new Dune's `mdx` stanza.
The design document can be found [here](https://github.com/ocaml/dune/issues/3955).
The corresponding Dune's PR is [here](https://github.com/ocaml/dune/pull/3956).

This is a rough first attempt to generate a test executable, but it already works for most cases.
The main missing feature is the ability to pass a list of directories containing `cm*` files to the generator. 

I made a subcommand for now, but a separate binary might be a better choice ?