### PR TITLE
Allow writing out a block to a file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 #### Added
 
+- Support for writing files from blocks. (#381, @talex5)
+
 #### Changed
 
 #### Deprecated

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ OCaml documentation comments:
 The possible labels are:
 
 - `skip` -- ignore this block
-- `ocaml`, `cram`, `toplevel`, `include` -- set the block type
+- `ocaml`, `cram`, `toplevel`, `include`, `write` -- set the block type
 - `version=VERSION` -- set OCaml version
 - `non-deterministic[=output|command]` -- see "Non-deterministic tests" section
 - `dir=PATH` -- set the directory where the tests should be run
@@ -247,6 +247,14 @@ Non-OCaml files can also be read and included in a block:
     ```
     ```
 However, part splitting is only supported for OCaml files.
+
+It is also possible to copy from the document to a file:
+
+    <!-- $MDX write,file=data.csv -->
+    ```csv
+    "a",1
+    "b",2
+    ```
 
 ### Tests
 

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -48,6 +48,7 @@ let report_error_in_block block msg =
     | Raw _ -> ""
     | Include { file_kind = Fk_ocaml _; _ } -> "OCaml file include "
     | Include { file_kind = Fk_other _; _ } -> "file include "
+    | Write _ -> "file write "
     | OCaml _ -> "OCaml "
     | Cram _ -> "cram "
     | Toplevel _ -> "toplevel "

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -59,6 +59,7 @@ type include_value = {
   file_kind : include_file_kind;
 }
 
+type write_value = { target : string; header : Header.t option }
 type raw_value = { header : Header.t option }
 
 (** The type for block values. *)
@@ -68,6 +69,7 @@ type value =
   | Cram of cram_value
   | Toplevel of toplevel_value
   | Include of include_value
+  | Write of write_value
 
 type section = int * string
 (** The type for sections. *)

--- a/lib/document.ml
+++ b/lib/document.ml
@@ -39,6 +39,6 @@ let envs t =
       | Block b -> (
           match b.value with
           | OCaml { env; _ } | Toplevel { env; _ } -> Ocaml_env.Set.add env acc
-          | Raw _ | Cram _ | Include _ -> acc)
+          | Raw _ | Cram _ | Include _ | Write _ -> acc)
       | Section _ | Text _ -> acc)
     Ocaml_env.Set.empty t

--- a/lib/label.ml
+++ b/lib/label.ml
@@ -73,7 +73,7 @@ type non_det = Nd_output | Nd_command
 
 let default_non_det = Nd_output
 
-type block_kind = OCaml | Cram | Toplevel | Include
+type block_kind = OCaml | Cram | Toplevel | Include | Write
 
 type t =
   | Dir of string
@@ -93,6 +93,7 @@ let pp_block_kind ppf = function
   | Cram -> Fmt.string ppf "cram"
   | Toplevel -> Fmt.string ppf "toplevel"
   | Include -> Fmt.string ppf "include"
+  | Write -> Fmt.string ppf "write"
 
 let pp ppf = function
   | Dir d -> Fmt.pf ppf "dir=%s" d
@@ -151,6 +152,7 @@ let interpret label value =
   | "cram" -> doesnt_accept_value ~label ~value (Block_kind Cram)
   | "toplevel" -> doesnt_accept_value ~label ~value (Block_kind Toplevel)
   | "include" -> doesnt_accept_value ~label ~value (Block_kind Include)
+  | "write" -> doesnt_accept_value ~label ~value (Block_kind Write)
   | v when is_prefix ~prefix:"unset-" v ->
       doesnt_accept_value ~label ~value
         (Unset (split_prefix ~prefix:"unset-" v))

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -29,7 +29,7 @@ type non_det = Nd_output | Nd_command
 
 val default_non_det : non_det
 
-type block_kind = OCaml | Cram | Toplevel | Include
+type block_kind = OCaml | Cram | Toplevel | Include | Write
 
 type t =
   | Dir of string

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -514,3 +514,15 @@
 (rule
  (alias runtest)
  (action (diff warnings/test-case.md warnings.actual)))
+
+(rule
+ (target write-block.actual)
+ (deps (package mdx) (source_tree write-block))
+ (action
+  (with-stdout-to %{target}
+   (chdir write-block
+    (run ocaml-mdx test --output - test-case.md)))))
+
+(rule
+ (alias runtest)
+ (action (diff write-block/test-case.md.expected write-block.actual)))

--- a/test/bin/mdx-test/expect/write-block/test-case.md
+++ b/test/bin/mdx-test/expect/write-block/test-case.md
@@ -1,0 +1,21 @@
+We can sync from the md to files with MDX comments:
+
+<!-- $MDX write,file=data.json -->
+```json
+{ "value": 42 }
+```
+
+```sh
+$ cat data.json
+```
+
+OCaml code can be written, but is not executed:
+
+<!-- $MDX write,file=test.ml -->
+```ocaml
+abcd + defg
+```
+
+```sh
+$ cat test.ml
+```

--- a/test/bin/mdx-test/expect/write-block/test-case.md.expected
+++ b/test/bin/mdx-test/expect/write-block/test-case.md.expected
@@ -1,0 +1,23 @@
+We can sync from the md to files with MDX comments:
+
+<!-- $MDX write,file=data.json -->
+```json
+{ "value": 42 }
+```
+
+```sh
+$ cat data.json
+{ "value": 42 }
+```
+
+OCaml code can be written, but is not executed:
+
+<!-- $MDX write,file=test.ml -->
+```ocaml
+abcd + defg
+```
+
+```sh
+$ cat test.ml
+abcd + defg
+```


### PR DESCRIPTION
This allows input data to be shown with syntax highlighing and then used in future steps. e.g.

    <!-- $MDX write,file=data.json -->
    ```json
    { "value": 42 }
    ```