### PR TITLE
Update opam dependencies specification

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@
   (csexp
    (>= 1.3.2))
   astring
-  logs
+  (logs (>= 0.7.0))
   (cmdliner
    (>= 1.0.0))
   (re

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
   (ocaml
    (>= 4.02.3))
   ocamlfind
-  fmt
+  (fmt (>= 0.8.4))
   (cppo :build)
   (csexp
    (>= 1.3.2))

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
   (ocaml
    (>= 4.02.3))
   ocamlfind
-  (fmt (>= 0.8.4))
+  (fmt (>= 0.8.5))
   (cppo :build)
   (csexp
    (>= 1.3.2))

--- a/dune-project
+++ b/dune-project
@@ -35,6 +35,6 @@
   result
   (ocaml-version
    (>= 2.3.0))
-  odoc
+  (odoc (>= 1.4.1))
   (lwt :with-test)
   (alcotest :with-test)))

--- a/mdx.opam
+++ b/mdx.opam
@@ -28,7 +28,7 @@ depends: [
   "cppo" {build}
   "csexp" {>= "1.3.2"}
   "astring"
-  "logs"
+  "logs" {>= "0.7.0"}
   "cmdliner" {>= "1.0.0"}
   "re" {>= "1.7.2"}
   "result"

--- a/mdx.opam
+++ b/mdx.opam
@@ -24,7 +24,7 @@ depends: [
   "dune" {>= "2.2"}
   "ocaml" {>= "4.02.3"}
   "ocamlfind"
-  "fmt" {>= "0.8.4"}
+  "fmt" {>= "0.8.5"}
   "cppo" {build}
   "csexp" {>= "1.3.2"}
   "astring"

--- a/mdx.opam
+++ b/mdx.opam
@@ -24,7 +24,7 @@ depends: [
   "dune" {>= "2.2"}
   "ocaml" {>= "4.02.3"}
   "ocamlfind"
-  "fmt"
+  "fmt" {>= "0.8.4"}
   "cppo" {build}
   "csexp" {>= "1.3.2"}
   "astring"

--- a/mdx.opam
+++ b/mdx.opam
@@ -33,7 +33,7 @@ depends: [
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}
-  "odoc"
+  "odoc" {>= "1.4.1"}
   "lwt" {with-test}
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
As shown by ocaml/opam-repository#18782, our opam file was missing some lower bounds.

This PR adds them to match our latest release's opam file.