### PR TITLE
Make MDX compatible with 4.14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Add trailing `;;` to the output of toplevel phrases that were missing it.
   (#346, @Leonidas-from-XIV)
+- Make MDX compatible with OCaml 4.14 (#356, @NathanReb)
 
 #### Changed
 

--- a/lib/top/compat_top.ml
+++ b/lib/top/compat_top.ml
@@ -62,7 +62,11 @@ let find_class_type env loc id =
 #endif
 
 let type_structure env str loc =
+#if OCAML_VERSION >= (4, 14, 0)
+  let tstr, _, _, _, env =
+#else
   let tstr, _, _, env =
+#endif
 #if OCAML_VERSION >= (4, 12, 0)
     let _ = loc in
     Typemod.type_structure env str
@@ -148,4 +152,18 @@ let ctype_is_equal =
   Ctype.is_equal
 #else
   Ctype.equal
+#endif
+
+let ctype_expand_head_and_get_desc env ty =
+#if OCAML_VERSION >= (4, 14, 0)
+  Types.get_desc (Ctype.expand_head env ty)
+#else
+  (Ctype.expand_head env ty).Types.desc
+#endif
+
+let ctype_get_desc ty =
+#if OCAML_VERSION >= (4, 14, 0)
+  Types.get_desc ty
+#else
+  (Ctype.repr ty).Types.desc
 #endif

--- a/lib/top/compat_top.mli
+++ b/lib/top/compat_top.mli
@@ -57,3 +57,7 @@ val match_env :
 
 val ctype_is_equal :
   Env.t -> bool -> Types.type_expr list -> Types.type_expr list -> bool
+
+val ctype_expand_head_and_get_desc : Env.t -> Types.type_expr -> Types.type_desc
+
+val ctype_get_desc : Types.type_expr -> Types.type_desc

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -224,8 +224,8 @@ module Rewrite = struct
   let normalize_type_path env path =
     match Env.find_type path env with
     | { Types.type_manifest = Some ty; _ } -> (
-        match Ctype.expand_head env ty with
-        | { Types.desc = Types.Tconstr (path, _, _); _ } -> path
+        match Compat_top.ctype_expand_head_and_get_desc env ty with
+        | Types.Tconstr (path, _, _) -> path
         | _ -> path)
     | _ -> path
 
@@ -259,7 +259,7 @@ module Rewrite = struct
     match (pstr_item.Parsetree.pstr_desc, tstr_item.Typedtree.str_desc) with
     | ( Parsetree.Pstr_eval (e, _),
         Typedtree.Tstr_eval ({ Typedtree.exp_type = typ; _ }, _) ) -> (
-        match (Ctype.repr typ).Types.desc with
+        match Compat_top.ctype_get_desc typ with
         | Types.Tconstr (path, _, _) -> apply ts env pstr_item path e
         | _ -> pstr_item)
     | _ -> pstr_item


### PR DESCRIPTION
Not much to note here, some changes in the typing API, all pretty straight forward (see the upstream PR https://github.com/ocaml/ocaml/pull/10337) and the new `Shape.t` returned by `type_structure` which we can simply ignore as @voodoos confirmed it's not really relevant to MDX!