### PR TITLE
Remove trailing whitespaces that were added to indent empty lines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 #### Fixed
 
+- Remove trailing whitespaces that were added to indent empty lines (#341, @gpetiot)
+
 #### Removed
 
 #### Security

--- a/lib/output.ml
+++ b/lib/output.ml
@@ -23,7 +23,8 @@ let dump ppf = function
   | `Output s -> Fmt.pf ppf "`Output %S" s
   | `Ellipsis -> Fmt.pf ppf "`Ellipsis"
 
-let pp ?(pad = 0) ppf = function
+let pp ?(pad = 0) ?syntax ppf = function
+  | `Output "" when syntax <> Some Syntax.Cram -> Fmt.pf ppf "\n"
   | `Output s -> Fmt.pf ppf "%a%s\n" pp_pad pad s
   | `Ellipsis -> Fmt.pf ppf "%a...\n" pp_pad pad
 

--- a/lib/output.mli
+++ b/lib/output.mli
@@ -28,7 +28,7 @@ val merge : [ `Output of string ] list -> t list -> t list
 (** [merge output test] merges any [`Ellipsis] items from [test] into
    [output]. *)
 
-val pp : ?pad:int -> t Fmt.t
+val pp : ?pad:int -> ?syntax:Syntax.t -> t Fmt.t
 (** [pp] is the pretty-printer for test outputs. [pad] is the size of
    the optional whitespace left-padding (by default it is 0). *)
 

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -115,7 +115,7 @@ let run_cram_tests ?syntax t ?root ppf temp_file pad tests =
           | `Ellipsis -> Output.pp ~pad ppf `Ellipsis
           | `Output line ->
               let line = ansi_color_strip line in
-              Output.pp ~pad ppf (`Output line))
+              Output.pp ?syntax ~pad ppf (`Output line))
         output;
       Cram.pp_exit_code ~pad ppf n)
     tests;

--- a/test/bin/mdx-test/expect/empty-lines/test-case.md
+++ b/test/bin/mdx-test/expect/empty-lines/test-case.md
@@ -5,6 +5,10 @@ This shell block contains an empty line within a padded block:
 
 ```
 
+```sh
+  $ echo "Hello..." && echo "" && echo "world!"
+```
+
 This toplevel block contains an empty line within a padded block:
 
 ```ocaml

--- a/test/bin/mdx-test/expect/empty-lines/test-case.md.expected
+++ b/test/bin/mdx-test/expect/empty-lines/test-case.md.expected
@@ -2,7 +2,14 @@ This shell block contains an empty line within a padded block:
 
 ```sh
  $ echo ''
- 
+
+```
+
+```sh
+  $ echo "Hello..." && echo "" && echo "world!"
+  Hello...
+
+  world!
 ```
 
 This toplevel block contains an empty line within a padded block:

--- a/test/bin/mdx-test/misc/environment-variable-unset/test-case.md
+++ b/test/bin/mdx-test/misc/environment-variable-unset/test-case.md
@@ -7,5 +7,5 @@ Environment variables can be unset in an shell and bash blocks.
 
 ```sh unset-VAR
   $ echo $VAR
-  
+
 ```


### PR DESCRIPTION
Fix #340

The `syntax` check is made to not produce an error in `.t` cram files: `File "test-case.t", lines 16-17: Error in the cram code block`