### PR TITLE
4.13 compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 #### Added
 
+- Support for OCaml 4.13 (#330, @emillon)
+
 #### Changed
 
 #### Deprecated

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+### unreleased
+
+#### Added
+
+#### Changed
+
+#### Deprecated
+
+#### Removed
+
+#### Fixed
+
+#### Security
+
 ### 1.10.0
 
 #### Added

--- a/lib/top/compat_top.ml
+++ b/lib/top/compat_top.ml
@@ -386,3 +386,10 @@ let top_directive_require pkg =
 #else  
   Parsetree.Ptop_dir ("require", Pdir_string pkg)
 #endif
+
+let ctype_is_equal =
+#if OCAML_VERSION >= (4, 13, 0)
+  Ctype.is_equal
+#else
+  Ctype.equal
+#endif

--- a/lib/top/compat_top.mli
+++ b/lib/top/compat_top.mli
@@ -105,3 +105,6 @@ val top_directive_name : Parsetree.toplevel_phrase -> string option
 
 val top_directive_require : string -> Parsetree.toplevel_phrase
 (** [top_directive require "pkg"] builds the AST for [#require "pkg"] *)
+
+val ctype_is_equal :
+  Env.t -> bool -> Types.type_expr list -> Types.type_expr list -> bool

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -611,9 +611,10 @@ let init ~verbose:v ~silent:s ~verbose_findlib ~directives ~packages ~predicates
   Topfind.add_predicates predicates;
   (* [require] directive is overloaded to toggle the [errors] reference when
      an exception is raised. *)
-  Hashtbl.add Toploop.directive_table "require"
+  Toploop.add_directive "require"
     (Toploop.Directive_string
-       (fun s -> protect Topfind.load_deeply (in_words s)));
+       (fun s -> protect Topfind.load_deeply (in_words s)))
+    { Toploop.section = "Loading code"; doc = "Load an ocamlfind package" };
   let t = { verbose = v; silent = s; verbose_findlib } in
   show ();
   show_val ();

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -453,8 +453,11 @@ let show_exception () =
   reg_show_prim "show_exception"
     (fun env loc id lid ->
       let desc = Compat_top.find_constructor env loc lid in
-      if not (Ctype.equal env true [ desc.cstr_res ] [ Predef.type_exn ]) then
-        raise Not_found;
+      if
+        not
+          (Compat_top.ctype_is_equal env true [ desc.cstr_res ]
+             [ Predef.type_exn ])
+      then raise Not_found;
       let ret_type =
         if desc.cstr_generalized then Some Predef.type_exn else None
       in

--- a/test/bin/mdx-test/expect/warnings/test-case.md
+++ b/test/bin/mdx-test/expect/warnings/test-case.md
@@ -1,34 +1,31 @@
 No warning is printed by default:
 
 ```ocaml
-let () =
-  let f ~x:() = () in
-  f ();;
-let x = 4
+type p = { x : int ; y : int }
+
+let x { x } = x
 ```
 
 Warning attributes must be set to print them:
 
 ```ocaml version<4.12
-[@@@warning "+6"]
-let () =
-  let f ~x:() = () in
-  f ();;
-let x = 4
+[@@@warning "+9"]
+let x { x } = x
 ```
 ```mdx-error
 ...
-Warning 6: label x was omitted in the application of this function.
+Warning 9: the following labels are not bound in this record pattern:
+y
+Either bind these labels explicitly or add '; _' to the pattern.
 ```
 
 ```ocaml version>=4.12
-[@@@warning "+6"]
-let () =
-  let f ~x:() = () in
-  f ();;
-let x = 4
+[@@@warning "+9"]
+let x { x } = x
 ```
 ```mdx-error
-Line 4, characters 5-6:
-Warning 6 [labels-omitted]: label x was omitted in the application of this function.
+Line 2, characters 9-14:
+Warning 9 [missing-record-field-pattern]: the following labels are not bound in this record pattern:
+y
+Either bind these labels explicitly or add '; _' to the pattern.
 ```


### PR DESCRIPTION
- Adding to `directive_table` is deprecated in 4.13. Using `add_directive` requires adding some information that will be
displayed by `#help`.
- Handle `Ctype.equal` being renamed to `Ctype.is_equal`