### PR TITLE
Preview: upgrade to ocamlformat.0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version=0.20.1
+version=0.21.0
 profile=conventional

--- a/test/lib/test_dep.ml
+++ b/test/lib/test_dep.ml
@@ -79,8 +79,7 @@ Tata
   in
   [
     make_test ~lines ~line_des:"block: file=tikitaka.ml"
-      ~expected:(Ok [ File "tikitaka.ml" ])
-      ();
+      ~expected:(Ok [ File "tikitaka.ml" ]) ();
     make_test ~lines:lines2 ~line_des:"skip + file + dir"
       ~expected:(Ok [ File "burn.sh"; Dir "ping/" ])
       ();


### PR DESCRIPTION
This is a preview of the formatting of your project codebase with the upcoming `ocamlformat.0.21.0`. Note that this package is not yet released in opam (so the linting/formatting task of your CI won't pass), the formatting might also change slightly in the released version as we try to integrate feedback from our users.

As always, we are happy to hear your feedback!  Thank you for using ocamlformat!