### PR TITLE
Report all syntax errors in Markdown files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Fixed compatibility with Cmdliner 1.1.0 (#371, @Leonidas-from-XIV)
 - Report errors and exit codes of toplevel directives (#382, @talex5,
   @Leonidas-from-XIV)
+- Fix block locations in error reporting (#<PR_NUMBER>, @NathanReb)
 
 #### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 #### Added
 
+- Report all parsing errors in Markdown files (#<PR_NUMBER>, @NathanReb)
+
 #### Changed
 
 #### Deprecated

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 #### Added
 
-- Report all parsing errors in Markdown files (#<PR_NUMBER>, @NathanReb)
+- Report all parsing errors in Markdown files (#389, @NathanReb)
 
 #### Changed
 
@@ -13,7 +13,7 @@
 - Fixed compatibility with Cmdliner 1.1.0 (#371, @Leonidas-from-XIV)
 - Report errors and exit codes of toplevel directives (#382, @talex5,
   @Leonidas-from-XIV)
-- Fix block locations in error reporting (#<PR_NUMBER>, @NathanReb)
+- Fix block locations in error reporting (#389, @NathanReb)
 
 #### Removed
 

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -52,8 +52,8 @@ let report_error_in_block block msg =
     | Cram _ -> "cram "
     | Toplevel _ -> "toplevel "
   in
-  Fmt.epr "%a: Error in the %scode block@]\n%s\n"
-    Stable_printer.Location.print_loc block.loc kind msg
+  Fmt.epr "%a: Error in the %scode block@]\n%s\n" Stable_printer.Location.pp
+    block.loc kind msg
 
 let run setup non_deterministic silent_eval record_backtrace syntax silent
     verbose_findlib prelude prelude_str file section root force_output output :

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -27,7 +27,7 @@ let locate_error_msg ~loc s =
 
 let locate_errors ~loc r =
   Result.map_error
-    (fun l -> List.map (function `Msg m -> `Msg (locate_error_msg ~loc m)) l)
+    (fun l -> List.map (fun (`Msg m) -> `Msg (locate_error_msg ~loc m)) l)
     r
 
 module Header = struct

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -20,11 +20,10 @@ let loc_error ~loc fmt =
   Format.kasprintf
     (fun s -> Error (`Msg s))
     ("%a: invalid code block: " ^^ fmt)
-    Stable_printer.Location.print_loc loc
+    Stable_printer.Location.pp loc
 
 let locate_error_msg ~loc s =
-  Format.asprintf "%a: invalid code block: %s" Stable_printer.Location.print_loc
-    loc s
+  Format.asprintf "%a: invalid code block: %s" Stable_printer.Location.pp loc s
 
 let locate_errors ~loc r =
   Result.map_error
@@ -139,7 +138,7 @@ let dump ppf ({ loc; section; labels; contents; value; _ } as b) =
   Fmt.pf ppf
     "{@[loc: %a;@ section: %a;@ labels: %a;@ header: %a;@ contents: %a;@ \
      value: %a@]}"
-    Stable_printer.Location.print_loc loc
+    Stable_printer.Location.pp loc
     Fmt.(Dump.option dump_section)
     section
     Fmt.Dump.(list Label.pp)

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -16,6 +16,21 @@
 
 open Util.Result.Infix
 
+let loc_error ~loc fmt =
+  Format.kasprintf
+    (fun s -> Error (`Msg s))
+    ("%a: invalid code block: " ^^ fmt)
+    Stable_printer.Location.print_loc loc
+
+let locate_error_msg ~loc s =
+  Format.asprintf "%a: invalid code block: %s" Stable_printer.Location.print_loc
+    loc s
+
+let locate_errors ~loc r =
+  Result.map_error
+    (fun l -> List.map (function `Msg m -> `Msg (locate_error_msg ~loc m)) l)
+    r
+
 module Header = struct
   type t = Shell of [ `Sh | `Bash ] | OCaml | Other of string
 
@@ -41,6 +56,26 @@ module Header = struct
 end
 
 type section = int * string
+
+module Raw = struct
+  type t =
+    | Include of { loc : Location.t; section : section option; labels : string }
+    | Any of {
+        loc : Location.t;
+        section : section option;
+        header : string;
+        contents : string list;
+        label_cmt : string option;
+        legacy_labels : string;
+        errors : Output.t list;
+      }
+
+  let make ~loc ~section ~header ~contents ~label_cmt ~legacy_labels ~errors =
+    Any { loc; section; header; contents; label_cmt; legacy_labels; errors }
+
+  let make_include ~loc ~section ~labels = Include { loc; section; labels }
+end
+
 type cram_value = { language : [ `Sh | `Bash ]; non_det : Label.non_det option }
 
 type ocaml_value = {
@@ -253,20 +288,20 @@ let version_enabled version =
 
 let get_label f (labels : Label.t list) = Util.List.find_map f labels
 
-let label_not_allowed ~label ~kind =
-  Util.Result.errorf "`%s` label is not allowed for %s blocks." label kind
+let label_not_allowed ~loc ~label ~kind =
+  loc_error ~loc "`%s` label is required for %s blocks." label kind
 
-let label_required ~label ~kind =
-  Util.Result.errorf "`%s` label is required for %s blocks." label kind
+let label_required ~loc ~label ~kind =
+  loc_error ~loc "`%s` label is required for %s blocks." label kind
 
-let check_not_set msg = function
-  | Some _ -> Util.Result.errorf msg
+let check_not_set ~loc msg = function
+  | Some _ -> loc_error ~loc "%s" msg
   | None -> Ok ()
 
-let check_no_errors = function
+let check_no_errors ~loc = function
   | [] -> Ok ()
   | _ :: _ ->
-      Util.Result.errorf "error block cannot be attached to a non-OCaml block"
+      loc_error ~loc "error block cannot be attached to a non-OCaml block"
 
 type block_config = {
   non_det : Label.non_det option;
@@ -301,22 +336,22 @@ let get_block_config l =
     file_inc = get_label (function File x -> Some x | _ -> None) l;
   }
 
-let mk_ocaml ~config ~contents ~errors =
+let mk_ocaml ~loc ~config ~contents ~errors =
   let kind = "OCaml" in
   match config with
   | { file_inc = None; part = None; env; non_det; _ } -> (
       match guess_ocaml_kind contents with
       | `Code -> Ok (OCaml { env = Ocaml_env.mk env; non_det; errors })
       | `Toplevel ->
-          Util.Result.errorf "toplevel syntax is not allowed in OCaml blocks.")
-  | { file_inc = Some _; _ } -> label_not_allowed ~label:"file" ~kind
-  | { part = Some _; _ } -> label_not_allowed ~label:"part" ~kind
+          loc_error ~loc "toplevel syntax is not allowed in OCaml blocks.")
+  | { file_inc = Some _; _ } -> label_not_allowed ~loc ~label:"file" ~kind
+  | { part = Some _; _ } -> label_not_allowed ~loc ~label:"part" ~kind
 
-let mk_cram ?language ~config ~header ~errors () =
+let mk_cram ~loc ?language ~config ~header ~errors () =
   let kind = "shell" in
   match config with
   | { file_inc = None; part = None; env = None; non_det; _ } ->
-      check_no_errors errors >>| fun () ->
+      check_no_errors ~loc errors >>| fun () ->
       let language =
         Util.Option.value language
           ~default:
@@ -325,28 +360,27 @@ let mk_cram ?language ~config ~header ~errors () =
             | _ -> `Sh)
       in
       Cram { language; non_det }
-  | { file_inc = Some _; _ } -> label_not_allowed ~label:"file" ~kind
-  | { part = Some _; _ } -> label_not_allowed ~label:"part" ~kind
-  | { env = Some _; _ } -> label_not_allowed ~label:"env" ~kind
+  | { file_inc = Some _; _ } -> label_not_allowed ~loc ~label:"file" ~kind
+  | { part = Some _; _ } -> label_not_allowed ~loc ~label:"part" ~kind
+  | { env = Some _; _ } -> label_not_allowed ~loc ~label:"env" ~kind
 
-let mk_toplevel ~config ~contents ~errors =
+let mk_toplevel ~loc ~config ~contents ~errors =
   let kind = "toplevel" in
   match config with
   | { file_inc = None; part = None; env; non_det; _ } -> (
       match guess_ocaml_kind contents with
-      | `Code ->
-          Util.Result.errorf "invalid toplevel syntax in toplevel blocks."
+      | `Code -> loc_error ~loc "invalid toplevel syntax in toplevel blocks."
       | `Toplevel ->
-          check_no_errors errors >>| fun () ->
+          check_no_errors ~loc errors >>| fun () ->
           Toplevel { env = Ocaml_env.mk env; non_det })
-  | { file_inc = Some _; _ } -> label_not_allowed ~label:"file" ~kind
-  | { part = Some _; _ } -> label_not_allowed ~label:"part" ~kind
+  | { file_inc = Some _; _ } -> label_not_allowed ~loc ~label:"file" ~kind
+  | { part = Some _; _ } -> label_not_allowed ~loc ~label:"part" ~kind
 
-let mk_include ~config ~header ~errors =
+let mk_include ~loc ~config ~header ~errors =
   let kind = "include" in
   match config with
   | { file_inc = Some file_included; part; non_det = None; env = None; _ } -> (
-      check_no_errors errors >>= fun () ->
+      check_no_errors ~loc errors >>= fun () ->
       match header with
       | Some Header.OCaml ->
           let file_kind = Fk_ocaml { part_included = part } in
@@ -356,28 +390,28 @@ let mk_include ~config ~header ~errors =
           | None ->
               let file_kind = Fk_other { header } in
               Ok (Include { file_included; file_kind })
-          | Some _ -> label_not_allowed ~label:"part" ~kind:"non-OCaml include")
-      )
-  | { file_inc = None; _ } -> label_required ~label:"file" ~kind
+          | Some _ ->
+              label_not_allowed ~loc ~label:"part" ~kind:"non-OCaml include"))
+  | { file_inc = None; _ } -> label_required ~loc ~label:"file" ~kind
   | { non_det = Some _; _ } ->
-      label_not_allowed ~label:"non-deterministic" ~kind
-  | { env = Some _; _ } -> label_not_allowed ~label:"env" ~kind
+      label_not_allowed ~loc ~label:"non-deterministic" ~kind
+  | { env = Some _; _ } -> label_not_allowed ~loc ~label:"env" ~kind
 
-let infer_block ~config ~header ~contents ~errors =
+let infer_block ~loc ~config ~header ~contents ~errors =
   match config with
-  | { file_inc = Some _; _ } -> mk_include ~config ~header ~errors
+  | { file_inc = Some _; _ } -> mk_include ~loc ~config ~header ~errors
   | { file_inc = None; part; _ } -> (
       match header with
       | Some (Header.Shell language) ->
-          mk_cram ~language ~config ~header ~errors ()
+          mk_cram ~loc ~language ~config ~header ~errors ()
       | Some Header.OCaml -> (
           match guess_ocaml_kind contents with
-          | `Code -> mk_ocaml ~config ~contents ~errors
-          | `Toplevel -> mk_toplevel ~config ~contents ~errors)
+          | `Code -> mk_ocaml ~loc ~config ~contents ~errors
+          | `Toplevel -> mk_toplevel ~loc ~config ~contents ~errors)
       | _ ->
-          check_not_set "`part` label requires a `file` label." part
+          check_not_set ~loc "`part` label requires a `file` label." part
           >>= fun () ->
-          check_no_errors errors >>| fun () -> Raw { header })
+          check_no_errors ~loc errors >>| fun () -> Raw { header })
 
 let mk ~loc ~section ~labels ~legacy_labels ~header ~contents ~errors =
   let block_kind =
@@ -385,11 +419,11 @@ let mk ~loc ~section ~labels ~legacy_labels ~header ~contents ~errors =
   in
   let config = get_block_config labels in
   (match block_kind with
-  | Some OCaml -> mk_ocaml ~config ~contents ~errors
-  | Some Cram -> mk_cram ~config ~header ~errors ()
-  | Some Toplevel -> mk_toplevel ~config ~contents ~errors
-  | Some Include -> mk_include ~config ~header ~errors
-  | None -> infer_block ~config ~header ~contents ~errors)
+  | Some OCaml -> mk_ocaml ~loc ~config ~contents ~errors
+  | Some Cram -> mk_cram ~loc ~config ~header ~errors ()
+  | Some Toplevel -> mk_toplevel ~loc ~config ~contents ~errors
+  | Some Include -> mk_include ~loc ~config ~header ~errors
+  | None -> infer_block ~loc ~config ~header ~contents ~errors)
   >>= fun value ->
   version_enabled config.version >>| fun version_enabled ->
   {
@@ -412,7 +446,27 @@ let mk_include ~loc ~section ~labels =
       let header = Header.infer_from_file file_inc in
       mk ~loc ~section ~labels ~legacy_labels:false ~header ~contents:[]
         ~errors:[]
-  | None -> label_required ~label:"file" ~kind:"include"
+  | None -> label_required ~loc ~label:"file" ~kind:"include"
+
+let parse_labels ~label_cmt ~legacy_labels =
+  match (label_cmt, legacy_labels) with
+  | Some label_cmt, "" ->
+      Label.of_string label_cmt >>= fun labels -> Ok (labels, false)
+  | Some _, _ -> Error [ `Msg "cannot mix both block labels syntax" ]
+  | None, l -> Label.of_string l >>= fun labels -> Ok (labels, true)
+
+let from_raw raw =
+  match raw with
+  | Raw.Include { loc; section; labels } ->
+      locate_errors ~loc (Label.of_string labels) >>= fun labels ->
+      Util.Result.to_error_list @@ mk_include ~loc ~section ~labels
+  | Raw.Any { loc; section; header; contents; label_cmt; legacy_labels; errors }
+    ->
+      let header = Header.of_string header in
+      locate_errors ~loc (parse_labels ~label_cmt ~legacy_labels)
+      >>= fun (labels, legacy_labels) ->
+      Util.Result.to_error_list
+      @@ mk ~loc ~section ~header ~contents ~labels ~legacy_labels ~errors
 
 let is_active ?section:s t =
   let active =

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -289,7 +289,7 @@ let version_enabled version =
 let get_label f (labels : Label.t list) = Util.List.find_map f labels
 
 let label_not_allowed ~loc ~label ~kind =
-  loc_error ~loc "`%s` label is required for %s blocks." label kind
+  loc_error ~loc "`%s` label is not allowed for %s blocks." label kind
 
 let label_required ~loc ~label ~kind =
   loc_error ~loc "`%s` label is required for %s blocks." label kind

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -72,6 +72,23 @@ type value =
 type section = int * string
 (** The type for sections. *)
 
+module Raw : sig
+  type t
+
+  val make :
+    loc:Location.t ->
+    section:section option ->
+    header:string ->
+    contents:string list ->
+    label_cmt:string option ->
+    legacy_labels:string ->
+    errors:Output.t list ->
+    t
+
+  val make_include :
+    loc:Location.t -> section:section option -> labels:string -> t
+end
+
 type t = {
   loc : Location.t;
   section : section option;
@@ -105,6 +122,8 @@ val mk_include :
   (t, [ `Msg of string ]) result
 (** [mk_include] builds an include block from a comment [<!-- $MDX ... -->]
     that is not followed by a code block [``` ... ```]. *)
+
+val from_raw : Raw.t -> (t, [ `Msg of string ] list) Result.result
 
 (** {2 Printers} *)
 

--- a/lib/lexer_mdx.mli
+++ b/lib/lexer_mdx.mli
@@ -1,4 +1,5 @@
-type token = [ `Block of Block.t | `Section of int * string | `Text of string ]
+type token =
+  [ `Block of Block.Raw.t | `Section of int * string | `Text of string ]
 
 val markdown_token : Lexing.lexbuf -> (token list, [ `Msg of string ]) result
 val cram_token : Lexing.lexbuf -> (token list, [ `Msg of string ]) result

--- a/lib/lexer_mdx.mll
+++ b/lib/lexer_mdx.mll
@@ -116,7 +116,8 @@ and cram_block = parse
     | exn ->
       let loc = Location.curr lexbuf in
       let msg =
-        Format.asprintf "%a: %s" Stable_printer.Location.print_loc loc (Printexc.to_string exn)
+        Format.asprintf "%a: %s" Stable_printer.Location.pp loc
+          (Printexc.to_string exn)
       in
       Util.Result.errorf "%s" msg
 
@@ -127,7 +128,8 @@ let cram_token lexbuf =
     | exn ->
       let loc = Location.curr lexbuf in
       let msg =
-        Format.asprintf "%a: %s" Stable_printer.Location.print_loc loc (Printexc.to_string exn)
+        Format.asprintf "%a: %s" Stable_printer.Location.pp loc
+          (Printexc.to_string exn)
       in
       Util.Result.errorf "%s" msg
 }

--- a/lib/lexer_mdx.mll
+++ b/lib/lexer_mdx.mll
@@ -1,17 +1,9 @@
 {
 open Astring
 
-type token = [ `Block of Block.t | `Section of int * string | `Text of string ]
+type token = [ `Block of Block.Raw.t | `Section of int * string | `Text of string ]
 
 let newline lexbuf = Lexing.new_line lexbuf
-
-let labels l =
-  match Label.of_string l with
-  | Ok labels -> labels
-  | Error msgs ->
-    let msgs = List.map (fun (`Msg (x : string)) -> x) msgs in
-    let msg = String.concat ~sep:" " msgs in
-    failwith msg
 }
 
 let eol = '\n' | eof
@@ -24,15 +16,8 @@ rule text section = parse
         newline lexbuf;
         `Section section :: text (Some section) lexbuf }
   | ( "<!--" ws* "$MDX" ws* ([^' ' '\n']* as label_cmt) ws* "-->" ws* eol? )?
-      "```" ([^' ' '\n']* as h) ws* ([^'\n']* as legacy_labels) eol
-      { let header = Block.Header.of_string h in
-        let contents = block lexbuf in
-        let labels, legacy_labels =
-          match (label_cmt, legacy_labels) with
-          | Some label_cmt, "" -> labels label_cmt, false
-          | Some _, _ -> failwith "cannot mix both block labels syntax"
-          | None, l -> labels l, true
-        in
+      "```" ([^' ' '\n']* as header) ws* ([^'\n']* as legacy_labels) eol
+      { let contents = block lexbuf in
         let errors =
           match error_block lexbuf with
           | exception _ -> []
@@ -47,12 +32,8 @@ rule text section = parse
         let loc = Location.curr lexbuf in
         newline lexbuf;
         let block =
-          match
-            Block.mk ~loc ~section ~header ~contents ~labels
-              ~legacy_labels ~errors
-          with
-          | Ok block -> block
-          | Error (`Msg msg) -> failwith msg
+          Block.Raw.make ~loc ~section ~header ~contents ~label_cmt
+            ~legacy_labels ~errors
         in
         (match errors with
          | [] -> ()
@@ -61,15 +42,10 @@ rule text section = parse
            List.iter (fun _ -> newline lexbuf) errors;
            newline lexbuf);
         `Block block :: text section lexbuf }
-  | "<!--" ws* "$MDX" ws* ([^' ' '\n']* as label_cmt) ws* "-->" ws* eol
-      { let labels = labels label_cmt in
-        newline lexbuf;
+  | "<!--" ws* "$MDX" ws* ([^' ' '\n']* as labels) ws* "-->" ws* eol
+      { newline lexbuf;
         let loc = Location.curr lexbuf in
-        let block =
-          match Block.mk_include ~loc ~section ~labels with
-          | Ok block -> block
-          | Error (`Msg msg) -> failwith msg
-        in
+        let block = Block.Raw.make_include ~loc ~section ~labels in
         `Block block :: text section lexbuf }
   | ([^'\n']* as str) eol
       { newline lexbuf;
@@ -89,44 +65,32 @@ and cram_text section = parse
         newline lexbuf;
         `Section section :: cram_text (Some section) lexbuf }
   | "  " ([^'\n']* as first_line) eol
-      { let header = Some (Block.Header.Shell `Sh) in
+      { let header = "sh" in
         let requires_empty_line, contents = cram_block lexbuf in
         let contents = first_line :: contents in
-        let labels = [] in
-        let legacy_labels = false in
+        let label_cmt = Some "" in
+        let legacy_labels = "" in
         let loc = Location.curr lexbuf in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
         let block =
-          match
-            Block.mk ~loc ~section ~header ~contents ~labels
+            Block.Raw.make ~loc ~section ~header ~contents ~label_cmt
               ~legacy_labels ~errors:[]
-          with
-          | Ok block -> block
-          | Error (`Msg msg) -> failwith msg
         in
         `Block block
         :: (if requires_empty_line then `Text "" :: rest else rest) }
   | "<-- non-deterministic" ws* ([^'\n']* as choice) eol
-      { let header = Some (Block.Header.Shell `Sh) in
+      { let header = "sh" in
         let requires_empty_line, contents = cram_block lexbuf in
-        let labels =
-          match Label.interpret "non-deterministic" (Some (Eq, choice)) with
-          | Ok label -> [label]
-          | Error (`Msg msg) -> failwith msg
-        in
-        let legacy_labels = false in
+        let label_cmt = Some (Printf.sprintf "non-deterministic=%s" choice) in
+        let legacy_labels = "" in
         newline lexbuf;
         let loc = Location.curr lexbuf in
         List.iter (fun _ -> newline lexbuf) contents;
         let rest = cram_text section lexbuf in
         let block =
-          match
-            Block.mk ~loc ~section ~header ~contents ~labels
+            Block.Raw.make ~loc ~section ~header ~contents ~label_cmt
               ~legacy_labels ~errors:[]
-          with
-          | Ok block -> block
-          | Error (`Msg msg) -> failwith msg
         in
         `Block block
         :: (if requires_empty_line then `Text "" :: rest else rest) }
@@ -145,12 +109,6 @@ and cram_block = parse
   let markdown_token lexbuf =
     try Ok (text None lexbuf)
     with
-    | Failure e ->
-      let loc = Location.curr lexbuf in
-      let msg =
-        Format.asprintf "%a: invalid code block: %s" Stable_printer.Location.print_loc loc e
-      in
-      Util.Result.errorf "%s" msg
     | exn ->
       let loc = Location.curr lexbuf in
       let msg =
@@ -162,12 +120,6 @@ and cram_block = parse
 let cram_token lexbuf =
     try Ok (cram_text None lexbuf)
     with
-    | Failure e ->
-      let loc = Location.curr lexbuf in
-      let msg =
-        Format.asprintf "%a: invalid code block: %s" Stable_printer.Location.print_loc loc e
-      in
-      Util.Result.errorf "%s" msg
     | exn ->
       let loc = Location.curr lexbuf in
       let msg =

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -64,13 +64,8 @@ let parse l =
         | `Block rb -> Block.from_raw rb >>= fun b -> Ok (Block b))
       l
   in
-  let errors =
-    Util.List.concat_map (function Ok _ -> [] | Error l -> l) results
-  in
-  let ok =
-    List.filter_map (function Ok x -> Some x | Error _ -> None) results
-  in
-  match errors with [] -> Ok ok | _ -> Error errors
+  let ok, errors = Util.Result.List.split results in
+  match errors with [] -> Ok ok | _ -> Error (List.concat errors)
 
 let parse_lexbuf file_contents syntax l =
   match syntax with

--- a/lib/mdx.ml
+++ b/lib/mdx.ml
@@ -64,7 +64,9 @@ let parse l =
         | `Block rb -> Block.from_raw rb >>= fun b -> Ok (Block b))
       l
   in
-  let errors = List.concat_map (function Ok _ -> [] | Error l -> l) results in
+  let errors =
+    Util.List.concat_map (function Ok _ -> [] | Error l -> l) results
+  in
   let ok =
     List.filter_map (function Ok x -> Some x | Error _ -> None) results
   in

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -47,15 +47,15 @@ val dump : line list Fmt.t
 
 (** {2 Document} *)
 
-val of_string : syntax -> string -> (t, [ `Msg of string ]) result
+val of_string : syntax -> string -> (t, [ `Msg of string ] list) result
 (** [of_string syntax s] is the document [t] such that
     [to_string ~syntax t = s]. *)
 
-val parse_file : syntax -> string -> (t, [ `Msg of string ]) result
+val parse_file : syntax -> string -> (t, [ `Msg of string ] list) result
 (** [parse_file s] is {!of_string} of [s]'s contents. *)
 
 val parse_lexbuf :
-  string -> syntax -> Lexing.lexbuf -> (t, [ `Msg of string ]) result
+  string -> syntax -> Lexing.lexbuf -> (t, [ `Msg of string ] list) result
 (** [parse_lexbuf l] is {!of_string} of [l]'s contents. *)
 
 (** {2 Evaluation} *)
@@ -64,7 +64,7 @@ val run_to_stdout :
   ?syntax:syntax ->
   f:(string -> t -> string) ->
   string ->
-  (unit, [ `Msg of string ]) result
+  (unit, [ `Msg of string ] list) result
 (** [run_to_stdout ?syntax ~f file] runs the callback [f] on the raw and
     structured content of [file], as specified  by [syntax] (defaults to [Normal]).
     The returned corrected version is then written to stdout. *)
@@ -74,7 +74,7 @@ val run_to_file :
   f:(string -> t -> string) ->
   outfile:string ->
   string ->
-  (unit, [ `Msg of string ]) result
+  (unit, [ `Msg of string ] list) result
 (** Same as [run_to_stdout] but writes the corrected version to [outfile]*)
 
 val run :
@@ -82,7 +82,7 @@ val run :
   ?force_output:bool ->
   f:(string -> t -> string) ->
   string ->
-  (unit, [ `Msg of string ]) result
+  (unit, [ `Msg of string ] list) result
 (** [run_to_file ?syntax ?force_output ~f ~outfile file] runs the callback [f]
     similarly to [run_to_stdout] to generate its corrected version. If
     [force_output] is [true] (defaults to [false]) or if the corrected version

--- a/lib/mli_parser.ml
+++ b/lib/mli_parser.ml
@@ -221,4 +221,4 @@ let parse_mli file_contents =
 
 let parse_mli file_contents =
   try Ok (parse_mli file_contents)
-  with exn -> Util.Result.errorf "%s" (Printexc.to_string exn)
+  with exn -> Error [ `Msg (Printexc.to_string exn) ]

--- a/lib/mli_parser.mli
+++ b/lib/mli_parser.mli
@@ -1,2 +1,2 @@
-val parse_mli : string -> (Document.line list, [ `Msg of string ]) result
+val parse_mli : string -> (Document.line list, [ `Msg of string ] list) result
 (** Slice an mli file into its [Text] and [Block] parts. *)

--- a/lib/stable_printer.ml
+++ b/lib/stable_printer.ml
@@ -1,7 +1,7 @@
 module Location = struct
   open Location
 
-  let print_loc ppf loc =
+  let pp ppf loc =
     (*setup_colors ();*)
     let file_valid = function
       | "_none_" ->

--- a/lib/stable_printer.mli
+++ b/lib/stable_printer.mli
@@ -3,6 +3,6 @@ Use this for user facing part of the code so that mdx's output does not
 depend on the ocaml version it was built with. *)
 
 module Location : sig
-  val print_loc : Format.formatter -> Location.t -> unit
+  val pp : Format.formatter -> Location.t -> unit
   (** Prints location for error reporting as ["File <file>, lines <line-range>"] *)
 end

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -24,7 +24,7 @@ module Result = struct
       | Ok x -> f x
       | Error l ->
           List.iter
-            (function `Msg m -> Printf.eprintf "[mdx] Fatal error: %s\n" m)
+            (fun (`Msg m) -> Printf.eprintf "[mdx] Fatal error: %s\n" m)
             l;
           1
   end

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -95,6 +95,15 @@ module List = struct
       | h :: t -> ( match f h with Some x -> Some x | None -> aux t)
     in
     aux l
+
+  let concat_map f l =
+    let rec aux f acc = function
+      | [] -> List.rev acc
+      | x :: l ->
+          let xs = f x in
+          aux f (List.rev_append xs acc) l
+    in
+    aux f [] l
 end
 
 module Array = struct

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -22,12 +22,15 @@ module Result = struct
     let ( >>! ) r f =
       match r with
       | Ok x -> f x
-      | Error (`Msg e) ->
-          Printf.eprintf "[mdx] Fatal error: %s\n" e;
+      | Error l ->
+          List.iter
+            (function `Msg m -> Printf.eprintf "[mdx] Fatal error: %s\n" m)
+            l;
           1
   end
 
   let errorf fmt = Format.ksprintf (fun s -> Error (`Msg s)) fmt
+  let to_error_list = function Ok x -> Ok x | Error err -> Error [ err ]
 
   module List = struct
     open Infix

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -45,6 +45,15 @@ module Result = struct
     let map ~f l =
       fold ~f:(fun acc elm -> f elm >>| fun elm' -> elm' :: acc) ~init:[] l
       >>| List.rev
+
+    let split l =
+      let rec split_rec oks errors l =
+        match l with
+        | [] -> (List.rev oks, List.rev errors)
+        | Ok x :: tl -> split_rec (x :: oks) errors tl
+        | Error x :: tl -> split_rec oks (x :: errors) tl
+      in
+      split_rec [] [] l
   end
 end
 
@@ -95,15 +104,6 @@ module List = struct
       | h :: t -> ( match f h with Some x -> Some x | None -> aux t)
     in
     aux l
-
-  let concat_map f l =
-    let rec aux f acc = function
-      | [] -> List.rev acc
-      | x :: l ->
-          let xs = f x in
-          aux f (List.rev_append xs acc) l
-    in
-    aux f [] l
 end
 
 module Array = struct

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -50,6 +50,7 @@ end
 
 module List : sig
   val find_map : ('a -> 'b option) -> 'a list -> 'b option
+  val concat_map : ('a -> 'b list) -> 'a list -> 'b list
 end
 
 module String : sig

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -36,6 +36,7 @@ module Result : sig
       ('acc, 'err) result
 
     val map : f:('a -> ('b, 'err) result) -> 'a list -> ('b list, 'err) result
+    val split : ('a, 'err) result list -> 'a list * 'err list
   end
 end
 
@@ -50,7 +51,6 @@ end
 
 module List : sig
   val find_map : ('a -> 'b option) -> 'a list -> 'b option
-  val concat_map : ('a -> 'b list) -> 'a list -> 'b list
 end
 
 module String : sig

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -20,11 +20,13 @@ module Result : sig
       ('a, 'err) result -> ('a -> ('b, 'err) result) -> ('b, 'err) result
 
     val ( >>| ) : ('a, 'err) result -> ('a -> 'b) -> ('b, 'err) result
-    val ( >>! ) : ('a, [ `Msg of string ]) result -> ('a -> int) -> int
+    val ( >>! ) : ('a, [ `Msg of string ] list) result -> ('a -> int) -> int
   end
 
   val errorf :
     ('a, unit, string, ('b, [> `Msg of string ]) result) format4 -> 'a
+
+  val to_error_list : ('a, 'err) result -> ('a, 'err list) result
 
   module List : sig
     val fold :

--- a/test/bin/mdx-test/failure/block-locations/test-case.md
+++ b/test/bin/mdx-test/failure/block-locations/test-case.md
@@ -1,0 +1,27 @@
+There was a bug in a the lexer/parser for markdown and cram files
+that lead to increasingly big offsets in block locations.
+This impacted error reporting quite badly.
+
+Here we have a few valid blocks followed by one that triggers an error,
+it should be reported with the correct block location.
+
+
+<!-- $MDX toplevel -->
+```ocaml
+# 1 + 1;;
+```
+
+<!-- $MDX toplevel -->
+```ocaml
+# 1 + 1;;
+```
+
+<!-- $MDX toplevel -->
+```ocaml
+# 1 + 1;;
+```
+
+<!-- $MDX pif=paf -->
+```ocaml
+# 1 + 1;;
+```

--- a/test/bin/mdx-test/failure/block-locations/test-case.md.expected
+++ b/test/bin/mdx-test/failure/block-locations/test-case.md.expected
@@ -1,0 +1,1 @@
+[mdx] Fatal error: File "test-case.md", lines 21-23: invalid code block: `pif` is not a valid label.

--- a/test/bin/mdx-test/failure/block-locations/test-case.md.expected
+++ b/test/bin/mdx-test/failure/block-locations/test-case.md.expected
@@ -1,1 +1,1 @@
-[mdx] Fatal error: File "test-case.md", lines 21-23: invalid code block: `pif` is not a valid label.
+[mdx] Fatal error: File "test-case.md", lines 24-27: invalid code block: `pif` is not a valid label.

--- a/test/bin/mdx-test/failure/cram-command-syntax/test-case.t.expected
+++ b/test/bin/mdx-test/failure/cram-command-syntax/test-case.t.expected
@@ -1,2 +1,2 @@
-File "test-case.t", line 3: Error in the cram code block
+File "test-case.t", lines 3-4: Error in the cram code block
 Blocks must start with a command or similar, not with an output line. To indicate a line as a command, start it with a dollar followed by a space.

--- a/test/bin/mdx-test/failure/cram-empty-line/test-case.t.expected
+++ b/test/bin/mdx-test/failure/cram-empty-line/test-case.t.expected
@@ -1,2 +1,2 @@
-File "test-case.t", line 5: Error in the cram code block
+File "test-case.t", lines 5-6: Error in the cram code block
 Blocks must start with a command or similar, not with an output line. Please, make sure that there's no spare empty line, particularly between the output and its input.

--- a/test/bin/mdx-test/failure/dune.inc
+++ b/test/bin/mdx-test/failure/dune.inc
@@ -1,5 +1,18 @@
 
 (rule
+ (target block-locations.actual)
+ (deps (package mdx) (source_tree block-locations))
+ (action
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir block-locations
+     (run %{bin:ocaml-mdx} test test-case.md))))))
+
+(rule
+ (alias runtest)
+ (action (diff block-locations/test-case.md.expected block-locations.actual)))
+
+(rule
  (target both-prelude.actual)
  (deps (package mdx) (source_tree both-prelude))
  (action

--- a/test/bin/mdx-test/failure/dune.inc
+++ b/test/bin/mdx-test/failure/dune.inc
@@ -106,6 +106,19 @@
  (action (diff ml-file-not-found/test-case.md.expected ml-file-not-found.actual)))
 
 (rule
+ (target multiple-errors.actual)
+ (deps (package mdx) (source_tree multiple-errors))
+ (action
+  (with-accepted-exit-codes 1
+   (with-outputs-to %{target}
+    (chdir multiple-errors
+     (run %{bin:ocaml-mdx} test test-case.md))))))
+
+(rule
+ (alias runtest)
+ (action (diff multiple-errors/test-case.md.expected multiple-errors.actual)))
+
+(rule
  (target part-not-ended.actual)
  (deps (package mdx) (source_tree part-not-ended))
  (action

--- a/test/bin/mdx-test/failure/invalid-label-value/test-case.md.expected
+++ b/test/bin/mdx-test/failure/invalid-label-value/test-case.md.expected
@@ -1,1 +1,2 @@
-[mdx] Fatal error: File "test-case.md", line 3: invalid code block: "bar" is not a valid value for label `non-deterministic`. Valid values are <none>, "command" and "output". Label `skip` does not allow a value.
+[mdx] Fatal error: File "test-case.md", lines 3-5: invalid code block: "bar" is not a valid value for label `non-deterministic`. Valid values are <none>, "command" and "output".
+[mdx] Fatal error: File "test-case.md", lines 3-5: invalid code block: Label `skip` does not allow a value.

--- a/test/bin/mdx-test/failure/invalid-label/test-case.md.expected
+++ b/test/bin/mdx-test/failure/invalid-label/test-case.md.expected
@@ -1,1 +1,1 @@
-[mdx] Fatal error: File "test-case.md", line 3: invalid code block: `toto` is not a valid label.
+[mdx] Fatal error: File "test-case.md", lines 3-5: invalid code block: `toto` is not a valid label.

--- a/test/bin/mdx-test/failure/mixed-label-syntax/test-case.md.expected
+++ b/test/bin/mdx-test/failure/mixed-label-syntax/test-case.md.expected
@@ -1,1 +1,1 @@
-[mdx] Fatal error: File "test-case.md", line 3: invalid code block: cannot mix both block labels syntax
+[mdx] Fatal error: File "test-case.md", lines 3-8: invalid code block: cannot mix both block labels syntax

--- a/test/bin/mdx-test/failure/mixed-label-syntax/test-case.md.expected
+++ b/test/bin/mdx-test/failure/mixed-label-syntax/test-case.md.expected
@@ -1,1 +1,1 @@
-[mdx] Fatal error: File "test-case.md", lines 3-8: invalid code block: cannot mix both block labels syntax
+[mdx] Fatal error: File "test-case.md", lines 3-9: invalid code block: cannot mix both block labels syntax

--- a/test/bin/mdx-test/failure/multiple-errors/test-case.md
+++ b/test/bin/mdx-test/failure/multiple-errors/test-case.md
@@ -1,0 +1,12 @@
+MDX should be able to report several simple errors such as
+misused label or syntax errors inside blocks.
+
+<!-- $MDX pif=paf -->
+```ocaml
+# 1 + 1;;
+```
+
+<!-- $MDX foo=bar -->
+```ocaml
+let x = 1
+```

--- a/test/bin/mdx-test/failure/multiple-errors/test-case.md.expected
+++ b/test/bin/mdx-test/failure/multiple-errors/test-case.md.expected
@@ -1,1 +1,2 @@
-[mdx] Fatal error: File "test-case.md", line 4: invalid code block: `pif` is not a valid label.
+[mdx] Fatal error: File "test-case.md", lines 4-6: invalid code block: `pif` is not a valid label.
+[mdx] Fatal error: File "test-case.md", lines 8-10: invalid code block: `foo` is not a valid label.

--- a/test/bin/mdx-test/failure/multiple-errors/test-case.md.expected
+++ b/test/bin/mdx-test/failure/multiple-errors/test-case.md.expected
@@ -1,0 +1,1 @@
+[mdx] Fatal error: File "test-case.md", line 4: invalid code block: `pif` is not a valid label.

--- a/test/bin/mdx-test/failure/multiple-errors/test-case.md.expected
+++ b/test/bin/mdx-test/failure/multiple-errors/test-case.md.expected
@@ -1,2 +1,2 @@
-[mdx] Fatal error: File "test-case.md", lines 4-6: invalid code block: `pif` is not a valid label.
-[mdx] Fatal error: File "test-case.md", lines 8-10: invalid code block: `foo` is not a valid label.
+[mdx] Fatal error: File "test-case.md", lines 4-7: invalid code block: `pif` is not a valid label.
+[mdx] Fatal error: File "test-case.md", lines 9-12: invalid code block: `foo` is not a valid label.

--- a/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
@@ -1,1 +1,1 @@
-[mdx] Fatal error: File "test-case.md", lines 3-4: invalid code block: `part` label is required for non-OCaml include blocks.
+[mdx] Fatal error: File "test-case.md", lines 3-4: invalid code block: `part` label is not allowed for non-OCaml include blocks.

--- a/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
+++ b/test/bin/mdx-test/failure/part-unsupported/test-case.md.expected
@@ -1,1 +1,1 @@
-[mdx] Fatal error: File "test-case.md", lines 3-5: invalid code block: `part` label is not allowed for non-OCaml include blocks.
+[mdx] Fatal error: File "test-case.md", lines 3-4: invalid code block: `part` label is required for non-OCaml include blocks.

--- a/test/lib/test_block.ml
+++ b/test/lib/test_block.ml
@@ -25,6 +25,13 @@ let test_mk =
         Mdx.Block.mk ~loc:Location.none ~section:None ~labels
           ~legacy_labels:false ~header ~contents ~errors:[]
       in
+      let expected =
+        Result.map_error
+          (function
+            | `Msg m ->
+                `Msg ({|File "_none_", line 1: invalid code block: |} ^ m))
+          expected
+      in
       Alcotest.(check (result Testable.block Testable.msg))
         test_name expected actual
     in

--- a/test/lib/test_dep.ml
+++ b/test/lib/test_dep.ml
@@ -52,7 +52,7 @@ let test_of_line =
       let actual =
         Mdx.of_string Mdx.Normal lines >>| fun lines -> Mdx.Dep.of_lines lines
       in
-      Alcotest.(check (result (list Testable.dep) Testable.msg))
+      Alcotest.(check (result (list Testable.dep) (list Testable.msg)))
         test_name expected actual
     in
     (test_name, `Quick, test_fun)


### PR DESCRIPTION
This PR improves the MDX workflow by making sure that all parsing errors are reported at once rather than exiting on the first errors.

Obviously that only impacts errors that we can recover from e.g. mis-used or missing labels, syntax error inside a block but not for errors such as invalid markdown.

We used to do all the work in markdown/cram parser. I changed that to extract raw bits of data from the parser and leave their interpretation to a later pass.

While working on this I discovered that the locations we attach to blocks are incorrect due to inconsistencies in `eol` handling in the lexer code which I took the liberty to fix as part of this PR. I can eventually extract it as a separate PR depending on this one if you'd like but basing it on this work made it significantly simpler.

