### PR TITLE
Remove result compatibility package

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -1,5 +1,4 @@
 open Cmdliner
-open Result
 
 let named wrapper = Term.(app (const wrapper))
 

--- a/dune-project
+++ b/dune-project
@@ -32,7 +32,6 @@
    (>= 1.1.0))
   (re
    (>= 1.7.2))
-  result
   (ocaml-version
    (>= 2.3.0))
   (odoc-parser (>= 1.0.0))

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -14,7 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Result
 open Util.Result.Infix
 
 module Header = struct

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -96,13 +96,13 @@ val mk :
   header:Header.t option ->
   contents:string list ->
   errors:Output.t list ->
-  (t, [ `Msg of string ]) Result.result
+  (t, [ `Msg of string ]) result
 
 val mk_include :
   loc:Location.t ->
   section:section option ->
   labels:Label.t list ->
-  (t, [ `Msg of string ]) Result.result
+  (t, [ `Msg of string ]) result
 (** [mk_include] builds an include block from a comment [<!-- $MDX ... -->]
     that is not followed by a code block [``` ... ```]. *)
 

--- a/lib/dune
+++ b/lib/dune
@@ -4,7 +4,7 @@
  (preprocess
   (action
    (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
- (libraries astring csexp fmt logs ocaml-version odoc-parser re result str
+ (libraries astring csexp fmt logs ocaml-version odoc-parser re str
    compiler-libs.common unix))
 
 (ocamllex lexer_mdx)

--- a/lib/label.ml
+++ b/lib/label.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Result
-
 module Relation = struct
   type t = Eq | Neq | Le | Lt | Ge | Gt
 

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -47,9 +47,7 @@ type t =
 val pp : Format.formatter -> t -> unit
 
 val interpret :
-  string ->
-  (Relation.t * string) option ->
-  (t, [> `Msg of string ]) Result.result
+  string -> (Relation.t * string) option -> (t, [> `Msg of string ]) result
 
-val of_string : string -> (t list, [ `Msg of string ] list) Result.result
+val of_string : string -> (t list, [ `Msg of string ] list) result
 (** [of_string s] cuts [s] into a list of labels. *)

--- a/lib/lexer_mdx.mli
+++ b/lib/lexer_mdx.mli
@@ -1,6 +1,4 @@
 type token = [ `Block of Block.t | `Section of int * string | `Text of string ]
 
-val markdown_token :
-  Lexing.lexbuf -> (token list, [ `Msg of string ]) Result.result
-
-val cram_token : Lexing.lexbuf -> (token list, [ `Msg of string ]) Result.result
+val markdown_token : Lexing.lexbuf -> (token list, [ `Msg of string ]) result
+val cram_token : Lexing.lexbuf -> (token list, [ `Msg of string ]) result

--- a/lib/lexer_mdx.mll
+++ b/lib/lexer_mdx.mll
@@ -1,5 +1,4 @@
 {
-open Result
 open Astring
 
 type token = [ `Block of Block.t | `Section of int * string | `Text of string ]

--- a/lib/library.ml
+++ b/lib/library.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Result
-
 type t = { base_name : string; sub_lib : string option }
 
 let compare t t' =

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -24,7 +24,7 @@ val equal : t -> t -> bool
 val compare : t -> t -> int
 val pp : t Fmt.t
 
-val from_string : string -> (t, string) Result.result
+val from_string : string -> (t, string) result
 (** [from_string s] returns the library represented by [s] or an error if [s]
     isn't a valid library. *)
 

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -47,15 +47,15 @@ val dump : line list Fmt.t
 
 (** {2 Document} *)
 
-val of_string : syntax -> string -> (t, [ `Msg of string ]) Result.result
+val of_string : syntax -> string -> (t, [ `Msg of string ]) result
 (** [of_string syntax s] is the document [t] such that
     [to_string ~syntax t = s]. *)
 
-val parse_file : syntax -> string -> (t, [ `Msg of string ]) Result.result
+val parse_file : syntax -> string -> (t, [ `Msg of string ]) result
 (** [parse_file s] is {!of_string} of [s]'s contents. *)
 
 val parse_lexbuf :
-  string -> syntax -> Lexing.lexbuf -> (t, [ `Msg of string ]) Result.result
+  string -> syntax -> Lexing.lexbuf -> (t, [ `Msg of string ]) result
 (** [parse_lexbuf l] is {!of_string} of [l]'s contents. *)
 
 (** {2 Evaluation} *)
@@ -64,7 +64,7 @@ val run_to_stdout :
   ?syntax:syntax ->
   f:(string -> t -> string) ->
   string ->
-  (unit, [ `Msg of string ]) Result.result
+  (unit, [ `Msg of string ]) result
 (** [run_to_stdout ?syntax ~f file] runs the callback [f] on the raw and
     structured content of [file], as specified  by [syntax] (defaults to [Normal]).
     The returned corrected version is then written to stdout. *)
@@ -74,7 +74,7 @@ val run_to_file :
   f:(string -> t -> string) ->
   outfile:string ->
   string ->
-  (unit, [ `Msg of string ]) Result.result
+  (unit, [ `Msg of string ]) result
 (** Same as [run_to_stdout] but writes the corrected version to [outfile]*)
 
 val run :
@@ -82,7 +82,7 @@ val run :
   ?force_output:bool ->
   f:(string -> t -> string) ->
   string ->
-  (unit, [ `Msg of string ]) Result.result
+  (unit, [ `Msg of string ]) result
 (** [run_to_file ?syntax ?force_output ~f ~outfile file] runs the callback [f]
     similarly to [run_to_stdout] to generate its corrected version. If
     [force_output] is [true] (defaults to [false]) or if the corrected version

--- a/lib/mli_parser.ml
+++ b/lib/mli_parser.ml
@@ -220,5 +220,5 @@ let parse_mli file_contents =
   else tokens
 
 let parse_mli file_contents =
-  try Result.Ok (parse_mli file_contents)
+  try Ok (parse_mli file_contents)
   with exn -> Util.Result.errorf "%s" (Printexc.to_string exn)

--- a/lib/mli_parser.mli
+++ b/lib/mli_parser.mli
@@ -1,2 +1,2 @@
-val parse_mli : string -> (Document.line list, [ `Msg of string ]) Result.result
+val parse_mli : string -> (Document.line list, [ `Msg of string ]) result
 (** Slice an mli file into its [Text] and [Block] parts. *)

--- a/lib/ocaml_delimiter.ml
+++ b/lib/ocaml_delimiter.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Result
-
 type syntax = Cmt | Attr
 type part_begin = { indent : string; payload : string }
 type t = Part_begin of syntax * part_begin | Part_end

--- a/lib/ocaml_delimiter.mli
+++ b/lib/ocaml_delimiter.mli
@@ -20,4 +20,4 @@ type syntax = Cmt | Attr
 type part_begin = { indent : string; payload : string }
 type t = Part_begin of syntax * part_begin | Part_end
 
-val parse : string -> (t option, [ `Msg of string ]) Result.result
+val parse : string -> (t option, [ `Msg of string ]) result

--- a/lib/part.ml
+++ b/lib/part.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Result
-
 module Part = struct
   type t = {
     name : string;

--- a/lib/part.mli
+++ b/lib/part.mli
@@ -46,7 +46,7 @@ module Parse_parts : sig
     | Part_end
     | File_end
 
-  val parse_line : (string, [< `End_of_file ]) Result.result -> part_decl
+  val parse_line : (string, [< `End_of_file ]) result -> part_decl
 end
 
 (**/**)

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -15,7 +15,6 @@
  *)
 
 open Mdx
-open Result
 open Astring
 open Mdx.Util.Result.Infix
 

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -102,7 +102,7 @@ module Phrase = struct
     doc : Lexbuf.t;
     startpos : position;
     endpos : position;
-    parsed : (toplevel_phrase, exn) Result.result;
+    parsed : (toplevel_phrase, exn) result;
   }
 
   let result t = t.parsed
@@ -120,7 +120,7 @@ module Phrase = struct
     let startpos = lexbuf.Lexing.lex_start_p in
     let parsed =
       match Parse.toplevel_phrase lexbuf with
-      | phrase -> Result.Ok phrase
+      | phrase -> Ok phrase
       | exception exn ->
           let exn =
             match error_of_exn exn with
@@ -456,7 +456,7 @@ let eval t cmd =
               | None -> [])
             phrases
           |> List.concat
-          |> fun x -> if !errors then Result.Error x else Result.Ok x))
+          |> fun x -> if !errors then Error x else Ok x))
 
 let add_directive ~name ~doc kind =
   let directive =

--- a/lib/top/mdx_top.mli
+++ b/lib/top/mdx_top.mli
@@ -15,8 +15,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Result
-
 (** Toplevel logic for [mdx]. *)
 
 type t

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Result
-
 module Result = struct
   module Infix = struct
     let ( >>= ) r f = match r with Ok x -> f x | Error _ as e -> e

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Result
-
 module Result : sig
   module Infix : sig
     val ( >>= ) :

--- a/mdx.opam
+++ b/mdx.opam
@@ -28,7 +28,6 @@ depends: [
   "logs" {>= "0.7.0"}
   "cmdliner" {>= "1.1.0"}
   "re" {>= "1.7.2"}
-  "result"
   "ocaml-version" {>= "2.3.0"}
   "odoc-parser" {>= "1.0.0"}
   "lwt" {with-test}

--- a/test/lib/test_ocaml_delimiter.ml
+++ b/test/lib/test_ocaml_delimiter.ml
@@ -1,5 +1,4 @@
 open Mdx.Ocaml_delimiter
-open Result
 
 let test_parse =
   let make_test ~line ~expected =

--- a/test/lib/test_part.ml
+++ b/test/lib/test_part.ml
@@ -1,5 +1,4 @@
 open Mdx.Part
-open Result
 
 module Testable = struct
   let parse_parts_part_decl =


### PR DESCRIPTION
Since we depend on 4.08 it should suffice to use the built-in `Result` module.