### PR TITLE
Deduplicate implementation of `;;` detection

### DIFF
--- a/lib/block.ml
+++ b/lib/block.ml
@@ -219,7 +219,7 @@ let ends_by_semi_semi c =
   match List.rev c with
   | h :: _ ->
       let len = String.length h in
-      len > 2 && h.[len - 1] = ';' && h.[len - 2] = ';'
+      len > 2 && Astring.String.is_suffix ~affix:";;" h
   | _ -> false
 
 let pp_line_directive ppf (file, line) = Fmt.pf ppf "#%d %S" line file

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -217,9 +217,7 @@ let guess_ocaml_kind contents =
 
 let ends_by_semi_semi c =
   match List.rev c with
-  | h :: _ ->
-      let len = String.length h in
-      len > 2 && Astring.String.is_suffix ~affix:";;" h
+  | h :: _ -> Astring.String.is_suffix ~affix:";;" h
   | _ -> false
 
 let pp_line_directive ppf (file, line) = Fmt.pf ppf "#%d %S" line file

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -159,3 +159,7 @@ val executable_contents : syntax:Syntax.t -> t -> string list
    (e.g. the phrase result is discarded). *)
 
 val is_active : ?section:string -> t -> bool
+
+(** {2 Helpers} *)
+
+val ends_by_semi_semi : string list -> bool

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -141,15 +141,10 @@ module Phrase = struct
     let endpos = lexbuf.Lexing.lex_curr_p in
     { doc = { lexbuf; contents }; startpos; endpos; parsed }
 
-  let ends_by_semi_semi c =
-    match List.rev c with
-    | h :: _ ->
-        let len = String.length h in
-        len > 2 && h.[len - 1] = ';' && h.[len - 2] = ';'
-    | _ -> false
-
   let parse lines =
-    let lines = if ends_by_semi_semi lines then lines else lines @ [ ";;" ] in
+    let lines =
+      if Mdx.Block.ends_by_semi_semi lines then lines else lines @ [ ";;" ]
+    in
     match parse lines with exception End_of_file -> None | t -> Some t
 
   (** Returns the name of the toplevel directive or [None] if the given phrase
@@ -394,13 +389,9 @@ let rtrim l = List.rev (ltrim (List.rev l))
 let trim l = ltrim (rtrim (List.map trim_line l))
 
 let cut_into_sentences l =
-  let ends_by_semi_semi h =
-    let len = String.length h in
-    len > 2 && h.[len - 1] = ';' && h.[len - 2] = ';'
-  in
   let rec aux acc sentence = function
     | [] -> List.rev (List.rev sentence :: acc)
-    | h :: t when ends_by_semi_semi h ->
+    | h :: t when Mdx.Block.ends_by_semi_semi [ h ] ->
         aux (List.rev (h :: sentence) :: acc) [] t
     | h :: t -> aux acc (h :: sentence) t
   in


### PR DESCRIPTION
While pondering a solution for #368 I realized that the code is full of duplicated definitions of `ends_by_semi_semi`, so I just decided to make it consistent. `Mdx.Block` might not be the best place to put it, but I gather it is still better than having it copied in 3 places. Interestingly, it was all the same implementation.

4.13 can use `String.ends_with` but that's a pretty high limit so I decided to use the implementation from `Astring` to make it a bit more readable, which we depend on already.