### PR TITLE
Format "expected" dune file

### DIFF
--- a/test/bin/mdx-rule/misc/duniverse-mode/dune
+++ b/test/bin/mdx-rule/misc/duniverse-mode/dune
@@ -9,4 +9,9 @@
 (rule
  (alias runtest)
  (action
-  (diff %{dep:dune.gen.expected} %{dep:dune.gen})))
+  (diff %{dep:dune.gen.expected.formatted} %{dep:dune.gen})))
+
+(rule
+ (with-stdout-to
+  dune.gen.expected.formatted
+  (run dune format-dune-file %{dep:dune.gen.expected})))


### PR DESCRIPTION
This makes sure that we do not depend on the actual formatting of the dune file (it has changed in dune 2.8).