### PR TITLE
Show exceptions in the correct order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 #### Fixed
 
+- Show exceptions in the correct order (#332, @talex5)
+
 #### Security
 
 ### 1.9.0

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -372,7 +372,7 @@ let errors = ref false
 
 let eval t cmd =
   let buf = Buffer.create 1024 in
-  let ppf = Format.formatter_of_buffer buf in
+  let ppf = Format.formatter_of_out_channel stderr in
   errors := false;
   let exec_code ~capture phrase =
     let lines = ref [] in

--- a/test/bin/mdx-test/expect/errors/test-case.md
+++ b/test/bin/mdx-test/expect/errors/test-case.md
@@ -65,3 +65,9 @@ Error: This expression has type string but an expression was expected of type
 # raise Not_found
 Exception: Not_found.
 ```
+
+```ocaml
+# print_endline "first"; failwith "second"
+first
+Exception: Failure "second".
+```


### PR DESCRIPTION
Previously:

- We redirected stdout and stderr to a file.
- We copied this to an in-memory buffer from time to time.
- We wrote exceptions directly to the in-memory buffer.

This meant that exceptions raised after writing output would appear before the output in the buffer.

We now write exceptions to the file too. This means that they appear in order with the rest of the output.

Fixes #328.