### PR TITLE
[Preview] upgrade to ocamlformat.0.20.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version=0.19.0
+version=0.20.0
 profile=conventional

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -1,31 +1,18 @@
 open Cmdliner.Term
 
 val named : ('a -> 'b) -> 'a t -> 'b t
-
 val non_deterministic : [> `Non_deterministic of bool ] t
-
 val syntax : [> `Syntax of Mdx.syntax option ] t
-
 val file : [> `File of string ] t
-
 val section : [> `Section of string option ] t
-
 val silent_eval : [> `Silent_eval of bool ] t
-
 val record_backtrace : [> `Record_backtrace of bool ] t
-
 val silent : [> `Silent of bool ] t
-
 val verbose_findlib : [> `Verbose_findlib of bool ] t
-
 val prelude : [> `Prelude of string list ] t
-
 val prelude_str : [> `Prelude_str of string list ] t
-
 val directories : [> `Directories of string list ] t
-
 val root : [> `Root of string option ] t
-
 val force_output : [> `Force_output of bool ] t
 
 type output = File of string | Stdout

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -17,7 +17,6 @@
 open Cmdliner
 
 let cmds = [ Test.cmd; Pp.cmd; Deps.cmd; Dune_gen.cmd ]
-
 let main (`Setup ()) = `Help (`Pager, None)
 
 let main =

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -85,5 +85,4 @@ let cmd =
     Term.info "ocaml-mdx-test" ~version:"%%VERSION%%" ~doc ~exits ~man )
 
 let main () = Term.(exit_status @@ eval cmd)
-
 let () = main ()

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -42,7 +42,6 @@ module Header = struct
 end
 
 type section = int * string
-
 type cram_value = { language : [ `Sh | `Bash ]; non_det : Label.non_det option }
 
 type ocaml_value = {
@@ -52,9 +51,7 @@ type ocaml_value = {
 }
 
 type toplevel_value = { env : Ocaml_env.t; non_det : Label.non_det option }
-
 type include_ocaml_file = { part_included : string option }
-
 type include_other_file = { header : Header.t option }
 
 type include_file_kind =
@@ -62,7 +59,6 @@ type include_file_kind =
   | Fk_other of include_other_file
 
 type include_value = { file_included : string; file_kind : include_file_kind }
-
 type raw_value = { header : Header.t option }
 
 type value =
@@ -87,7 +83,6 @@ type t = {
 }
 
 let dump_string ppf s = Fmt.pf ppf "%S" s
-
 let dump_section = Fmt.(Dump.pair int string)
 
 let header t =
@@ -195,7 +190,6 @@ let pp ?syntax ppf b =
   pp_errors ppf b
 
 let directory t = t.dir
-
 let file t = match t.value with Include t -> Some t.file_included | _ -> None
 
 let non_det t =
@@ -206,13 +200,9 @@ let non_det t =
   | Include _ | Raw _ -> None
 
 let skip t = t.skip
-
 let set_variables t = t.set_variables
-
 let unset_variables t = t.unset_variables
-
 let value t = t.value
-
 let section t = t.section
 
 let guess_ocaml_kind contents =
@@ -234,7 +224,6 @@ let ends_by_semi_semi c =
   | _ -> false
 
 let pp_line_directive ppf (file, line) = Fmt.pf ppf "#%d %S" line file
-
 let line_directive = Fmt.to_to_string pp_line_directive
 
 let executable_contents ~syntax b =

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -20,9 +20,7 @@ module Header : sig
   type t = Shell of [ `Sh | `Bash ] | OCaml | Other of string
 
   val pp : Format.formatter -> t -> unit
-
   val of_string : string -> t option
-
   val infer_from_file : string -> t option
 end
 

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -17,7 +17,6 @@
 let src = Logs.Src.create "ocaml-mdx"
 
 module Log = (val Logs.src_log src : Logs.LOG)
-
 open Astring
 open Misc
 

--- a/lib/dep.mli
+++ b/lib/dep.mli
@@ -17,7 +17,5 @@
 type t = File of string | Dir of string
 
 val of_block : Block.t -> t option
-
 val of_lines : Document.line list -> t list
-
 val to_sexp : t -> Util.Sexp.t

--- a/lib/deprecated.mli
+++ b/lib/deprecated.mli
@@ -19,6 +19,5 @@ val warn : ?replacement:string -> string -> since:string -> unit
 
 module Missing_double_semicolon : sig
   val fix : Toplevel.t list -> Toplevel.t list
-
   val report : filename:string -> unit
 end

--- a/lib/document.ml
+++ b/lib/document.ml
@@ -15,9 +15,7 @@
  *)
 
 type syntax = Syntax.t = Normal | Cram | Mli
-
 type line = Section of (int * string) | Text of string | Block of Block.t
-
 type t = line list
 
 let pp_line ?syntax ppf (l : line) =

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -18,7 +18,6 @@ module Relation : sig
   type t = Eq | Neq | Le | Lt | Ge | Gt
 
   val pp : Format.formatter -> t -> unit
-
   val compare : t -> int -> int -> bool
 
   val raw_parse : string -> string * (t * string) option

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -21,9 +21,7 @@ type t = { base_name : string; sub_lib : string option }
     *)
 
 val equal : t -> t -> bool
-
 val compare : t -> t -> int
-
 val pp : t Fmt.t
 
 val from_string : string -> (t, string) Result.result

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -17,9 +17,7 @@
 let src = Logs.Src.create "ocaml-mdx"
 
 module Lexer_mdx = Lexer_mdx
-
 module Log = (val Logs.src_log src : Logs.LOG)
-
 module Output = Output
 module Cram = Cram
 module Deprecated = Deprecated

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -41,7 +41,6 @@ module Label = Label
 module Dep = Dep
 module Ocaml_env = Ocaml_env
 module Stable_printer = Stable_printer
-
 include module type of Document
 
 val dump : line list Fmt.t

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -30,7 +30,6 @@ let pp_pad ppf = function
   | i -> Fmt.string ppf (String.v ~len:i (fun _ -> ' '))
 
 let pp_lines pp = Fmt.(list ~sep:(unit "\n") pp)
-
 let dump_string ppf s = Fmt.pf ppf "%S" s
 
 let read_file file =

--- a/lib/ocaml_delimiter.ml
+++ b/lib/ocaml_delimiter.ml
@@ -17,16 +17,12 @@
 open Result
 
 type syntax = Cmt | Attr
-
 type part_begin = { indent : string; payload : string }
-
 type t = Part_begin of syntax * part_begin | Part_end
 
 module Regexp = struct
   let marker = Re.str "$MDX"
-
   let spaces = Re.rep1 Re.space
-
   let id = Re.(rep1 (alt [ alnum; char '_'; char '-'; char '=' ]))
 
   let cmt =

--- a/lib/ocaml_delimiter.mli
+++ b/lib/ocaml_delimiter.mli
@@ -18,7 +18,6 @@
 type syntax = Cmt | Attr
 
 type part_begin = { indent : string; payload : string }
-
 type t = Part_begin of syntax * part_begin | Part_end
 
 val parse : string -> (t option, [ `Msg of string ]) Result.result

--- a/lib/ocaml_env.ml
+++ b/lib/ocaml_env.ml
@@ -1,7 +1,6 @@
 type t = Default | User_defined of string
 
 let mk = function None | Some "" -> Default | Some s -> User_defined s
-
 let name = function Default -> "" | User_defined s -> s
 
 type env = t

--- a/lib/ocaml_env.mli
+++ b/lib/ocaml_env.mli
@@ -3,7 +3,6 @@
 type t = Default | User_defined of string
 
 val name : t -> string
-
 val mk : string option -> t
 
 module Set : Set.S with type elt = t

--- a/lib/part.ml
+++ b/lib/part.ml
@@ -24,11 +24,8 @@ module Part = struct
   }
 
   let v ~name ~sep_indent ~body = { name; sep_indent; body }
-
   let name { name; _ } = name
-
   let sep_indent { sep_indent; _ } = sep_indent
-
   let body { body; _ } = body
 end
 

--- a/lib/syntax.mli
+++ b/lib/syntax.mli
@@ -1,9 +1,6 @@
 type t = Normal | Cram | Mli
 
 val pp : Format.formatter -> t -> unit
-
 val equal : t -> t -> bool
-
 val infer : file:string -> t option
-
 val of_string : string -> t option

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -379,16 +379,12 @@ let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
 
 module Package = struct
   let unix = "unix"
-
   let findlib_top = "findlib.top"
-
   let findlib_internal = "findlib.internal"
-
   let compilerlibs_toplevel = "compiler-libs.toplevel"
 end
 
 module Predicate = struct
   let byte = "byte"
-
   let toploop = "toploop"
 end

--- a/lib/test/mdx_test.mli
+++ b/lib/test/mdx_test.mli
@@ -2,17 +2,13 @@ exception Test_block_failure of Mdx.Block.t * string
 
 module Package : sig
   val unix : string
-
   val findlib_top : string
-
   val findlib_internal : string
-
   val compilerlibs_toplevel : string
 end
 
 module Predicate : sig
   val byte : string
-
   val toploop : string
 end
 

--- a/lib/top/compat_top.mli
+++ b/lib/top/compat_top.mli
@@ -1,5 +1,4 @@
 val lookup_type : Longident.t -> Env.t -> Path.t
-
 val lookup_value : Longident.t -> Env.t -> Path.t * Types.value_description
 
 val find_value :

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -106,7 +106,6 @@ module Phrase = struct
   }
 
   let result t = t.parsed
-
   let start t = t.startpos
 
   let error_of_exn exn =
@@ -383,7 +382,6 @@ let trim_line str =
     else String.sub str trim_from (trim_to - trim_from)
 
 let rtrim l = List.rev (ltrim (List.rev l))
-
 let trim l = ltrim (rtrim (List.map trim_line l))
 
 let cut_into_sentences l =
@@ -496,17 +494,11 @@ let reg_show_prim name to_sig doc =
   add_directive ~name ~doc (`Show_prim to_sig)
 
 let sig_value id desc = Types.Sig_value (id, desc, Exported)
-
 let sig_type id desc = Types.Sig_type (id, desc, Trec_not, Exported)
-
 let sig_typext id ext = Types.Sig_typext (id, ext, Text_exception, Exported)
-
 let sig_module id md = Types.Sig_module (id, Mp_present, md, Trec_not, Exported)
-
 let sig_modtype id desc = Types.Sig_modtype (id, desc, Exported)
-
 let sig_class id desc = Types.Sig_class (id, desc, Trec_not, Exported)
-
 let sig_class_type id desc = Types.Sig_class_type (id, desc, Trec_not, Exported)
 
 let show_val () =
@@ -701,7 +693,6 @@ let init ~verbose:v ~silent:s ~verbose_findlib ~directives ~packages ~predicates
   t
 
 let envs = Hashtbl.create 8
-
 let is_predef_or_global id = Ident.is_predef id || Ident.global id
 
 let rec save_summary acc s =
@@ -729,7 +720,6 @@ let rec save_summary acc s =
     ~value_unbound:default_case ~module_unbound:default_case
 
 let default_env = ref (Compmisc.initial_env ())
-
 let first_call = ref true
 
 let env_deps env =

--- a/lib/toplevel.ml
+++ b/lib/toplevel.ml
@@ -17,7 +17,6 @@
 let src = Logs.Src.create "ocaml-mdx"
 
 module Log = (val Logs.src_log src : Logs.LOG)
-
 open Astring
 open Misc
 

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -19,7 +19,6 @@ open Result
 module Result = struct
   module Infix = struct
     let ( >>= ) r f = match r with Ok x -> f x | Error _ as e -> e
-
     let ( >>| ) r f = match r with Ok x -> Ok (f x) | Error _ as e -> e
 
     let ( >>! ) r f =
@@ -64,7 +63,6 @@ end
 
 module Option = struct
   let is_some = function Some _ -> true | None -> false
-
   let value ~default = function Some v -> v | None -> default
 end
 

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -22,7 +22,6 @@ module Result : sig
       ('a, 'err) result -> ('a -> ('b, 'err) result) -> ('b, 'err) result
 
     val ( >>| ) : ('a, 'err) result -> ('a -> 'b) -> ('b, 'err) result
-
     val ( >>! ) : ('a, [ `Msg of string ]) result -> ('a -> int) -> int
   end
 
@@ -46,7 +45,6 @@ end
 
 module Option : sig
   val is_some : 'a option -> bool
-
   val value : default:'a -> 'a option -> 'a
 end
 

--- a/test/bin/gen_rule_helpers/gen_rule_helpers.ml
+++ b/test/bin/gen_rule_helpers/gen_rule_helpers.ml
@@ -37,13 +37,9 @@ let get_files dir =
   read_dir dir |> List.filter is_file
 
 let cwd_options_file = "test-case.opts"
-
 let cwd_test_file_md = "test-case.md"
-
 let cwd_test_file_t = "test-case.t"
-
 let cwd_test_file_mli = "test-case.mli"
-
 let cwd_enabled_if_file = "test-case.enabled-if"
 
 type dir = {

--- a/test/lib/testable.ml
+++ b/test/lib/testable.ml
@@ -21,5 +21,4 @@ let ocaml_delimiter =
   Alcotest.testable pp ( = )
 
 let block = Alcotest.testable Mdx.Block.dump ( = )
-
 let header = Alcotest.testable Mdx.Block.Header.pp ( = )

--- a/test/lib/testable.mli
+++ b/test/lib/testable.mli
@@ -1,9 +1,5 @@
 val sexp : Mdx.Util.Sexp.t Alcotest.testable
-
 val msg : [ `Msg of string ] Alcotest.testable
-
 val ocaml_delimiter : Mdx.Ocaml_delimiter.t Alcotest.testable
-
 val block : Mdx.Block.t Alcotest.testable
-
 val header : Mdx.Block.Header.t Alcotest.testable


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.20.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.
The changes are due to:
- `module-item-spacing` is now set to `compact` for the default profile