### PR TITLE
Update dune lang to get proper opam file generation

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.2)
+(lang dune 2.7)
 
 (name mdx)
 

--- a/mdx.opam
+++ b/mdx.opam
@@ -21,7 +21,7 @@ license: "ISC"
 homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
-  "dune" {>= "2.2"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.02.3"}
   "ocamlfind"
   "fmt" {>= "0.8.5"}
@@ -38,7 +38,7 @@ depends: [
   "alcotest" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
opam-repository CI rejects the use of `{pinned}` now, bumping the dune lang that way generate the right opam file, using the prefered `{dev}` flag
