### PR TITLE
Upgrade to ocamlformat.0.19.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version=0.18.0
+version=0.19.0
 profile=conventional

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -70,11 +70,12 @@ let pp_rules ~nd ~prelude ~md_file ~ml_files ~dirs ~root ~packages ~locks fmt
     and ml_files = List.map2 (fun name p -> `Named (name, p)) var_names ml_files
     and dirs = List.map (fun p -> `Source_tree p) dirs
     and prelude = List.map (fun p -> `Path p) prelude_files in
-    `Named ("x", md_file) :: packages @ ml_files @ dirs @ prelude
+    (`Named ("x", md_file) :: packages) @ ml_files @ dirs @ prelude
   in
   let actions arg =
-    `Run ("ocaml-mdx" :: "test" :: options @ arg @ root @ [ "%{x}" ])
-    :: `Diff_corrected "x" :: List.map (fun v -> `Diff_corrected v) var_names
+    `Run (("ocaml-mdx" :: "test" :: options) @ arg @ root @ [ "%{x}" ])
+    :: `Diff_corrected "x"
+    :: List.map (fun v -> `Diff_corrected v) var_names
   in
   let pp fmt name arg =
     Fmt.pf fmt


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.19.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.