### PR TITLE
Do not use patch_env anymore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 
 #### Fixed
 
+- Use the same output as the normal toplevel. Mdx used to carry an unsafe patch
+  to work around a bug fixed in OCaml 4.06 and that patch would change the
+  printed types in some corner cases. (#322, @emillon)
+
 #### Removed
 
 #### Security

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -537,35 +537,6 @@ let verbose t =
 let silent t =
   add_directive ~name:"silent" ~doc:"Be silent" (`Bool (fun x -> t.silent <- x))
 
-(* BLACK MAGIC: patch field of a module at runtime *)
-let monkey_patch (type a) (m : a) (type b) (prj : unit -> b) (v : b) =
-  let m = Obj.repr m in
-  let v = Obj.repr v in
-  let v' = Obj.repr (prj ()) in
-  if v' == v then ()
-  else
-    try
-      for i = 0 to Obj.size m - 1 do
-        if Obj.field m i == v' then (
-          Obj.set_field m i v;
-          if Obj.repr (prj ()) == v then raise Exit;
-          Obj.set_field m i v')
-      done;
-      invalid_arg "monkey_patch: field not found"
-    with Exit -> ()
-
-let patch_env () =
-  let module M = struct
-    module type T = module type of Env
-
-    let field () = Env.without_cmis
-
-    let replacement f x = f x
-
-    let () = monkey_patch (module Env : T) field replacement
-  end in
-  ()
-
 let protect f arg =
   try
     let _ = f arg in
@@ -604,7 +575,6 @@ let init ~verbose:v ~silent:s ~verbose_findlib ~directives ~packages ~predicates
   Mdx.Compat.init_path ();
   Toploop.toplevel_env := Compmisc.initial_env ();
   Sys.interactive := false;
-  patch_env ();
   List.iter
     (function
       | Directory path -> Topdirs.dir_directory path


### PR DESCRIPTION
`Env.without_cmis` has an issue in 4.04 and 4.05: it corrupts the environment, making the toplevel unusable after (see ocaml/ocaml#1223).

The `patch_env` function in mdx makes it a noop instead. This prevents corruption, but will display different results in some cases.

This PR restricts that workaround to affected versions. This has two benefits:
    
- this gives us a way to retire this piece of code, which relies on unsafe behavior
- this aligns the mdx behavior for recent compilers (after 2017) with what the toplevel does in these corner cases