### PR TITLE
Upgrade to Odoc 2.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 #### Changed
 
+- Use odoc-parser.0.9.0 (#333, @julow)
+
 #### Deprecated
 
 #### Fixed

--- a/dune-project
+++ b/dune-project
@@ -35,6 +35,6 @@
   result
   (ocaml-version
    (>= 2.3.0))
-  (odoc (>= 1.4.1))
+  (odoc-parser (>= 0.9.0))
   (lwt :with-test)
   (alcotest :with-test)))

--- a/lib/dune
+++ b/lib/dune
@@ -4,7 +4,8 @@
  (preprocess
   (action
    (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
- (libraries astring csexp fmt logs ocaml-version odoc.parser re result str))
+ (libraries astring csexp fmt logs ocaml-version odoc-parser re result str
+   compiler-libs.common))
 
 (ocamllex lexer_mdx)
 

--- a/lib/mli_parser.ml
+++ b/lib/mli_parser.ml
@@ -1,7 +1,7 @@
 open! Compat
 
 module Code_block = struct
-  type t = { location : Odoc_model.Location_.span; contents : string }
+  type t = { location : Odoc_parser.Loc.span; contents : string }
 end
 
 let drop_last lst =
@@ -14,8 +14,8 @@ let drop_first_and_last = function
   | [] -> None
   | first :: tl -> Some (first, drop_last tl)
 
-let slice lines ~(start : Odoc_model.Location_.point)
-    ~(end_ : Odoc_model.Location_.point) =
+let slice lines ~(start : Odoc_parser.Loc.point) ~(end_ : Odoc_parser.Loc.point)
+    =
   let lines_to_include =
     Util.Array.slice lines ~from:(start.line - 1) ~to_:(end_.line - 1)
     |> Array.to_list
@@ -65,7 +65,7 @@ let slice lines ~(start : Odoc_model.Location_.point)
    end of "[**", but doesn't add those three characters to the within-the-file column
    number. Here, we make the adjustment.
 *)
-let account_for_docstring_open_token (location : Odoc_model.Location_.span) =
+let account_for_docstring_open_token (location : Odoc_parser.Loc.span) =
   let start_shift = 3 in
   let end_shift = if location.start.line = location.end_.line then 3 else 0 in
   {
@@ -78,8 +78,8 @@ let extract_code_blocks ~(location : Lexing.position) ~docstring =
   let rec acc blocks =
     List.map
       (fun block ->
-        match Odoc_model.Location_.value block with
-        | `Code_block contents ->
+        match Odoc_parser.Loc.value block with
+        | `Code_block (_metadata, { Odoc_parser.Loc.value = contents; _ }) ->
             let location =
               if location.pos_lnum = block.location.start.line then
                 account_for_docstring_open_token block.location
@@ -91,17 +91,17 @@ let extract_code_blocks ~(location : Lexing.position) ~docstring =
       blocks
     |> List.concat
   in
-  let parsed = Odoc_parser.parse_comment_raw ~location ~text:docstring in
+  let parsed = Odoc_parser.parse_comment ~location ~text:docstring in
   List.iter
-    (fun error -> failwith (Odoc_model.Error.to_string error))
-    parsed.warnings;
+    (fun error -> failwith (Odoc_parser.Warning.to_string error))
+    (Odoc_parser.warnings parsed);
   List.map
     (fun element ->
-      match Odoc_model.Location_.value element with
-      | #Odoc_parser.Ast.nestable_block_element as e ->
-          acc
-            [ { Odoc_model.Location_.location = element.location; value = e } ]
-      | `Tag tag -> (
+      match element with
+      | { Odoc_parser.Loc.value = #Odoc_parser.Ast.nestable_block_element; _ }
+        as e ->
+          acc [ e ]
+      | { value = `Tag tag; _ } -> (
           match tag with
           | `Deprecated blocks -> acc blocks
           | `Param (_, blocks) -> acc blocks
@@ -110,8 +110,8 @@ let extract_code_blocks ~(location : Lexing.position) ~docstring =
           | `See (_, _, blocks) -> acc blocks
           | `Before (_, blocks) -> acc blocks
           | _ -> [])
-      | `Heading _ -> [])
-    parsed.value
+      | { value = `Heading _; _ } -> [])
+    (Odoc_parser.ast parsed)
   |> List.concat
 
 let docstrings lexbuf =
@@ -128,10 +128,10 @@ let docstrings lexbuf =
   in
   loop [] |> List.rev
 
-let convert_pos (p : Lexing.position) (pt : Odoc_model.Location_.point) =
+let convert_pos (p : Lexing.position) (pt : Odoc_parser.Loc.point) =
   { p with pos_lnum = pt.line; pos_cnum = pt.column }
 
-let convert_loc (loc : Location.t) (sp : Odoc_model.Location_.span) =
+let convert_loc (loc : Location.t) (sp : Odoc_parser.Loc.span) =
   let loc_start = convert_pos loc.loc_start sp.start in
   let loc_end = convert_pos loc.loc_end sp.end_ in
   { loc with loc_start; loc_end }
@@ -155,7 +155,7 @@ let parse_mli file_contents =
      [Text] and [Block] parts by using the starts and ends of those blocks as
      boundaries. *)
   let code_blocks = docstring_code_blocks file_contents in
-  let cursor = ref { Odoc_model.Location_.line = 1; column = 0 } in
+  let cursor = ref { Odoc_parser.Loc.line = 1; column = 0 } in
   let lines = String.split_on_char '\n' file_contents |> Array.of_list in
   let tokens =
     List.map
@@ -185,11 +185,11 @@ let parse_mli file_contents =
   in
   let eof =
     {
-      Odoc_model.Location_.line = Array.length lines;
+      Odoc_parser.Loc.line = Array.length lines;
       column = String.length lines.(Array.length lines - 1);
     }
   in
-  let eof_is_beyond_location (loc : Odoc_model.Location_.point) =
+  let eof_is_beyond_location (loc : Odoc_parser.Loc.point) =
     eof.line > loc.line || (eof.line = loc.line && eof.column > loc.column)
   in
   if eof_is_beyond_location !cursor then

--- a/lib/mli_parser.mli
+++ b/lib/mli_parser.mli
@@ -1,8 +1,4 @@
 open! Compat
 
-module Code_block : sig
-  type t = { location : Odoc_model.Location_.span; contents : string }
-end
-
 val parse_mli : string -> (Document.line list, [ `Msg of string ]) Result.result
 (** Slice an mli file into its [Text] and [Block] parts. *)

--- a/mdx.opam
+++ b/mdx.opam
@@ -33,7 +33,7 @@ depends: [
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}
-  "odoc" {>= "1.4.1"}
+  "odoc-parser" {>= "0.9.0"}
   "lwt" {with-test}
   "alcotest" {with-test}
 ]

--- a/mdx.opam
+++ b/mdx.opam
@@ -36,6 +36,7 @@ depends: [
   "odoc-parser" {>= "0.9.0"}
   "lwt" {with-test}
   "alcotest" {with-test}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
In Odoc 2.0.0 (which is not released yet), the parser will be packaged separately and the API will change slightly. The API might change a bit again, I'll update this PR accordingly.

An other change is the "metadata" field, allowing to attach informations on every code blocks:

```ocaml
{@ocaml labels... [ ... ]}
```

This PR updates the code to work with the new version and handle the metadata field.

An other change in this PR is that code blocks without header are no longer run. Existing code blocks that were running before need to be changed. Perhaps this change is out of scope and should be removed ?

