### PR TITLE
Recognise the metadata field on Odoc code blocks

### DIFF
--- a/test/bin/mdx-test/expect/simple-mli/test-case.mli
+++ b/test/bin/mdx-test/expect/simple-mli/test-case.mli
@@ -19,14 +19,30 @@
       print_endline (String.concat " " [the; last; phrase])
     ]}
 
-    {[
+    With the optional header:
+
+    {@ocaml[
       # List.map (fun x -> x * x) [(1 + 9); 2; 3]
       - : int list = [100; 4; 9]
       # List.map (fun x -> x * x) [1; 2; 3]
       - : int list = [1; 4; 9]
     ]}
+
+    A shell block:
+
+    {@sh set-FOO=Hello,set-BAR=Bash[$ echo $FOO $BAR
+Hello Bash
+
+    ]}
+
+    A block that doesn't run:
+
+    {@text[
+      # 1
+      = 2 ?
+    ]}
 *)
 val foo : string
 
-(** {[1 + 1 = 3]} *)
+(** {@ocaml[1 + 1 = 3]} *)
 val bar : string

--- a/test/lib/test_mli_parser.ml
+++ b/test/lib/test_mli_parser.ml
@@ -11,7 +11,7 @@ let mli =
 
     {[List.map (fun x -> x * x) [1; 2; 3]]}
 
-    {[
+    {@ocaml [
       # List.map (fun x -> x * x) [(1 + 9); 2; 3]
       - : int list = [100; 4; 9]
       # List.map (fun x -> x * x) [1; 2; 3]
@@ -20,7 +20,7 @@ let mli =
 *)
 val foo : string
 
-(** {[1 + 1 = 3]} *)
+(** {@ocaml [1 + 1 = 3]} *)
 val bar : string
 |}
 
@@ -53,7 +53,7 @@ let test_parse_mli =
  Block {loc: File "_none_", line 9; section: None; labels: [];
         header: Some ocaml;
         contents: ["List.map (fun x -> x * x) [1; 2; 3]"]; value: OCaml};
- Text "]}"; Text "\n\n    "; Text "{[";
+ Text "]}"; Text "\n\n    "; Text "{@"; Text "ocaml"; Text "[";
  Block {loc: File "_none_", lines 11-16; section: None; labels: [];
         header: Some ocaml;
         contents: ["# List.map (fun x -> x * x) [(1 + 9); 2; 3]";
@@ -61,7 +61,8 @@ let test_parse_mli =
                    "# List.map (fun x -> x * x) [1; 2; 3]";
                    "- : int list = [1; 4; 9]"];
         value: Toplevel};
- Text "    ]}"; Text "\n*)\nval foo : string\n\n(** "; Text "{[";
+ Text "    ]}"; Text "\n*)\nval foo : string\n\n(** "; Text "{@";
+ Text "ocaml"; Text "[";
  Block {loc: File "_none_", line 20; section: None; labels: [];
         header: Some ocaml; contents: ["1 + 1 = 3"]; value: OCaml};
  Text "]}";|x})


### PR DESCRIPTION
Odoc's parser will change again: https://github.com/ocaml-doc/odoc-parser/pull/2
It was decided to parse the "metadata" field of code blocks into two fields: the language tag and an arbitrary string. It is not possible to write the second field without the first.

If the metadata is absent, the code block is run as OCaml. This is backward compatible.

Until now, Mdx would strip it from the original file by ignoring it at parsing and not outputting it back. (<https://github.com/realworldocaml/mdx/pull/333#issuecomment-876388599>)
