### PR TITLE
Add warning for phrases that are missing trailing ;;

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 #### Deprecated
 
+- Add a deprecation warning for toplevel blocks that are not terminated with `;;` (#342, @Leonidas-from-XIV)
+
 #### Fixed
 
 - Fix accidental redirect of stderr to stdout (#343, @Leonidas-from-XIV)

--- a/lib/deprecated.ml
+++ b/lib/deprecated.ml
@@ -27,12 +27,15 @@ let warn ?replacement s ~since =
 module Missing_double_semicolon = struct
   let missing_semicolon = ref false
 
-  let check_toplevel : Toplevel.t -> unit = function
-    | toplevel -> (
-        match List.rev toplevel.command with
-        | cmd :: _ when not @@ Astring.String.is_suffix ~affix:";;" cmd ->
-            missing_semicolon := true
-        | _ -> ())
+  let check_toplevel : Toplevel.t -> unit =
+   fun toplevel ->
+    match List.rev toplevel.command with
+    | cmd :: _ ->
+        let ends_with_semi =
+          cmd |> Astring.String.trim |> Astring.String.is_suffix ~affix:";;"
+        in
+        if not ends_with_semi then missing_semicolon := true
+    | [] -> ()
 
   let check_block block = List.iter check_toplevel block
 

--- a/lib/deprecated.ml
+++ b/lib/deprecated.ml
@@ -23,3 +23,28 @@ let warn ?replacement s ~since =
   Format.eprintf
     "Warning: %s is deprecated since %s and will be removed in 2.0.0. %s\n%!" s
     since replacement
+
+module Missing_double_semicolon = struct
+  let missing_semicolon = ref false
+
+  let check_toplevel : Toplevel.t -> unit = function
+    | toplevel -> (
+        match List.rev toplevel.command with
+        | cmd :: _ when not @@ Astring.String.is_suffix ~affix:";;" cmd ->
+            missing_semicolon := true
+        | _ -> ())
+
+  let check_block block = List.iter check_toplevel block
+
+  let report ~filename =
+    if !missing_semicolon then
+      Format.eprintf
+        "Warning: OCaml toplevel block without trailing ;; detected in file \
+         '%s'.\n\
+         Non-semicolon terminated phrases are deprecated.\n\
+         MDX 2.0 will accept them as input but will output them with ;; \
+         appended.\n\
+         In MDX 3.0 support for toplevel blocks without ;; will be removed \
+         completely.\n"
+        filename
+end

--- a/lib/deprecated.mli
+++ b/lib/deprecated.mli
@@ -16,3 +16,9 @@
 
 val warn : ?replacement:string -> string -> since:string -> unit
 (** Emits a warning on the standard error. *)
+
+module Missing_double_semicolon : sig
+  val check_block : Toplevel.t list -> unit
+
+  val report : filename:string -> unit
+end

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -317,30 +317,31 @@ let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
             ~det:(fun () ->
               run_cram_tests ?syntax t ?root ppf temp_file pad tests)
       | Toplevel { non_det; env } ->
-          let tests =
+          let phrases =
             let syntax = Util.Option.value syntax ~default:Normal in
             Toplevel.of_lines ~syntax ~loc:t.loc t.contents
           in
+          Deprecated.Missing_double_semicolon.check_block phrases;
           with_non_det non_deterministic non_det ~command:print_block
             ~output:(fun () ->
               assert (syntax <> Some Cram);
               print_block ();
               List.iter
-                (fun (test : Toplevel.t) ->
+                (fun (phrase : Toplevel.t) ->
                   match
                     Mdx_top.in_env env (fun () ->
-                        eval_test ~block:t ?root c test.command)
+                        eval_test ~block:t ?root c phrase.command)
                   with
                   | Ok _ -> ()
                   | Error e ->
                       let output = List.map (fun l -> `Output l) e in
-                      if Output.equal test.output output then ()
-                      else err_eval ~cmd:test.command e)
-                tests)
+                      if Output.equal phrase.output output then ()
+                      else err_eval ~cmd:phrase.command e)
+                phrases)
             ~det:(fun () ->
               assert (syntax <> Some Cram);
               Mdx_top.in_env env (fun () ->
-                  run_toplevel_tests ?syntax ?root c ppf tests t))
+                  run_toplevel_tests ?syntax ?root c ppf phrases t))
     else print_block ()
   in
   let gen_corrected file_contents items =
@@ -364,6 +365,7 @@ let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
             try test_block ~ppf ~temp_file t
             with Failure msg -> raise (Test_block_failure (t, msg))))
       items;
+    Deprecated.Missing_double_semicolon.report ~filename:file;
     Format.pp_print_flush ppf ();
     Buffer.contents buf
   in

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -287,7 +287,7 @@ let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
 
   let test_block ~ppf ~temp_file t =
     let print_block () = Block.pp ?syntax ppf t in
-    if Block.is_active ?section t then
+    if Block.is_active ?section t then (
       match Block.value t with
       | Raw _ -> print_block ()
       | Include { file_included; file_kind = Fk_ocaml { part_included } } ->
@@ -341,7 +341,7 @@ let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
             ~det:(fun () ->
               assert (syntax <> Some Cram);
               Mdx_top.in_env env (fun () ->
-                  run_toplevel_tests ?syntax ?root c ppf phrases t))
+                  run_toplevel_tests ?syntax ?root c ppf phrases t)))
     else print_block ()
   in
   let gen_corrected file_contents items =

--- a/test/bin/mdx-pp/expect/spaces/test-case.md
+++ b/test/bin/mdx-pp/expect/spaces/test-case.md
@@ -14,15 +14,15 @@ let x =
 
 # let x = 1
 
-  in x
+  in x;;
 - : int = 1
 
 
-# 3
+# 3;;
 - : int = 3
 
 
-# Printf.printf "foo\n\nbar\n"
+# Printf.printf "foo\n\nbar\n";;
 foo
 
 bar

--- a/test/bin/mdx-pp/expect/spaces/test_case.ml.expected
+++ b/test/bin/mdx-pp/expect/spaces/test_case.ml.expected
@@ -9,9 +9,8 @@ let x =
 #15 "test-case.md"
   let x = 1
   
-  in x
+  in x;;
 #21 "test-case.md"
-  3
+  3;;
 #25 "test-case.md"
-  Printf.printf "foo\n\nbar\n"
-;;
+  Printf.printf "foo\n\nbar\n";;

--- a/test/bin/mdx-test/expect/code/test-case.md
+++ b/test/bin/mdx-test/expect/code/test-case.md
@@ -11,9 +11,9 @@ let () = Printf.printf "n: %d\n%!" (f 42)
 Yo!
 
 ```ocaml
-# let x = 3
+# let x = 3;;
 val x : int = 3
-# type t = int
+# type t = int;;
 type t = int
 ```
 
@@ -22,12 +22,12 @@ class istack = object end
 ```
 
 ```ocaml
-# module type Foo = sig type t end
+# module type Foo = sig type t end;;
 module type Foo = sig type t end
 ```
 
 
 ```ocaml skip
-# Pipe.f ()
+# Pipe.f ();;
 - : unit
 ```

--- a/test/bin/mdx-test/expect/ellipsis/test-case.md
+++ b/test/bin/mdx-test/expect/ellipsis/test-case.md
@@ -10,7 +10,7 @@ $ for i in `seq 1 10`; do echo $i; done
 ```
 
 ```ocaml
-# for i = 1 to 10 do Printf.printf "%d\n%!" i; done
+# for i = 1 to 10 do Printf.printf "%d\n%!" i; done;;
 1
 2
 ...

--- a/test/bin/mdx-test/expect/empty-line/test-case.md
+++ b/test/bin/mdx-test/expect/empty-line/test-case.md
@@ -1,8 +1,8 @@
 Testing empty line output
 
 ```ocaml
-# print_newline ()
+# print_newline ();;
 - : unit = ()
-# print_endline ""
+# print_endline "";;
 - : unit = ()
 ```

--- a/test/bin/mdx-test/expect/empty-lines/test-case.md
+++ b/test/bin/mdx-test/expect/empty-lines/test-case.md
@@ -8,6 +8,6 @@ This shell block contains an empty line within a padded block:
 This toplevel block contains an empty line within a padded block:
 
 ```ocaml
- # print_newline
+ # print_newline;;
 
 ```

--- a/test/bin/mdx-test/expect/empty-lines/test-case.md.expected
+++ b/test/bin/mdx-test/expect/empty-lines/test-case.md.expected
@@ -8,6 +8,6 @@ This shell block contains an empty line within a padded block:
 This toplevel block contains an empty line within a padded block:
 
 ```ocaml
- # print_newline
+ # print_newline;;
  - : unit -> unit = <fun>
 ```

--- a/test/bin/mdx-test/expect/environment-variable-set/test-case.md
+++ b/test/bin/mdx-test/expect/environment-variable-set/test-case.md
@@ -5,10 +5,10 @@ Environment variables can be loeaded in ocaml blocks
 Environment variables can be loaded in an ocaml block environment.
 
 ```ocaml set-FOO=bar,set-BAR=foo
-  # print_endline (Sys.getenv "FOO")
+  # print_endline (Sys.getenv "FOO");;
   bar
   - : unit = ()
-  # print_endline (Sys.getenv "BAR")
+  # print_endline (Sys.getenv "BAR");;
   foo
   - : unit = ()
 ```
@@ -16,7 +16,7 @@ Environment variables can be loaded in an ocaml block environment.
 And the variable stays available in subsequent blocks.
 
 ```ocaml
-  # print_endline (Sys.getenv "FOO")
+  # print_endline (Sys.getenv "FOO");;
   bar
   - : unit = ()
 ```

--- a/test/bin/mdx-test/expect/environment-variable/test-case.md
+++ b/test/bin/mdx-test/expect/environment-variable/test-case.md
@@ -1,10 +1,10 @@
 Environment variable can also loaded in an environment
 
 ```ocaml set-FOO=bar,set-BAR=foo
-  # print_endline (Sys.getenv "FOO")
+  # print_endline (Sys.getenv "FOO");;
   bar
   - : unit = ()
-  # print_endline (Sys.getenv "BAR")
+  # print_endline (Sys.getenv "BAR");;
   foo
   - : unit = ()
 ```
@@ -12,7 +12,7 @@ Environment variable can also loaded in an environment
 And the variable stays available in subsequent blocks
 
 ```ocaml
-  # print_endline (Sys.getenv "FOO")
+  # print_endline (Sys.getenv "FOO");;
   bar
   - : unit = ()
 ```

--- a/test/bin/mdx-test/expect/errors/test-case.md
+++ b/test/bin/mdx-test/expect/errors/test-case.md
@@ -31,7 +31,7 @@ Hi!
 
 ```ocaml version=4.02
 # let x =
-  1 + "42"
+  1 + "42";;
 Characters 14-18:
 Error: This expression has type bytes but an expression was expected of type
          int
@@ -39,7 +39,7 @@ Error: This expression has type bytes but an expression was expected of type
 
 ```ocaml version=4.06
 # let x =
-  1 + "42"
+  1 + "42";;
 Characters 14-18:
 Error: This expression has type string but an expression was expected of type
          int
@@ -47,7 +47,7 @@ Error: This expression has type string but an expression was expected of type
 
 ```ocaml version=4.07
 # let x =
-  1 + "42"
+  1 + "42";;
 Characters 14-18:
 Error: This expression has type string but an expression was expected of type
          int
@@ -55,19 +55,19 @@ Error: This expression has type string but an expression was expected of type
 
 ```ocaml version>=4.08
 # let x =
-  1 + "42"
+  1 + "42";;
 Line 2, characters 7-11:
 Error: This expression has type string but an expression was expected of type
          int
 ```
 
 ```ocaml non-deterministic=output
-# raise Not_found
+# raise Not_found;;
 Exception: Not_found.
 ```
 
 ```ocaml
-# print_endline "first"; failwith "second"
+# print_endline "first"; failwith "second";;
 first
 Exception: Failure "second".
 ```

--- a/test/bin/mdx-test/expect/labels-syntax/test-case.md
+++ b/test/bin/mdx-test/expect/labels-syntax/test-case.md
@@ -6,10 +6,10 @@ Environment variables can be loaded in an ocaml block environment.
 
 <!-- $MDX set-FOO=bar,set-BAR=foo -->
 ```ocaml
-  # print_endline (Sys.getenv "FOO")
+  # print_endline (Sys.getenv "FOO");;
   bar
   - : unit = ()
-  # print_endline (Sys.getenv "BAR")
+  # print_endline (Sys.getenv "BAR");;
   foo
   - : unit = ()
 ```

--- a/test/bin/mdx-test/expect/lines/test-case.md
+++ b/test/bin/mdx-test/expect/lines/test-case.md
@@ -9,18 +9,18 @@ let f x =
 And
 
 ```ocaml version=4.02
-# let f x = x + 1
+# let f x = x + 1;;
 val f : int -> int = <fun>
 # let f y =
-  y^"foo"
+  y^"foo";;
 val f : bytes -> bytes = <fun>
 ```
 
 ```ocaml version>=4.06
-# let f x = x + 1
+# let f x = x + 1;;
 val f : int -> int = <fun>
 # let f y =
-  y^"foo"
+  y^"foo";;
 val f : string -> string = <fun>
 ```
 
@@ -30,7 +30,7 @@ And
 # let f x = function
   | 0 -> 1
   | n ->
-  n + "foo"
+  n + "foo";;
 Characters 45-50:
 Error: This expression has type bytes but an expression was expected of type
          int
@@ -40,7 +40,7 @@ Error: This expression has type bytes but an expression was expected of type
 # let f x = function
   | 0 -> 1
   | n ->
-  n + "foo"
+  n + "foo";;
 Characters 45-50:
 Error: This expression has type string but an expression was expected of type
          int
@@ -50,7 +50,7 @@ Error: This expression has type string but an expression was expected of type
 # let f x = function
   | 0 -> 1
   | n ->
-  n + "foo"
+  n + "foo";;
 Characters 45-50:
 Error: This expression has type string but an expression was expected of type
          int
@@ -60,7 +60,7 @@ Error: This expression has type string but an expression was expected of type
 # let f x = function
   | 0 -> 1
   | n ->
-  n + "foo"
+  n + "foo";;
 Line 4, characters 7-12:
 Error: This expression has type string but an expression was expected of type
          int

--- a/test/bin/mdx-test/expect/lwt/test-case.md
+++ b/test/bin/mdx-test/expect/lwt/test-case.md
@@ -1,16 +1,16 @@
 #require directives work as expected:
 
 ```ocaml
-# #require "lwt"
-# let x = Lwt.return 3
+# #require "lwt";;
+# let x = Lwt.return 3;;
 val x : int Lwt.t = <abstr>
 ```
 
 Top-level `Lwt` values are automatically evaluated with `Lwt_main.run`:
 
 ```ocaml
-# Lwt.return 4
+# Lwt.return 4;;
 - : int = 4
-# Lwt_list.map_p Lwt.return [1;2;3]
+# Lwt_list.map_p Lwt.return [1;2;3];;
 - : int list = [1; 2; 3]
 ```

--- a/test/bin/mdx-test/expect/multilines/test-case.md
+++ b/test/bin/mdx-test/expect/multilines/test-case.md
@@ -31,7 +31,7 @@ val fact : int -> int = <fun>
 # print_string "foo \
   \" \
   toto\
-  \ bar\""
+  \ bar\"";;
 foo " toto bar"
 - : unit = ()
 ```

--- a/test/bin/mdx-test/expect/non-det/test-case.md
+++ b/test/bin/mdx-test/expect/non-det/test-case.md
@@ -15,7 +15,7 @@ $ echo $RANDOM
 ```
 
 ```ocaml non-deterministic=output
-# Random.self_init (); Random.int 42
+# Random.self_init (); Random.int 42;;
 0
 ```
 
@@ -26,7 +26,7 @@ $ touch hello-world
 ```
 
 ```ocaml
-# Sys.file_exists "hello-world"
+# Sys.file_exists "hello-world";;
 - : bool = true
 ```
 
@@ -45,8 +45,8 @@ $ touch bar
 
 
 ```ocaml
-# Sys.file_exists "toto"
+# Sys.file_exists "toto";;
 - : bool = false
-# Sys.file_exists "bar"
+# Sys.file_exists "bar";;
 - : bool = true
 ```

--- a/test/bin/mdx-test/expect/prelude-file/test-case.md
+++ b/test/bin/mdx-test/expect/prelude-file/test-case.md
@@ -3,15 +3,15 @@ Prelude can also be in a file
 # A Guided Tour
 
 ```ocaml env=toto
-# raise Not_found
+# raise Not_found;;
 Exception: Not_found.
 ```
 
 ```ocaml
-# print_int x
+# print_int x;;
 2
 - : unit = ()
-# print_int y
+# print_int y;;
 4
 - : unit = ()
 ```

--- a/test/bin/mdx-test/expect/prelude/test-case.md
+++ b/test/bin/mdx-test/expect/prelude/test-case.md
@@ -1,7 +1,7 @@
 `ocaml-mdx test` can also take a prelude file.
 
 ```ocaml
-# Lwt.return 4
+# Lwt.return 4;;
 - : int = 4
 ```
 
@@ -9,19 +9,19 @@ It's possible to load a prelude only in a specific environment using
 `--prelude=toto:prelude.ml`:
 
 ```ocaml env=toto
-# print_endline x
+# print_endline x;;
 42
 - : unit = ()
 ```
 
 ```ocaml version<4.08
-# print_endline x
+# print_endline x;;
 Characters 14-15:
 Error: Unbound value x
 ```
 
 ```ocaml version>=4.08
-# print_endline x
+# print_endline x;;
 Line 1, characters 15-16:
 Error: Unbound value x
 ```

--- a/test/bin/mdx-test/expect/simple-mli/test-case.mli
+++ b/test/bin/mdx-test/expect/simple-mli/test-case.mli
@@ -1,7 +1,7 @@
 (** This is a doc comment with some code blocks in it:
 
     {[
-      # List.map (fun x -> x * x) [(1 + 9); 2; 3]
+      # List.map (fun x -> x * x) [(1 + 9); 2; 3];;
       - : int list = [100; 4; 9]
     ]}
 
@@ -20,9 +20,9 @@
     ]}
 
     {[
-      # List.map (fun x -> x * x) [(1 + 9); 2; 3]
+      # List.map (fun x -> x * x) [(1 + 9); 2; 3];;
       - : int list = [100; 4; 9]
-      # List.map (fun x -> x * x) [1; 2; 3]
+      # List.map (fun x -> x * x) [1; 2; 3];;
       - : int list = [1; 4; 9]
     ]}
 *)

--- a/test/bin/mdx-test/expect/spaces/test-case.md
+++ b/test/bin/mdx-test/expect/spaces/test-case.md
@@ -13,15 +13,15 @@ let x =
 
 # let x = 1
 
-  in x
+  in x;;
 - : int = 1
 
 
-# 3
+# 3;;
 - : int = 3
 
 
-# Printf.printf "foo\n\nbar\n"
+# Printf.printf "foo\n\nbar\n";;
 foo
 
 bar

--- a/test/bin/mdx-test/expect/trailing-whitespaces/test-case.md
+++ b/test/bin/mdx-test/expect/trailing-whitespaces/test-case.md
@@ -9,3 +9,13 @@ val x : int = 13
 $ echo "bob  "
 bob  
 ```
+
+Also, it should be valid to terminate phrases that end with `;;` but have
+trailing whitespace:
+
+```ocaml
+# let terminated_with_space = 42;; 
+val terminated_with_space : int = 42
+# let terminated_with_tab = 42;;	
+val terminated_with_tab : int = 42
+```

--- a/test/bin/mdx-test/expect/trailing-whitespaces/test-case.md.expected
+++ b/test/bin/mdx-test/expect/trailing-whitespaces/test-case.md.expected
@@ -9,3 +9,13 @@ val x : int = 13
 $ echo "bob  "
 bob
 ```
+
+Also, it should be valid to terminate phrases that end with `;;` but have
+trailing whitespace:
+
+```ocaml
+# let terminated_with_space = 42;; 
+val terminated_with_space : int = 42
+# let terminated_with_tab = 42;;	
+val terminated_with_tab : int = 42
+```

--- a/test/bin/mdx-test/misc/missing-double-semicolon/dune
+++ b/test/bin/mdx-test/misc/missing-double-semicolon/dune
@@ -1,0 +1,13 @@
+(rule
+ (target test-case.actual)
+ (deps
+  (package mdx))
+ (action
+  (with-outputs-to
+   %{target}
+   (run %{bin:ocaml-mdx} test %{dep:test-case.md}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff test-case.expected test-case.actual)))

--- a/test/bin/mdx-test/misc/missing-double-semicolon/test-case.expected
+++ b/test/bin/mdx-test/misc/missing-double-semicolon/test-case.expected
@@ -1,0 +1,4 @@
+Warning: OCaml toplevel block without trailing ;; detected in file 'test-case.md'.
+Non-semicolon terminated phrases are deprecated.
+MDX 2.0 will accept them as input but will output them with ;; appended.
+In MDX 3.0 support for toplevel blocks without ;; will be removed completely.

--- a/test/bin/mdx-test/misc/missing-double-semicolon/test-case.md
+++ b/test/bin/mdx-test/misc/missing-double-semicolon/test-case.md
@@ -1,0 +1,9 @@
+#files that contain top level blocks missing ;; should trigger a single warning
+
+```ocaml
+# let x = 42
+```
+
+```ocaml
+# let y = 23
+```


### PR DESCRIPTION
This adds a deprecation warning about `;;` to be required in future versions of mdx along with the roadmap of how things will change.