### PR TITLE
Make MDX compatible with 4.14 (1.11.x port)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 #### Added
 
+- Make MDX compatible with OCaml 4.14 (#356, @NathanReb)
+
 #### Changed
 
 #### Deprecated

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
   (ocaml
    (>= 4.02.3))
   ocamlfind
-  (fmt (>= 0.8.5))
+  (fmt (and (>= 0.8.5) (< 0.8.10)))
   (cppo :build)
   (csexp
    (>= 1.3.2))

--- a/lib/top/compat_top.ml
+++ b/lib/top/compat_top.ml
@@ -106,7 +106,9 @@ let find_class_type env loc id =
 #endif
 
 let type_structure env str loc =
-#if OCAML_VERSION >= (4, 8, 0)
+#if OCAML_VERSION >= (4, 14, 0)
+  let tstr, _, _, _, env =
+#elif OCAML_VERSION >= (4, 8, 0)
   let tstr, _, _, env =
 #else
   let tstr, _, env =
@@ -392,4 +394,18 @@ let ctype_is_equal =
   Ctype.is_equal
 #else
   Ctype.equal
+#endif
+
+let ctype_expand_head_and_get_desc env ty =
+#if OCAML_VERSION >= (4, 14, 0)
+  Types.get_desc (Ctype.expand_head env ty)
+#else
+  (Ctype.expand_head env ty).Types.desc
+#endif
+
+let ctype_get_desc ty =
+#if OCAML_VERSION >= (4, 14, 0)
+  Types.get_desc ty
+#else
+  (Ctype.repr ty).Types.desc
 #endif

--- a/lib/top/compat_top.mli
+++ b/lib/top/compat_top.mli
@@ -108,3 +108,7 @@ val top_directive_require : string -> Parsetree.toplevel_phrase
 
 val ctype_is_equal :
   Env.t -> bool -> Types.type_expr list -> Types.type_expr list -> bool
+
+val ctype_expand_head_and_get_desc : Env.t -> Types.type_expr -> Types.type_desc
+
+val ctype_get_desc : Types.type_expr -> Types.type_desc

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -208,8 +208,8 @@ module Rewrite = struct
   let normalize_type_path env path =
     match Env.find_type path env with
     | { Types.type_manifest = Some ty; _ } -> (
-        match Ctype.expand_head env ty with
-        | { Types.desc = Types.Tconstr (path, _, _); _ } -> path
+        match Compat_top.ctype_expand_head_and_get_desc env ty with
+        | Types.Tconstr (path, _, _) -> path
         | _ -> path)
     | _ -> path
 
@@ -238,7 +238,7 @@ module Rewrite = struct
     match (pstr_item.Parsetree.pstr_desc, tstr_item.Typedtree.str_desc) with
     | ( Parsetree.Pstr_eval (e, _),
         Typedtree.Tstr_eval ({ Typedtree.exp_type = typ; _ }, _) ) -> (
-        match (Ctype.repr typ).Types.desc with
+        match Compat_top.ctype_get_desc typ with
         | Types.Tconstr (path, _, _) -> apply ts env pstr_item path e
         | _ -> pstr_item)
     | _ -> pstr_item

--- a/mdx.opam
+++ b/mdx.opam
@@ -24,7 +24,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.02.3"}
   "ocamlfind"
-  "fmt" {>= "0.8.5"}
+  "fmt" {>= "0.8.5" & < "0.8.10"}
   "cppo" {build}
   "csexp" {>= "1.3.2"}
   "astring"


### PR DESCRIPTION
@kit-ty-kate asked me to release a version of MDX that is compatible with 4.14 and since the current MDX `main` is being prepared for a 2.0 release I thought I'd backport @NathanReb's #356 to a 1.11.x branch so we can quickly release a 1.11.1 with just the compatibility fix.