### PR TITLE
Require dune 2.8 for the tests

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,6 +21,7 @@
  (depends
   (ocaml
    (>= 4.02.3))
+  (dune (or (and :with-test (>= 2.8)) (>= 2.2)))
   ocamlfind
   fmt
   (cppo :build)

--- a/mdx.opam
+++ b/mdx.opam
@@ -21,8 +21,8 @@ license: "ISC"
 homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
-  "dune" {>= "2.2"}
   "ocaml" {>= "4.02.3"}
+  "dune" {with-test & >= "2.8" | >= "2.2"}
   "ocamlfind"
   "fmt"
   "cppo" {build}

--- a/test/bin/mdx-rule/misc/duniverse-mode/dune.gen.expected
+++ b/test/bin/mdx-rule/misc/duniverse-mode/dune.gen.expected
@@ -9,6 +9,11 @@
   prelude.ml)
  (action
   (progn
-   (run ocaml-mdx test --prelude=prelude.ml --prelude-str
-     "#require \"prelude-str\"" %{x})
+   (run
+    ocaml-mdx
+    test
+    --prelude=prelude.ml
+    --prelude-str
+    "#require \"prelude-str\""
+    %{x})
    (diff? %{x} %{x}.corrected))))


### PR DESCRIPTION
This requires dune 2.8 or higher to run the tests because dune files formatting changed in 2.8 and was causing a test for `mdx rule` to fail.