### PR TITLE
Replace uses of deprecated fmt functions

### DIFF
--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -46,7 +46,7 @@ let run (`Setup ()) (`File file) (`Section section) =
           | Block b ->
               if not (Mdx.Block.skip b) then (
                 Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
-                let pp_lines = Fmt.(list ~sep:(unit "\n") string) in
+                let pp_lines = Fmt.(list ~sep:(any "\n") string) in
                 let contents = Mdx.Block.executable_contents ~syntax:Normal b in
                 match b.value with
                 | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents

--- a/bin/rule.ml
+++ b/bin/rule.ml
@@ -40,7 +40,7 @@ let pp_locks_field fmt dirs_and_files =
   match dirs_and_files with
   | [] -> ()
   | locks ->
-      Fmt.pf fmt " (locks @[%a@])\n" Fmt.(list ~sep:(unit "@\n") string) locks
+      Fmt.pf fmt " (locks @[%a@])\n" Fmt.(list ~sep:(any "@\n") string) locks
 
 let pp_rules ~nd ~prelude ~md_file ~ml_files ~dirs ~root ~packages ~locks fmt
     options =

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
   (ocaml
    (>= 4.02.3))
   ocamlfind
-  (fmt (and (>= 0.8.5) (< 0.8.10)))
+  (fmt (>= 0.8.7))
   (cppo :build)
   (csexp
    (>= 1.3.2))

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -131,7 +131,7 @@ let pp_lines syntax t =
         fun ppf -> Fmt.fmt "%*s%s" ppf (t.loc.loc_start.pos_cnum + 2) ""
     | _ -> Fmt.string
   in
-  Fmt.(list ~sep:(unit "\n") pp)
+  Fmt.(list ~sep:(any "\n") pp)
 
 let lstrip string =
   let hpad = Misc.hpad_of_lines [ string ] in
@@ -163,11 +163,11 @@ let pp_footer ?syntax ppf t =
 
 let pp_legacy_labels ppf = function
   | [] -> ()
-  | l -> Fmt.pf ppf " %a" Fmt.(list ~sep:(unit ",") Label.pp) l
+  | l -> Fmt.pf ppf " %a" Fmt.(list ~sep:(any ",") Label.pp) l
 
 let pp_labels ppf = function
   | [] -> ()
-  | l -> Fmt.pf ppf "<!-- $MDX %a -->\n" Fmt.(list ~sep:(unit ",") Label.pp) l
+  | l -> Fmt.pf ppf "<!-- $MDX %a -->\n" Fmt.(list ~sep:(any ",") Label.pp) l
 
 let pp_header ?syntax ppf t =
   match syntax with

--- a/lib/document.ml
+++ b/lib/document.ml
@@ -30,7 +30,7 @@ let pp_line ?syntax ppf (l : line) =
       | _ -> Fmt.pf ppf "%s\n" s)
 
 let pp ?syntax ppf t =
-  Fmt.pf ppf "%a\n" Fmt.(list ~sep:(unit "\n") (pp_line ?syntax)) t
+  Fmt.pf ppf "%a\n" Fmt.(list ~sep:(any "\n") (pp_line ?syntax)) t
 
 let to_string = Fmt.to_to_string pp
 

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -29,7 +29,7 @@ let pp_pad ppf = function
   | 0 -> ()
   | i -> Fmt.string ppf (String.v ~len:i (fun _ -> ' '))
 
-let pp_lines pp = Fmt.(list ~sep:(unit "\n") pp)
+let pp_lines pp = Fmt.(list ~sep:(any "\n") pp)
 
 let dump_string ppf s = Fmt.pf ppf "%S" s
 
@@ -55,4 +55,4 @@ let pp_position ppf lexbuf =
 
 (* TODO: better error reporting *)
 let err lexbuf fmt =
-  Fmt.kstrf (fun str -> Fmt.failwith "%a: %s" pp_position lexbuf str) fmt
+  Fmt.kstr (fun str -> Fmt.failwith "%a: %s" pp_position lexbuf str) fmt

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -128,9 +128,9 @@ let eval_test ?block ?root c cmd =
 
 let err_eval ~cmd lines =
   Fmt.epr "Got an error while evaluating:\n---\n%a\n---\n%a\n%!"
-    Fmt.(list ~sep:(unit "\n") string)
+    Fmt.(list ~sep:(any "\n") string)
     cmd
-    Fmt.(list ~sep:(unit "\n") string)
+    Fmt.(list ~sep:(any "\n") string)
     lines;
   exit 1
 

--- a/mdx.opam
+++ b/mdx.opam
@@ -24,7 +24,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.02.3"}
   "ocamlfind"
-  "fmt" {>= "0.8.5" & < "0.8.10"}
+  "fmt" {>= "0.8.7"}
   "cppo" {build}
   "csexp" {>= "1.3.2"}
   "astring"


### PR DESCRIPTION
This is a backport of #354 for the 1.11.x branch to undo the fix I needed to do for CI.