### PR TITLE
Fix compatibility with Cmdliner 1.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 #### Fixed
 
+- Fixed compatibility with Cmdliner 1.1.0 (#371, @Leonidas-from-XIV)
+
 #### Removed
 
 #### Security

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -5,7 +5,7 @@ let named wrapper = Term.(app (const wrapper))
 
 let non_deterministic =
   let doc = "Run non-deterministic tests." in
-  let env = Arg.env_var ~doc "MDX_RUN_NON_DETERMINISTIC" in
+  let env = Cmd.Env.info ~doc "MDX_RUN_NON_DETERMINISTIC" in
   named
     (fun x -> `Non_deterministic x)
     Arg.(value & flag & info [ "non-deterministic"; "n" ] ~env ~doc)

--- a/bin/deps.ml
+++ b/bin/deps.ml
@@ -33,10 +33,11 @@ let run (`Setup ()) (`Syntax syntax) (`File file) =
   Printf.printf "%s" (Mdx.Util.Csexp.to_string (List deps));
   0
 
-let cmd =
-  let open Cmdliner in
-  let doc =
-    "List the dependencies of the input file. This command is meant to be used \
-     by dune only. There are no stability guarantees."
-  in
-  (Term.(pure run $ Cli.setup $ Cli.syntax $ Cli.file), Term.info "deps" ~doc)
+let term = Cmdliner.Term.(const run $ Cli.setup $ Cli.syntax $ Cli.file)
+
+let doc =
+  "List the dependencies of the input file. This command is meant to be used \
+   by dune only. There are no stability guarantees."
+
+let info = Cmdliner.Cmd.info "deps" ~doc
+let cmd = Cmdliner.Cmd.v info term

--- a/bin/deps.mli
+++ b/bin/deps.mli
@@ -14,6 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Cmdliner
-
-val cmd : int Term.t * Term.info
+val cmd : int Cmdliner.Cmd.t

--- a/bin/dune_gen.ml
+++ b/bin/dune_gen.ml
@@ -56,11 +56,11 @@ let run (`Setup ()) (`Prelude prelude) (`Directories dirs) =
   Buffer.output_buffer stdout buffer;
   0
 
-let cmd =
-  let open Cmdliner in
-  let doc =
-    "Generate the source for a specialized testing binary. This command is \
-     meant to be used by dune only. There are no stability guarantees."
-  in
-  ( Term.(pure run $ Cli.setup $ Cli.prelude $ Cli.directories),
-    Term.info "dune-gen" ~doc )
+let term = Cmdliner.Term.(const run $ Cli.setup $ Cli.prelude $ Cli.directories)
+
+let doc =
+  "Generate the source for a specialized testing binary. This command is meant \
+   to be used by dune only. There are no stability guarantees."
+
+let info = Cmdliner.Cmd.info "dune-gen" ~doc
+let cmd = Cmdliner.Cmd.v info term

--- a/bin/dune_gen.mli
+++ b/bin/dune_gen.mli
@@ -14,6 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Cmdliner
-
-val cmd : int Term.t * Term.info
+val cmd : int Cmdliner.Cmd.t

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -17,13 +17,11 @@
 open Cmdliner
 
 let cmds = [ Test.cmd; Pp.cmd; Deps.cmd; Dune_gen.cmd ]
-let main (`Setup ()) = `Help (`Pager, None)
 
 let main =
   let doc = "Execute markdown files." in
-  let exits = Term.default_exits in
   let man = [] in
-  ( Term.(ret (const main $ Cli.setup)),
-    Term.info "ocaml-mdx" ~version:"%%VERSION%%" ~doc ~exits ~man )
+  Cmd.info "ocaml-mdx" ~version:"%%VERSION%%" ~doc ~man
 
-let () = Term.(exit_status @@ eval_choice main cmds)
+let group = Cmd.group main cmds
+let () = Stdlib.exit @@ Cmd.eval' group

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -17,11 +17,13 @@
 open Cmdliner
 
 let cmds = [ Test.cmd; Pp.cmd; Deps.cmd; Dune_gen.cmd ]
+let main (`Setup ()) = `Help (`Pager, None)
 
-let main =
+let info =
   let doc = "Execute markdown files." in
   let man = [] in
   Cmd.info "ocaml-mdx" ~version:"%%VERSION%%" ~doc ~man
 
-let group = Cmd.group main cmds
+let default = Term.(ret (const main $ Cli.setup))
+let group = Cmd.group ~default info cmds
 let () = Stdlib.exit @@ Cmd.eval' group

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -62,8 +62,7 @@ let run (`Setup ()) (`File file) (`Section section) =
 
 open Cmdliner
 
-let cmd =
-  let doc = "Pre-process markdown files to produce OCaml code." in
-  let exits = Term.default_exits in
-  ( Term.(pure run $ Cli.setup $ Cli.file $ Cli.section),
-    Term.info "pp" ~doc ~exits )
+let term = Term.(const run $ Cli.setup $ Cli.file $ Cli.section)
+let doc = "Pre-process markdown files to produce OCaml code."
+let info = Cmd.info "pp" ~doc
+let cmd = Cmd.v info term

--- a/bin/pp.mli
+++ b/bin/pp.mli
@@ -14,6 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Cmdliner
-
-val cmd : int Term.t * Term.info
+val cmd : int Cmdliner.Cmd.t

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -47,11 +47,12 @@ let run (`Setup ()) _ _ _ _ _ _ _ _ _ _ =
 
 open Cmdliner
 
-let cmd : int Term.t * Term.info =
-  let doc = "Test markdown files." in
-  ( Term.(
-      pure run $ Cli.setup $ Cli.non_deterministic $ Cli.silent_eval
-      $ Cli.syntax $ Cli.silent $ Cli.verbose_findlib $ Cli.prelude
-      $ Cli.prelude_str $ Cli.file $ Cli.section $ Cli.root $ Cli.force_output
-      $ Cli.output),
-    Term.info "test" ~doc )
+let term =
+  Term.(
+    const run $ Cli.setup $ Cli.non_deterministic $ Cli.silent_eval $ Cli.syntax
+    $ Cli.silent $ Cli.verbose_findlib $ Cli.prelude $ Cli.prelude_str
+    $ Cli.file $ Cli.section $ Cli.root $ Cli.force_output $ Cli.output)
+
+let doc = "Test markdown files."
+let info = Cmd.info "test" ~doc
+let cmd = Cmd.v info term

--- a/bin/test.mli
+++ b/bin/test.mli
@@ -14,6 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Cmdliner
-
-val cmd : int Term.t * Term.info
+val cmd : int Cmdliner.Cmd.t

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -73,16 +73,18 @@ let run setup non_deterministic silent_eval record_backtrace syntax silent
 
 open Cmdliner
 
-let cmd =
-  let exits = Term.default_exits in
+let term =
+  Term.(
+    const run $ Cli.setup $ Cli.non_deterministic $ Cli.silent_eval
+    $ Cli.record_backtrace $ Cli.syntax $ Cli.silent $ Cli.verbose_findlib
+    $ Cli.prelude $ Cli.prelude_str $ Cli.file $ Cli.section $ Cli.root
+    $ Cli.force_output $ Cli.output)
+
+let info =
   let man = [] in
   let doc = "Test markdown files." in
-  ( Term.(
-      pure run $ Cli.setup $ Cli.non_deterministic $ Cli.silent_eval
-      $ Cli.record_backtrace $ Cli.syntax $ Cli.silent $ Cli.verbose_findlib
-      $ Cli.prelude $ Cli.prelude_str $ Cli.file $ Cli.section $ Cli.root
-      $ Cli.force_output $ Cli.output),
-    Term.info "ocaml-mdx-test" ~version:"%%VERSION%%" ~doc ~exits ~man )
+  Cmd.info "ocaml-mdx-test" ~version:"%%VERSION%%" ~doc ~man
 
-let main () = Term.(exit_status @@ eval cmd)
+let cmd = Cmd.v info term
+let main () = Stdlib.exit @@ Cmd.eval' cmd
 let () = main ()

--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,7 @@
   astring
   (logs (>= 0.7.0))
   (cmdliner
-   (>= 1.0.0))
+   (>= 1.1.0))
   (re
    (>= 1.7.2))
   result

--- a/mdx.opam
+++ b/mdx.opam
@@ -26,7 +26,7 @@ depends: [
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.1.0"}
   "re" {>= "1.7.2"}
   "result"
   "ocaml-version" {>= "2.3.0"}

--- a/test/bin/gen_rule_helpers/gen_rule_helpers.ml
+++ b/test/bin/gen_rule_helpers/gen_rule_helpers.ml
@@ -157,5 +157,6 @@ let run generator =
     let man = [] in
     Cmd.info "gen_dune_rules" ~doc ~man
   in
-  let group = Cmd.group info cmds in
+  let default = Term.(ret (const (`Help (`Auto, None)))) in
+  let group = Cmd.group ~default info cmds in
   Stdlib.exit @@ Cmd.eval group

--- a/test/bin/gen_rule_helpers/gen_rule_helpers.ml
+++ b/test/bin/gen_rule_helpers/gen_rule_helpers.ml
@@ -144,16 +144,18 @@ let run generator =
   let cmds =
     Term.
       [
-        (const (rule_gen generator `Test_expect) $ const (), info "test_expect");
-        ( const (rule_gen generator `Test_failure) $ const (),
-          info "test_failure" );
+        (let term = const (rule_gen generator `Test_expect) $ const () in
+         let info = Cmd.info "test_expect" in
+         Cmd.v info term);
+        (let term = const (rule_gen generator `Test_failure) $ const () in
+         let info = Cmd.info "test_failure" in
+         Cmd.v info term);
       ]
   in
-  let default =
+  let info =
     let doc = "Generate dune files for the binary tests." in
-    let exits = Term.default_exits in
     let man = [] in
-    Term.
-      (ret (const (`Help (`Auto, None))), info "gen_dune_rules" ~doc ~exits ~man)
+    Cmd.info "gen_dune_rules" ~doc ~man
   in
-  Term.exit (Term.eval_choice default cmds)
+  let group = Cmd.group info cmds in
+  Stdlib.exit @@ Cmd.eval group

--- a/test/bin/mdx-test/misc/no-such-file/test.expected
+++ b/test/bin/mdx-test/misc/no-such-file/test.expected
@@ -1,3 +1,3 @@
-ocaml-mdx: FILE argument: no `foo' file
-Usage: ocaml-mdx test [OPTION]... FILE
-Try `ocaml-mdx test --help' or `ocaml-mdx --help' for more information.
+ocaml-mdx: FILE argument: no 'foo' file
+Usage: ocaml-mdx test [OPTION]… FILE
+Try 'ocaml-mdx test --help' or 'ocaml-mdx --help' for more information.

--- a/test/bin/mdx-test/misc/no-such-prelude/test.expected
+++ b/test/bin/mdx-test/misc/no-such-prelude/test.expected
@@ -1,3 +1,3 @@
-ocaml-mdx: option `--prelude': no `foo' file
-Usage: ocaml-mdx test [OPTION]... FILE
-Try `ocaml-mdx test --help' or `ocaml-mdx --help' for more information.
+ocaml-mdx: option '--prelude': no 'foo' file
+Usage: ocaml-mdx test [OPTION]… FILE
+Try 'ocaml-mdx test --help' or 'ocaml-mdx --help' for more information.


### PR DESCRIPTION
Currently the build fails because of the deprecations. I guess this is a good point to upgrade then.

Since we already depend on OCaml 4.08 depending on Cmdliner 1.1.0 should not be not much of a problem.