### PR TITLE
Allow running non-deterministic MDX stanzas using `dune-gen`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 - Add support for adding language tags and metadata labels in `mli` files.
   (#339, #357, @julow, @Leonidas-from-XIV)
+- Add support for running non-deterministic tests in `dune` MDX 0.2 stanza by
+  setting the `MDX_RUN_NON_DETERMINISTIC` environment variable. (#365,
+  #366, @Leonidas-from-XIV)
 
 #### Changed
 

--- a/bin/dune_gen.ml
+++ b/bin/dune_gen.ml
@@ -32,8 +32,13 @@ let run (`Setup ()) (`Prelude prelude) (`Directories dirs) =
   line "    ]";
   line "  in";
   line "  let predicates = Predicate.[ byte; toploop ] in";
+  line "  let non_deterministic =";
+  line "    match Sys.getenv_opt \"MDX_RUN_NON_DETERMINISTIC\" with";
+  line "    | Some _ -> true";
+  line "    | None -> false";
+  line "  in";
   line "  run_exn ~packages ~predicates ~prelude_str:[]";
-  line "    ~non_deterministic:false";
+  line "    ~non_deterministic";
   line "    ~silent_eval:false ~record_backtrace:false";
   line "    ~syntax:None ~silent:false";
   line "    ~verbose_findlib:false ~section:None";

--- a/test/bin/mdx-dune-gen/misc/basic/dune.gen.expected
+++ b/test/bin/mdx-dune-gen/misc/basic/dune.gen.expected
@@ -9,8 +9,13 @@ let run_exn_defaults =
     ]
   in
   let predicates = Predicate.[ byte; toploop ] in
+  let non_deterministic =
+    match Sys.getenv_opt "MDX_RUN_NON_DETERMINISTIC" with
+    | Some _ -> true
+    | None -> false
+  in
   run_exn ~packages ~predicates ~prelude_str:[]
-    ~non_deterministic:false
+    ~non_deterministic
     ~silent_eval:false ~record_backtrace:false
     ~syntax:None ~silent:false
     ~verbose_findlib:false ~section:None

--- a/test/bin/mdx-dune-gen/misc/non-deterministic/different.ml
+++ b/test/bin/mdx-dune-gen/misc/non-deterministic/different.ml
@@ -1,38 +1,42 @@
 (* small helper to determine whether two files differ *)
 
+type comparison = Same | Different
+
+let rec compare first second =
+  match input_line first with
+  | first_line -> (
+      match input_line second with
+      | second_line ->
+          match String.equal first_line second_line with
+          | true -> compare first second
+          | false ->
+              (* we found a difference between the lines *)
+              Different
+      | exception End_of_file ->
+          (* the second file ended before the first *)
+          Different)
+  | exception End_of_file ->
+      (* the first file ended first *)
+      match input_line second with
+      | _ ->
+          (* the second file continues: a difference *)
+          Different
+      | exception End_of_file ->
+          (* the second file ended too *)
+          Same
+
 let main () =
   let first = Sys.argv.(1) |> open_in in
   let second = Sys.argv.(2) |> open_in in
-  let rec loop () =
-    match input_line first with
-    | first_line -> (
-        match input_line second with
-        | second_line ->
-            match String.equal first_line second_line with
-            | true -> loop ()
-            | false ->
-                (* we found a difference between the lines *)
-                exit 0
-        | exception End_of_file ->
-            (* the second file ended before the first *)
-            exit 0
-    )
-    | exception End_of_file ->
-        (* the first file ended first *)
-        match input_line second with
-        | _ ->
-            (* the second file continues: a difference *)
-            exit 1
-        | exception End_of_file ->
-            (* the second file ended too *)
-            ()
-  in
-  loop ();
+  let comparison = compare first second in
   close_in first;
   close_in second;
-  (* we didn't find a difference, exit with a failure code *)
-  prerr_endline "The files appear to be identical";
-  exit 1
+  match comparison with
+  | Same ->
+    prerr_endline "The files appear to be identical";
+    (* we didn't find a difference, exit with a failure code *)
+    exit 1
+  | Different -> ()
 
 let () =
   main ()

--- a/test/bin/mdx-dune-gen/misc/non-deterministic/different.ml
+++ b/test/bin/mdx-dune-gen/misc/non-deterministic/different.ml
@@ -1,0 +1,38 @@
+(* small helper to determine whether two files differ *)
+
+let main () =
+  let first = Sys.argv.(1) |> open_in in
+  let second = Sys.argv.(2) |> open_in in
+  let rec loop () =
+    match input_line first with
+    | first_line -> (
+        match input_line second with
+        | second_line ->
+            match String.equal first_line second_line with
+            | true -> loop ()
+            | false ->
+                (* we found a difference between the lines *)
+                exit 0
+        | exception End_of_file ->
+            (* the second file ended before the first *)
+            exit 0
+    )
+    | exception End_of_file ->
+        (* the first file ended first *)
+        match input_line second with
+        | _ ->
+            (* the second file continues: a difference *)
+            exit 1
+        | exception End_of_file ->
+            (* the second file ended too *)
+            ()
+  in
+  loop ();
+  close_in first;
+  close_in second;
+  (* we didn't find a difference, exit with a failure code *)
+  prerr_endline "The files appear to be identical";
+  exit 1
+
+let () =
+  main ()

--- a/test/bin/mdx-dune-gen/misc/non-deterministic/dune
+++ b/test/bin/mdx-dune-gen/misc/non-deterministic/dune
@@ -30,11 +30,12 @@
 
 ;; make sure the non-deterministic is different from the deterministic
 
+(executable
+ (name different)
+ (modules different))
+
 (rule
  (alias runtest)
  (action
-  (with-accepted-exit-codes
-   1
-   (ignore-stdout
-    (run diff %{dep:dune-mdx-nondeterministic.expected}
-      %{dep:dune-mdx-nondeterministic.nondeterministic})))))
+  (run ./different.exe %{dep:dune-mdx-nondeterministic.expected}
+    %{dep:dune-mdx-nondeterministic.nondeterministic})))

--- a/test/bin/mdx-dune-gen/misc/non-deterministic/dune
+++ b/test/bin/mdx-dune-gen/misc/non-deterministic/dune
@@ -1,9 +1,7 @@
 (rule
- (target dune_gen.ml)
- (action
-  (with-stdout-to
-   %{target}
-   (run ocaml-mdx dune-gen))))
+ (with-stdout-to
+  dune_gen.ml
+  (run ocaml-mdx dune-gen)))
 
 (executable
  (name dune_gen)
@@ -12,33 +10,23 @@
  (libraries mdx.test))
 
 (rule
- (target dune-mdx-nondeterministic.deterministic)
- (deps
-  dune_gen.exe
-  (:input dune-mdx-nondeterministic))
- (action
-  (with-stdout-to
-   %{target}
-   (run ./dune_gen.exe %{input}))))
+ (with-stdout-to
+  dune-mdx-nondeterministic.deterministic
+  (run ./dune_gen.exe %{dep:dune-mdx-nondeterministic})))
 
 (rule
- (target dune-mdx-nondeterministic.nondeterministic)
- (deps
-  dune_gen.exe
-  (:input dune-mdx-nondeterministic))
- (action
-  (setenv
-   MDX_RUN_NON_DETERMINISTIC
-   1
-   (with-stdout-to
-    %{target}
-    (run ./dune_gen.exe %{input})))))
+ (setenv
+  MDX_RUN_NON_DETERMINISTIC
+  1
+  (with-stdout-to
+   dune-mdx-nondeterministic.nondeterministic
+   (run ./dune_gen.exe %{dep:dune-mdx-nondeterministic}))))
 
 (rule
  (alias runtest)
  (action
-  (diff %{dep:dune-mdx-nondeterministic.expected}
-    %{dep:dune-mdx-nondeterministic.deterministic})))
+  (diff dune-mdx-nondeterministic.expected
+    dune-mdx-nondeterministic.deterministic)))
 
 ;; make sure the non-deterministic is different from the deterministic
 

--- a/test/bin/mdx-dune-gen/misc/non-deterministic/dune
+++ b/test/bin/mdx-dune-gen/misc/non-deterministic/dune
@@ -1,0 +1,52 @@
+(rule
+ (target dune_gen.ml)
+ (action
+  (with-stdout-to
+   %{target}
+   (run ocaml-mdx dune-gen))))
+
+(executable
+ (name dune_gen)
+ (modules dune_gen)
+ (modes byte)
+ (libraries mdx.test))
+
+(rule
+ (target dune-mdx-nondeterministic.deterministic)
+ (deps
+  dune_gen.exe
+  (:input dune-mdx-nondeterministic))
+ (action
+  (with-stdout-to
+   %{target}
+   (run ./dune_gen.exe %{input}))))
+
+(rule
+ (target dune-mdx-nondeterministic.nondeterministic)
+ (deps
+  dune_gen.exe
+  (:input dune-mdx-nondeterministic))
+ (action
+  (setenv
+   MDX_RUN_NON_DETERMINISTIC
+   1
+   (with-stdout-to
+    %{target}
+    (run ./dune_gen.exe %{input})))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff %{dep:dune-mdx-nondeterministic.expected}
+    %{dep:dune-mdx-nondeterministic.deterministic})))
+
+;; make sure the non-deterministic is different from the deterministic
+
+(rule
+ (alias runtest)
+ (action
+  (with-accepted-exit-codes
+   1
+   (ignore-stdout
+    (run diff %{dep:dune-mdx-nondeterministic.expected}
+      %{dep:dune-mdx-nondeterministic.nondeterministic})))))

--- a/test/bin/mdx-dune-gen/misc/non-deterministic/dune-mdx-nondeterministic
+++ b/test/bin/mdx-dune-gen/misc/non-deterministic/dune-mdx-nondeterministic
@@ -1,0 +1,18 @@
+This test checks whether the non-deterministic mode works with the `dune` `mdx`
+stanza.
+
+Deterministic stanzas should get run and corrected, as for 1 plus one is not 3:
+
+```ocaml
+# 1 + 1;;
+- : int = 42
+```
+
+Non-deterministic ones should not be updated, since whatever `Random` outputs
+should be random:
+
+<!-- $MDX non-deterministic=command -->
+```ocaml
+# Random.int 1000;;
+- : int = 42
+```

--- a/test/bin/mdx-dune-gen/misc/non-deterministic/dune-mdx-nondeterministic.expected
+++ b/test/bin/mdx-dune-gen/misc/non-deterministic/dune-mdx-nondeterministic.expected
@@ -1,0 +1,18 @@
+This test checks whether the non-deterministic mode works with the `dune` `mdx`
+stanza.
+
+Deterministic stanzas should get run and corrected, as for 1 plus one is not 3:
+
+```ocaml
+# 1 + 1;;
+- : int = 2
+```
+
+Non-deterministic ones should not be updated, since whatever `Random` outputs
+should be random:
+
+<!-- $MDX non-deterministic=command -->
+```ocaml
+# Random.int 1000;;
+- : int = 42
+```


### PR DESCRIPTION
There is a number of ways this could be implemented, but for simplicity this just uses the same environment variable as the main executable, but to avoid dependencies it doesn't use the Cmdliner flag.

Closes #365.