### PR TITLE
Fix multilines for OCaml block in .mli file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 #### Changed
 
+- Preserve indentation in multiline OCaml blocks in .mli files (#395, @panglesd)
+
 #### Deprecated
 
 #### Fixed

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -162,8 +162,7 @@ let lstrip strings =
   let hpad = Misc.hpad_of_lines strings in
   List.map
     (fun string ->
-      let min a b = if a < b then a else b in
-      let first = min (Misc.hpad_of_lines [ string ]) hpad in
+      let first = Util.Int.min (Misc.hpad_of_lines [ string ]) hpad in
       Astring.String.with_index_range string ~first)
     strings
 

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -158,15 +158,20 @@ let pp_lines syntax t =
   in
   Fmt.(list ~sep:(any "\n") pp)
 
-let lstrip string =
-  let hpad = Misc.hpad_of_lines [ string ] in
-  Astring.String.with_index_range string ~first:hpad
+let lstrip strings =
+  let hpad = Misc.hpad_of_lines strings in
+  List.map
+    (fun string ->
+      let min a b = if a < b then a else b in
+      let first = min (Misc.hpad_of_lines [ string ]) hpad in
+      Astring.String.with_index_range string ~first)
+    strings
 
 let pp_contents ?syntax ppf t =
   match (syntax, t.contents) with
   | Some Syntax.Mli, [ line ] -> Fmt.pf ppf "%s" line
   | Some Syntax.Mli, lines ->
-      Fmt.pf ppf "@\n%a@\n" (pp_lines syntax t) (List.map lstrip lines)
+      Fmt.pf ppf "@\n%a@\n" (pp_lines syntax t) (lstrip lines)
   | (Some Cram | Some Normal | None), [] -> ()
   | (Some Cram | Some Normal | None), _ ->
       Fmt.pf ppf "%a\n" (pp_lines syntax t) t.contents

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -116,3 +116,7 @@ module Process = struct
   let wait ~pid =
     match snd (Unix.waitpid [] pid) with WEXITED n -> n | _ -> 255
 end
+
+module Int = struct
+  let min a b = if a < b then a else b
+end

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -77,3 +77,7 @@ module Process : sig
       Exit code is the same as the child process if it exits normally, or 255
       otherwise. *)
 end
+
+module Int : sig
+  val min : int -> int -> int
+end

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -276,6 +276,18 @@
  (action (diff multilines/test-case.md multilines.actual)))
 
 (rule
+ (target multilines-mli.actual)
+ (deps (package mdx) (source_tree multilines-mli))
+ (action
+  (with-stdout-to %{target}
+   (chdir multilines-mli
+    (run ocaml-mdx test --output - test-case.mli)))))
+
+(rule
+ (alias runtest)
+ (action (diff multilines-mli/test-case.mli multilines-mli.actual)))
+
+(rule
  (target non-det.actual)
  (deps (package mdx) (source_tree non-det))
  (action

--- a/test/bin/mdx-test/expect/multilines-mli/test-case.mli
+++ b/test/bin/mdx-test/expect/multilines-mli/test-case.mli
@@ -33,13 +33,4 @@ The formatting for multilines in .mli files is the following:
       | None -> ()
       | Some b -> b
   ]}
-
-But it does not work fine for toplevel (see [multilines/test-case.md] for the
-correct definition of [fact], which get erased by [mdx]):
-
-{[
-  # let rec fact = function;;
-  Line 1, characters 24-26:
-  Error: Syntax error
-]}
 *)

--- a/test/bin/mdx-test/expect/multilines-mli/test-case.mli
+++ b/test/bin/mdx-test/expect/multilines-mli/test-case.mli
@@ -22,19 +22,20 @@ This works for normal OCaml fragments:
 ]}
 
 The formatting for multilines in .mli files is the following:
-- Everything is indented with two spaces after the column of the opening code
-  block.
+- The first line is indented two spaces after the comment opening
+- The other lines are indented to keep the original indentation relative to the
+  first line
 
   {[
     match None with
     | None -> ()
     | Some a -> match a with
-    | None -> ()
-    | Some b -> b
+      | None -> ()
+      | Some b -> b
   ]}
 
 But it does not work fine for toplevel (see [multilines/test-case.md] for the
-correct definition of [fact]):
+correct definition of [fact], which get erased by [mdx]):
 
 {[
   # let rec fact = function;;

--- a/test/bin/mdx-test/expect/multilines-mli/test-case.mli
+++ b/test/bin/mdx-test/expect/multilines-mli/test-case.mli
@@ -1,0 +1,44 @@
+(**
+
+In OCaml docstring everything is indented with two spaces
+
+Test multi-lines shell commands:
+
+{@sh[
+  $ for i in `seq 1 10`; do \
+  >   echo $i; \
+  > done
+  1
+  ...
+  10
+]}
+
+This works for normal OCaml fragments:
+
+{[
+  let rec fact = function
+  | 1 -> 1
+  | n -> n * fact (n-1)
+]}
+
+The formatting for multilines in .mli files is the following:
+- Everything is indented with two spaces after the column of the opening code
+  block.
+
+  {[
+    match None with
+    | None -> ()
+    | Some a -> match a with
+    | None -> ()
+    | Some b -> b
+  ]}
+
+But it does not work fine for toplevel (see [multilines/test-case.md] for the
+correct definition of [fact]):
+
+{[
+  # let rec fact = function;;
+  Line 1, characters 24-26:
+  Error: Syntax error
+]}
+*)


### PR DESCRIPTION
This small PR fixes the fact that, in OCaml blocks, in .mli files, the indentation was erased to a "only 2 space relative to the opening bracket" indentation.

For instance,
```ocaml
(**
{[
  match None with
  | None -> ()
  | Some a -> match a with
    | None -> ()
    | Some _ -> ()
]}
*)
```
was turned into
```ocaml
(**
{[
  match None with
  | None -> ()
  | Some a -> match a with
  | None -> ()
  | Some _ -> ()
]}
*)
```
which is not ideal.

The first commit adds a test, showing the wrong behaviour,. The second commit is the patch and updates the test.
The new behaviour is the first line is indented two spaces after the opening bracket, and for other lines the indentation relative to the first one is kept, as long as they are at least as indented as the first one. In the previous example, the exact indententation would be kept. 

In the test, I also added that multilines in .mli files for toplevel block does not work!