### PR TITLE
Fix restoring stderr correctly

### DIFF
--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -22,7 +22,7 @@ type directive = Directory of string | Load of string
 
 let redirect ~f =
   let stdout_backup = Unix.dup Unix.stdout in
-  let stderr_backup = Unix.dup Unix.stdout in
+  let stderr_backup = Unix.dup Unix.stderr in
   let filename = Filename.temp_file "ocaml-mdx" "stdout" in
   let fd_out =
     Unix.openfile filename Unix.[ O_WRONLY; O_CREAT; O_TRUNC ] 0o600


### PR DESCRIPTION
When running `ocaml-mdx` it would output warnings to the "corrected" files when running with `--output -`. Since warnings are emitted on stderr this should not be happening, which means that something was messing with stderr. It turns out yes, there is code which modifies stderr but also takes care of restoring it. Unfortunately a typo caused the backup to be stderr instead so restoring would redirect stderr to stdout.

(This PR is necessary to test #342 properly without mdx writing the new warning into the corrected file)