### PR TITLE
Depend on CPPO >= 1.1.0 for `-V` option

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -23,7 +23,7 @@
    (>= 4.08.0))
   ocamlfind
   (fmt (>= 0.8.7))
-  (cppo :build)
+  (cppo (and :build (>= 1.1.0)))
   (csexp
    (>= 1.3.2))
   astring

--- a/mdx.opam
+++ b/mdx.opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}


### PR DESCRIPTION
This was kindly mentioned by @kit-ty-kate: https://github.com/ocaml/opam-repository/pull/20179