### PR TITLE
Retrieve the code block content from the odoc-parser locations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
   the output, before that line would've been dropped (#374, #387,
   @Leonidas-from-XIV)
 - Handle EINTR signal on waitpid call by restarting the syscall. (#409, @tmcgilchrist)
+- Fix parsing of multiline toplevel phrases in .mli files (#394, #397,
+  @Leonidas-from-XIV)
 
 #### Removed
 

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -47,7 +47,7 @@ let run (`Setup ()) (`File file) (`Section section) =
               if not (Mdx.Block.skip b) then (
                 Log.debug (fun l -> l "pp: %a" Mdx.Block.dump b);
                 let pp_lines = Fmt.(list ~sep:(any "\n") string) in
-                let contents = Mdx.Block.executable_contents ~syntax:Normal b in
+                let contents = Mdx.Block.executable_contents b in
                 match b.value with
                 | Toplevel _ -> Fmt.pr "%a\n" pp_lines contents
                 | OCaml _ ->

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -164,8 +164,6 @@ let pp_errors ppf t =
   | OCaml { errors = []; _ } -> ()
   | OCaml { errors; _ } ->
       let errors = error_padding errors in
-      Logs.debug (fun l ->
-          l "Printing errors: %a" (Fmt.Dump.list Output.dump) errors);
       Fmt.pf ppf "```mdx-error\n%a\n```\n"
         Fmt.(list ~sep:(any "\n") Output.pp)
         errors
@@ -408,10 +406,6 @@ let mk ~loc ~section ~labels ~legacy_labels ~header ~contents ~errors =
     get_label (function Block_kind x -> Some x | _ -> None) labels
   in
   let config = get_block_config labels in
-  Logs.debug (fun l ->
-      l "Block kind in Block.mk is %a"
-        (Fmt.Dump.option Label.pp_block_kind)
-        block_kind);
   let* value =
     match block_kind with
     | Some OCaml -> mk_ocaml ~loc ~config ~header ~contents ~errors
@@ -460,10 +454,6 @@ let from_raw raw =
       Util.Result.to_error_list @@ mk_include ~loc ~section ~labels
   | Raw.Any { loc; section; header; contents; label_cmt; legacy_labels; errors }
     ->
-      Logs.debug (fun l ->
-          l "Label_cmt %a,@ legacy_labels %s,@ header = %s"
-            Fmt.Dump.(option string)
-            label_cmt legacy_labels header);
       let header = Header.of_string header in
       let* labels, legacy_labels =
         locate_errors ~loc (parse_labels ~label_cmt ~legacy_labels)

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -263,13 +263,13 @@ let ends_by_semi_semi c =
 let pp_line_directive ppf (file, line) = Fmt.pf ppf "#%d %S" line file
 let line_directive = Fmt.to_to_string pp_line_directive
 
-let executable_contents ~syntax b =
+let executable_contents b =
   let contents =
     match b.value with
     | OCaml _ -> b.contents
     | Raw _ | Cram _ | Include _ -> []
     | Toplevel _ ->
-        let phrases = Toplevel.of_lines ~syntax ~loc:b.loc b.contents in
+        let phrases = Toplevel.of_lines ~loc:b.loc b.contents in
         List.flatten
           (List.map
              (fun (t : Toplevel.t) ->

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -115,7 +115,6 @@ type t = {
   value : value;
 }
 
-let dump_string ppf s = Fmt.pf ppf "%S" s
 let dump_section = Fmt.(Dump.pair int string)
 
 let header t =
@@ -145,18 +144,18 @@ let dump ppf ({ loc; section; labels; contents; value; _ } as b) =
     labels
     Fmt.(Dump.option Header.pp)
     (header b)
-    Fmt.(Dump.list dump_string)
+    Fmt.Dump.(list string)
     contents dump_value value
 
 let pp_lines syntax _t ppf lines =
   let print_line ppf first last line =
     (match syntax with
-    | Some Syntax.Cram -> Fmt.pf ppf "%s" line
+    | Some Syntax.Cram -> Fmt.string ppf line
     | Some Syntax.Mli -> (
         match (first, last) with
-        | true, _ | _, true -> Fmt.pf ppf "%s" (String.trim line)
-        | false, false -> Fmt.pf ppf "%s" line)
-    | Some Syntax.Normal | None -> Fmt.pf ppf "%s" line);
+        | true, _ | _, true -> Fmt.string ppf (String.trim line)
+        | false, false -> Fmt.string ppf line)
+    | Some Syntax.Normal | None -> Fmt.string ppf line);
     match last with false -> Fmt.pf ppf "\n" | true -> ()
   in
 
@@ -172,8 +171,8 @@ let pp_lines syntax _t ppf lines =
 
 let pp_contents ?syntax ppf t =
   match (syntax, t.contents) with
-  | Some Syntax.Mli, [ line ] -> Fmt.pf ppf "%s" line
-  | Some Syntax.Mli, lines -> Fmt.pf ppf "%a" (pp_lines syntax t) lines
+  | Some Syntax.Mli, [ line ] -> Fmt.string ppf line
+  | Some Syntax.Mli, lines -> (pp_lines syntax t) ppf lines
   | (Some Cram | Some Normal | None), [] -> ()
   | (Some Cram | Some Normal | None), lines ->
       Fmt.pf ppf "%a\n" (pp_lines syntax t) lines
@@ -182,7 +181,7 @@ let pp_errors ppf t =
   match t.value with
   | OCaml { errors; _ } when List.length errors > 0 ->
       Fmt.string ppf "```mdx-error\n";
-      Fmt.pf ppf "%a" Fmt.(list ~sep:nop Output.pp) errors;
+      Fmt.(list ~sep:nop Output.pp) ppf errors;
       Fmt.string ppf "```\n"
   | _ -> ()
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -33,6 +33,8 @@ type ocaml_value = {
       (** [env] is the name given to the environment where tests are run. *)
   non_det : Label.non_det option;
   errors : Output.t list;
+      (** [header] defines whether a header was specified for the block. *)
+  header : Header.t option;
 }
 
 type toplevel_value = {
@@ -142,10 +144,6 @@ val pp_footer : ?syntax:Syntax.t -> t Fmt.t
 val pp : ?syntax:Syntax.t -> t Fmt.t
 (** [pp] pretty-prints blocks. *)
 
-val pp_line_directive : (string * int) Fmt.t
-(** [pp_line_directive] pretty-prints a line directive given as a
-   filename and line number. *)
-
 (** {2 Accessors} *)
 
 val non_det : t -> Label.non_det option
@@ -171,11 +169,6 @@ val value : t -> value
 
 val section : t -> section option
 (** [section t] is [t]'s section. *)
-
-val executable_contents : t -> string list
-(** [executable_contents t] is either [t]'s contents if [t] is a raw
-   or a cram block, or [t]'s commands if [t] is a toplevel fragments
-   (e.g. the phrase result is discarded). *)
 
 val is_active : ?section:string -> t -> bool
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -172,7 +172,7 @@ val value : t -> value
 val section : t -> section option
 (** [section t] is [t]'s section. *)
 
-val executable_contents : syntax:Syntax.t -> t -> string list
+val executable_contents : t -> string list
 (** [executable_contents t] is either [t]'s contents if [t] is a raw
    or a cram block, or [t]'s commands if [t] is a toplevel fragments
    (e.g. the phrase result is discarded). *)

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -66,7 +66,7 @@ let rec hpad_of_lines = function
 
 let is_whitespace s = s |> String.trim |> String.is_empty
 
-let of_lines ~syntax:_ ~loc:_ t =
+let of_lines t =
   let hpad = hpad_of_lines t in
   let unpad line =
     match is_whitespace line with

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -20,12 +20,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 open Astring
 open Misc
 
-type t = {
-  command : string list;
-  output : Output.t list;
-  exit_code : int;
-  vpad : int;
-}
+type t = { command : string list; output : Output.t list; exit_code : int }
 
 let dump_line ppf = function
   | #Output.t as o -> Output.dump ppf o
@@ -42,20 +37,10 @@ let dump ppf (t : t) =
     Fmt.(Dump.list Output.dump)
     t.output t.exit_code
 
-let pp_vpad ppf t =
-  let rec loop = function
-    | 0 -> ()
-    | n ->
-        Fmt.pf ppf "\n";
-        loop (Int.pred n)
-  in
-  loop t.vpad
-
 let pp_command ?(pad = 0) ppf (t : t) =
   match t.command with
   | [] -> ()
   | l ->
-      pp_vpad ppf t;
       let sep ppf () = Fmt.pf ppf "\\\n%a> " pp_pad pad in
       Fmt.pf ppf "%a$ %a\n" pp_pad pad Fmt.(list ~sep string) l
 
@@ -97,11 +82,10 @@ let of_lines ~syntax:_ ~loc:_ t =
   let lines =
     Lexer_cram.token (Lexing.from_string (String.concat ~sep:"\n" lines))
   in
-  let vpad = 0 in
   Log.debug (fun l ->
       l "Cram.of_lines (pad=%d) %a" hpad Fmt.(Dump.list dump_line) lines);
   let mk command output ~exit:exit_code =
-    { command; output = List.rev output; exit_code; vpad }
+    { command; output = List.rev output; exit_code }
   in
   let rec command_cont acc = function
     | `Command_cont c :: t -> command_cont (c :: acc) t

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -19,12 +19,7 @@ let src = Logs.Src.create "ocaml-mdx"
 module Log = (val Logs.src_log src : Logs.LOG)
 open Astring
 
-type t = {
-  command : string list;
-  output : Output.t list;
-  exit_code : int;
-  vpad : int;
-}
+type t = { command : string list; output : Output.t list; exit_code : int }
 
 type cram_tests = {
   start_pad : int;
@@ -41,12 +36,12 @@ let dump_line ppf = function
   | `Command_cont c -> Fmt.pf ppf "`Command_cont %S" c
   | `Command_last c -> Fmt.pf ppf "`Command_last %S" c
 
-let dump ppf { command; output; exit_code; vpad } =
-  Fmt.pf ppf "{@[command: %a;@ output: %a;@ exit_code: %d;@ vpad: %d]}"
+let dump ppf { command; output; exit_code } =
+  Fmt.pf ppf "{@[command: %a;@ output: %a;@ exit_code: %d]}"
     Fmt.Dump.(list string)
     command
     (Fmt.Dump.list Output.dump)
-    output exit_code vpad
+    output exit_code
 
 let rec pp_vertical_pad ppf = function
   | 0 -> ()
@@ -54,13 +49,10 @@ let rec pp_vertical_pad ppf = function
       Fmt.pf ppf "\n";
       pp_vertical_pad ppf (Int.pred n)
 
-let pp_vpad ppf { vpad; _ } = pp_vertical_pad ppf vpad
-
 let pp_command ?(pad = 0) ppf (t : t) =
   match t.command with
   | [] -> ()
   | l ->
-      pp_vpad ppf t;
       let sep ppf () = Fmt.pf ppf "\\\n%a> " Pp.pp_pad pad in
       Fmt.pf ppf "%a$ %a" Pp.pp_pad pad Fmt.(list ~sep string) l
 
@@ -150,7 +142,7 @@ let of_lines t =
   Log.debug (fun l ->
       l "Cram.of_lines (pad=%d) %a" hpad Fmt.(Dump.list dump_line) lines);
   let mk command output ~exit:exit_code =
-    { command; output = List.rev output; exit_code; vpad = 0 }
+    { command; output = List.rev output; exit_code }
   in
   let rec command_cont acc = function
     | `Command_cont c :: t -> command_cont (c :: acc) t

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -75,17 +75,14 @@ let pp ?pad ppf (t : t) =
   pp_lines (Output.pp ?pad) ppf t.output;
   pp_exit_code ?pad ppf t.exit_code
 
-let rec hpad_of_lines = function
+let hpad_of_lines = function
   | [] -> 0
-  | h :: hs -> (
-      match String.equal String.empty h with
-      | true -> hpad_of_lines hs
-      | false ->
-          let i = ref 0 in
-          while !i < String.length h && h.[!i] = ' ' do
-            incr i
-          done;
-          !i)
+  | h :: _ ->
+      let i = ref 0 in
+      while !i < String.length h && h.[!i] = ' ' do
+        incr i
+      done;
+      !i
 
 let unpad_line ~hpad line =
   match Util.String.all_blank line with
@@ -144,9 +141,8 @@ let determine_padding lines =
       { start_pad; tests = lines; end_pad }
 
 let of_lines t =
-  (* TODO: determine hpad after padding, much easier *)
-  let hpad = hpad_of_lines t in
   let { start_pad; tests; end_pad } = determine_padding t in
+  let hpad = hpad_of_lines tests in
   let lines = unpad hpad tests in
   let lexer_input =
     lines |> List.map ((Fun.flip String.append) "\n") |> String.concat

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -18,7 +18,6 @@ let src = Logs.Src.create "ocaml-mdx"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 open Astring
-open Misc
 
 type t = {
   command : string list;
@@ -62,17 +61,17 @@ let pp_command ?(pad = 0) ppf (t : t) =
   | [] -> ()
   | l ->
       pp_vpad ppf t;
-      let sep ppf () = Fmt.pf ppf "\\\n%a> " pp_pad pad in
-      Fmt.pf ppf "%a$ %a" pp_pad pad Fmt.(list ~sep string) l
+      let sep ppf () = Fmt.pf ppf "\\\n%a> " Pp.pp_pad pad in
+      Fmt.pf ppf "%a$ %a" Pp.pp_pad pad Fmt.(list ~sep string) l
 
 let pp_exit_code ?(pad = 0) ppf = function
   | 0 -> ()
-  | n -> Fmt.pf ppf "\n%a[%d]" pp_pad pad n
+  | n -> Fmt.pf ppf "\n%a[%d]" Pp.pp_pad pad n
 
 let pp ?pad ppf (t : t) =
   pp_command ?pad ppf t;
   Fmt.string ppf "\n";
-  pp_lines (Output.pp ?pad) ppf t.output;
+  Pp.pp_lines (Output.pp ?pad) ppf t.output;
   pp_exit_code ?pad ppf t.exit_code
 
 let hpad_of_lines = function

--- a/lib/cram.mli
+++ b/lib/cram.mli
@@ -16,12 +16,7 @@
 
 (** Cram tests *)
 
-type t = {
-  command : string list;
-  output : Output.t list;
-  exit_code : int;
-  vpad : int;
-}
+type t = { command : string list; output : Output.t list; exit_code : int }
 (** The type for cram tests. *)
 
 (** {2 Accessors} *)

--- a/lib/cram.mli
+++ b/lib/cram.mli
@@ -16,13 +16,7 @@
 
 (** Cram tests *)
 
-type t = {
-  command : string list;
-  output : Output.t list;
-  exit_code : int;
-  (* TODO: remove vpad *)
-  vpad : int;
-}
+type t = { command : string list; output : Output.t list; exit_code : int }
 
 type cram_tests = {
   start_pad : int;
@@ -58,7 +52,7 @@ val pp : ?pad:int -> t Fmt.t
    the optional whitespace left padding (by default it is 0). *)
 
 val pp_vertical_pad : int Fmt.t
-(** [pp_vpad] is the pretty printer for the initial padding on the top
+(** [pp_vertical_pad] is the pretty printer for the initial padding on the top
    of Cram tests *)
 
 val dump : t Fmt.t

--- a/lib/cram.mli
+++ b/lib/cram.mli
@@ -49,8 +49,7 @@ val command_line : t -> string
 (** {2 Parser} *)
 
 val of_lines : string list -> cram_tests
-(** [of_lines l] parses the commands [l]. It returns the optional
-   whitespace padding. *)
+(** [of_lines l] parses the commands [l]. *)
 
 (** {2 Pretty-printer} *)
 

--- a/lib/cram.mli
+++ b/lib/cram.mli
@@ -34,7 +34,7 @@ val command_line : t -> string
 
 (** {2 Parser} *)
 
-val of_lines : syntax:Syntax.t -> loc:Location.t -> string list -> int * t list
+val of_lines : string list -> int * t list
 (** [of_lines l] parses the commands [l]. It returns the optional
    whitespace padding. *)
 

--- a/lib/cram.mli
+++ b/lib/cram.mli
@@ -20,8 +20,17 @@ type t = {
   command : string list;
   output : Output.t list;
   exit_code : int;
+  (* TODO: remove vpad *)
   vpad : int;
 }
+
+type cram_tests = {
+  start_pad : int;
+  hpad : int;
+  tests : t list;
+  end_pad : string option;
+}
+
 (** The type for cram tests. *)
 
 (** {2 Accessors} *)
@@ -39,7 +48,7 @@ val command_line : t -> string
 
 (** {2 Parser} *)
 
-val of_lines : string list -> int * t list
+val of_lines : string list -> cram_tests
 (** [of_lines l] parses the commands [l]. It returns the optional
    whitespace padding. *)
 
@@ -49,8 +58,14 @@ val pp : ?pad:int -> t Fmt.t
 (** [pp] is the pretty-printer for cram tests. [pad] is the size of
    the optional whitespace left padding (by default it is 0). *)
 
+val pp_vertical_pad : int Fmt.t
+(** [pp_vpad] is the pretty printer for the initial padding on the top
+   of Cram tests *)
+
 val dump : t Fmt.t
 (** [dump] it the printer for dumping cram tests. Useful for debugging. *)
+
+val dump_cram_tests : cram_tests Fmt.t
 
 val pp_command : ?pad:int -> t Fmt.t
 (** [pp_command] pretty-prints cram commands. *)

--- a/lib/cram.mli
+++ b/lib/cram.mli
@@ -16,7 +16,12 @@
 
 (** Cram tests *)
 
-type t = { command : string list; output : Output.t list; exit_code : int }
+type t = {
+  command : string list;
+  output : Output.t list;
+  exit_code : int;
+  vpad : int;
+}
 (** The type for cram tests. *)
 
 (** {2 Accessors} *)

--- a/lib/document.ml
+++ b/lib/document.ml
@@ -15,17 +15,24 @@
  *)
 
 type syntax = Syntax.t = Normal | Cram | Mli
-type line = Section of (int * string) | Text of string | Block of Block.t
+type section = int * string
+type line = Section of section | Text of string | Block of Block.t
 type t = line list
 
-let pp_line ?syntax ppf (l : line) =
-  match l with
-  | Block b -> Fmt.pf ppf "%a\n" (Block.pp ?syntax) b
-  | Section (d, s) -> Fmt.pf ppf "%s %s\n" (String.make d '#') s
-  | Text s -> (
-      match syntax with
-      | Some Mli -> Fmt.pf ppf "%s" s
-      | _ -> Fmt.pf ppf "%s\n" s)
+let pp_section ppf (level, text) =
+  Fmt.pf ppf "%s %s" (String.make level '#') text
+
+let dump_line ppf = function
+  | Block block -> Fmt.pf ppf "Block %a" Block.dump block
+  | Section section -> Fmt.pf ppf "Section %a" pp_section section
+  | Text text -> Fmt.pf ppf "Text %S" text
+
+let pp_line ?syntax ppf = function
+  | Block block -> Block.pp ?syntax ppf block
+  | Section section -> Fmt.pf ppf "%a\n" pp_section section
+  | Text s -> Fmt.string ppf s
+
+let dump ppf t = Fmt.Dump.(list dump_line) ppf t
 
 let pp ?syntax ppf t =
   Fmt.pf ppf "%a\n" Fmt.(list ~sep:(any "\n") (pp_line ?syntax)) t

--- a/lib/document.mli
+++ b/lib/document.mli
@@ -33,6 +33,9 @@ val pp : ?syntax:syntax -> t Fmt.t
 (** [pp] is the pretty printer for mdx documents. Should be idempotent
    with {!of_string}. *)
 
+val dump : t Fmt.t
+(** [dump] is the printer for dumping mdx documents. Useful for debugging. *)
+
 val to_string : t -> string
 (** [to_string t] converts the document [t] to a string. *)
 

--- a/lib/label.ml
+++ b/lib/label.ml
@@ -73,6 +73,13 @@ let default_non_det = Nd_output
 
 type block_kind = OCaml | Cram | Toplevel | Include
 
+(* TODO: [t] needs to be refactored because it usually is used as a [t list]
+   but most of these tags are not supposed to be specified multiple times.
+   There can be at most one Language_tag, similarly specifying multiple
+   Block_kind and Version labels is confusing at best. [t] should probably
+   be refactored to represent all labels and make sure that some labels
+   can be specified 0 or 1 times, while others are indeed lists. *)
+
 type t =
   | Dir of string
   | Source_tree of string
@@ -85,6 +92,9 @@ type t =
   | Set of string * string
   | Unset of string
   | Block_kind of block_kind
+  (* Specifies the language tag that is specified in the [mli] syntax, if
+     any. Can be left out if none is specified, in such case it will also
+     not be added back. *)
   | Language_tag of string
 
 let pp_block_kind ppf = function

--- a/lib/label.ml
+++ b/lib/label.ml
@@ -85,6 +85,7 @@ type t =
   | Set of string * string
   | Unset of string
   | Block_kind of block_kind
+  | Language_tag of string
 
 let pp_block_kind ppf = function
   | OCaml -> Fmt.string ppf "ocaml"
@@ -107,6 +108,7 @@ let pp ppf = function
   | Set (v, x) -> Fmt.pf ppf "set-%s=%s" v x
   | Unset x -> Fmt.pf ppf "unset-%s" x
   | Block_kind bk -> pp_block_kind ppf bk
+  | Language_tag language_tag -> Fmt.string ppf language_tag
 
 let is_prefix ~prefix s =
   let len_prefix = String.length prefix in

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -31,6 +31,8 @@ val default_non_det : non_det
 
 type block_kind = OCaml | Cram | Toplevel | Include
 
+val pp_block_kind : block_kind Fmt.t
+
 type t =
   | Dir of string
   | Source_tree of string
@@ -43,8 +45,9 @@ type t =
   | Set of string * string
   | Unset of string
   | Block_kind of block_kind
+  | Language_tag of string
 
-val pp : Format.formatter -> t -> unit
+val pp : t Fmt.t
 
 val interpret :
   string -> (Relation.t * string) option -> (t, [> `Msg of string ]) result

--- a/lib/lexer_cram.mll
+++ b/lib/lexer_cram.mll
@@ -1,6 +1,4 @@
 {
-open Astring
-let commands s = String.cuts ~sep:"\\\n> " s
 }
 
 let eol = '\n' | eof
@@ -12,13 +10,13 @@ rule token = parse
  | "[" (digit+ as str) "]" ws* eol
                      { `Exit (int_of_string str) :: token lexbuf }
  | ws* "..." ws* eol { `Ellipsis :: token lexbuf }
- | "$ "              {
+ | ws* "$ "              {
       let buf = Buffer.create 8 in
       let line, cont = command_line buf lexbuf in
       if cont then `Command_first line :: token lexbuf
       else `Command line :: token lexbuf
     }
- | "> "              {
+ | ws* "> "              {
       let buf = Buffer.create 8 in
       let line, cont = command_line buf lexbuf in
       if cont then `Command_cont line :: token lexbuf

--- a/lib/lexer_mdx.mll
+++ b/lib/lexer_mdx.mll
@@ -64,12 +64,12 @@ and cram_text section = parse
       { let section = (String.length n, str) in
         newline lexbuf;
         `Section section :: cram_text (Some section) lexbuf }
-  | "  " ([^'\n']* as first_line) eol
+  | ("  " as ws) ([^'\n']* as first_line) eol
       { let start = Lexing.lexeme_start_p lexbuf in
         newline lexbuf;
         let header = "sh" in
         let requires_empty_line, contents = cram_block lexbuf in
-        let contents = (Format.asprintf "  %s" first_line) :: contents in
+        let contents = (Format.asprintf "%s%s" ws first_line) :: contents in
         let label_cmt = Some "" in
         let legacy_labels = "" in
         let end_ = Lexing.lexeme_start_p lexbuf in
@@ -104,10 +104,10 @@ and cram_text section = parse
 and cram_block = parse
   | eof { false, [] }
   | eol { newline lexbuf; true, [] }
-  | "  " ([^'\n'] * as str) eol
+  | ("  " as ws) ([^'\n'] * as str) eol
       { let requires_empty_line, lst = cram_block lexbuf in
         newline lexbuf;
-        requires_empty_line, (Format.asprintf "  %s" str) :: lst }
+        requires_empty_line, (Format.asprintf "%s%s" ws str) :: lst }
 
 {
   let markdown_token lexbuf =

--- a/lib/lexer_mdx.mll
+++ b/lib/lexer_mdx.mll
@@ -69,7 +69,7 @@ and cram_text section = parse
         newline lexbuf;
         let header = "sh" in
         let requires_empty_line, contents = cram_block lexbuf in
-        let contents = first_line :: contents in
+        let contents = (Format.asprintf "  %s" first_line) :: contents in
         let label_cmt = Some "" in
         let legacy_labels = "" in
         let end_ = Lexing.lexeme_start_p lexbuf in
@@ -107,7 +107,7 @@ and cram_block = parse
   | "  " ([^'\n'] * as str) eol
       { let requires_empty_line, lst = cram_block lexbuf in
         newline lexbuf;
-        requires_empty_line, str :: lst }
+        requires_empty_line, (Format.asprintf "  %s" str) :: lst }
 
 {
   let markdown_token lexbuf =

--- a/lib/mdx.mli
+++ b/lib/mdx.mli
@@ -53,10 +53,6 @@ val of_string : syntax -> string -> (t, [ `Msg of string ] list) result
 val parse_file : syntax -> string -> (t, [ `Msg of string ] list) result
 (** [parse_file s] is {!of_string} of [s]'s contents. *)
 
-val parse_lexbuf :
-  string -> syntax -> Lexing.lexbuf -> (t, [ `Msg of string ] list) result
-(** [parse_lexbuf l] is {!of_string} of [l]'s contents. *)
-
 (** {2 Evaluation} *)
 
 val run_to_stdout :

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -28,12 +28,6 @@ let rec hpad_of_lines = function
           done;
           !i)
 
-let pp_pad ppf = function
-  | 0 -> ()
-  | i -> Fmt.string ppf (String.v ~len:i (fun _ -> ' '))
-
-let pp_lines pp = Fmt.(list ~sep:(any "\n") pp)
-
 let read_file file =
   let ic = open_in_bin file in
   let len = in_channel_length ic in

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -14,20 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Astring
-
-let rec hpad_of_lines = function
-  | [] -> 0
-  | h :: hs -> (
-      match Util.String.all_blank h with
-      | true -> hpad_of_lines hs
-      | false ->
-          let i = ref 0 in
-          while !i < String.length h && h.[!i] = ' ' do
-            incr i
-          done;
-          !i)
-
 let read_file file =
   let ic = open_in_bin file in
   let len = in_channel_length ic in

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -33,7 +33,6 @@ let pp_pad ppf = function
   | i -> Fmt.string ppf (String.v ~len:i (fun _ -> ' '))
 
 let pp_lines pp = Fmt.(list ~sep:(any "\n") pp)
-let dump_string ppf s = Fmt.pf ppf "%S" s
 
 let read_file file =
   let ic = open_in_bin file in

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -19,7 +19,7 @@ open Astring
 let rec hpad_of_lines = function
   | [] -> 0
   | h :: hs -> (
-      match String.is_empty @@ String.trim h with
+      match Util.String.all_blank h with
       | true -> hpad_of_lines hs
       | false ->
           let i = ref 0 in

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -16,14 +16,17 @@
 
 open Astring
 
-let hpad_of_lines = function
+let rec hpad_of_lines = function
   | [] -> 0
-  | h :: _ ->
-      let i = ref 0 in
-      while !i < String.length h && h.[!i] = ' ' do
-        incr i
-      done;
-      !i
+  | h :: hs -> (
+      match String.is_empty @@ String.trim h with
+      | true -> hpad_of_lines hs
+      | false ->
+          let i = ref 0 in
+          while !i < String.length h && h.[!i] = ' ' do
+            incr i
+          done;
+          !i)
 
 let pp_pad ppf = function
   | 0 -> ()

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -41,12 +41,14 @@ let read_file file =
   close_in ic;
   file_contents
 
-let init file =
-  let file_contents = read_file file in
+type loaded_file = { lexbuf : Lexing.lexbuf; string : string }
+
+let load_file ~filename =
+  let file_contents = read_file filename in
   let lexbuf = Lexing.from_string file_contents in
   lexbuf.lex_curr_p <-
-    { pos_fname = file; pos_cnum = 0; pos_lnum = 1; pos_bol = 0 };
-  (file_contents, lexbuf)
+    { pos_fname = filename; pos_cnum = 0; pos_lnum = 1; pos_bol = 0 };
+  { string = file_contents; lexbuf }
 
 let pp_position ppf lexbuf =
   let p = Lexing.lexeme_start_p lexbuf in

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -1,0 +1,21 @@
+(*
+ * Copyright (c) 2022 Marek Kubica <marek@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+val hpad_of_lines : string list -> int
+val pp_pad : int Fmt.t
+val pp_lines : 'a Fmt.t -> 'a list Fmt.t
+val init : string -> string * Lexing.lexbuf
+val err : Lexing.lexbuf -> ('a, Format.formatter, unit, 'b) format4 -> 'a

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -17,5 +17,8 @@
 val hpad_of_lines : string list -> int
 val pp_pad : int Fmt.t
 val pp_lines : 'a Fmt.t -> 'a list Fmt.t
-val init : string -> string * Lexing.lexbuf
+
+type loaded_file = { lexbuf : Lexing.lexbuf; string : string }
+
+val load_file : filename:string -> loaded_file
 val err : Lexing.lexbuf -> ('a, Format.formatter, unit, 'b) format4 -> 'a

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val hpad_of_lines : string list -> int
-
 type loaded_file = { lexbuf : Lexing.lexbuf; string : string }
 
 val load_file : filename:string -> loaded_file

--- a/lib/output.ml
+++ b/lib/output.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Misc
-
 type t = [ `Output of string | `Ellipsis ]
 
 let dump ppf = function
@@ -23,8 +21,8 @@ let dump ppf = function
   | `Ellipsis -> Fmt.pf ppf "`Ellipsis"
 
 let pp ?(pad = 0) ppf = function
-  | `Output s -> Fmt.pf ppf "%a%s" pp_pad pad s
-  | `Ellipsis -> Fmt.pf ppf "%a..." pp_pad pad
+  | `Output s -> Fmt.pf ppf "%a%s" Pp.pp_pad pad s
+  | `Ellipsis -> Fmt.pf ppf "%a..." Pp.pp_pad pad
 
 let equals_sub l r start length =
   let stop = start + length in

--- a/lib/output.ml
+++ b/lib/output.ml
@@ -23,8 +23,8 @@ let dump ppf = function
   | `Ellipsis -> Fmt.pf ppf "`Ellipsis"
 
 let pp ?(pad = 0) ppf = function
-  | `Output s -> Fmt.pf ppf "%a%s\n" pp_pad pad s
-  | `Ellipsis -> Fmt.pf ppf "%a...\n" pp_pad pad
+  | `Output s -> Fmt.pf ppf "%a%s" pp_pad pad s
+  | `Ellipsis -> Fmt.pf ppf "%a..." pp_pad pad
 
 let equals_sub l r start length =
   let stop = start + length in

--- a/lib/output.ml
+++ b/lib/output.ml
@@ -22,8 +22,7 @@ let dump ppf = function
   | `Output s -> Fmt.pf ppf "`Output %S" s
   | `Ellipsis -> Fmt.pf ppf "`Ellipsis"
 
-let pp ?(pad = 0) ?syntax ppf = function
-  | `Output "" when syntax <> Some Syntax.Cram -> Fmt.pf ppf "\n"
+let pp ?(pad = 0) ppf = function
   | `Output s -> Fmt.pf ppf "%a%s\n" pp_pad pad s
   | `Ellipsis -> Fmt.pf ppf "%a...\n" pp_pad pad
 

--- a/lib/output.mli
+++ b/lib/output.mli
@@ -28,7 +28,7 @@ val merge : [ `Output of string ] list -> t list -> t list
 (** [merge output test] merges any [`Ellipsis] items from [test] into
    [output]. *)
 
-val pp : ?pad:int -> ?syntax:Syntax.t -> t Fmt.t
+val pp : ?pad:int -> t Fmt.t
 (** [pp] is the pretty-printer for test outputs. [pad] is the size of
    the optional whitespace left-padding (by default it is 0). *)
 

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -14,10 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Astring
-
 let pp_pad ppf = function
   | 0 -> ()
-  | i -> Fmt.string ppf (String.v ~len:i (fun _ -> ' '))
+  | i -> Fmt.string ppf (String.init i (fun _ -> ' '))
 
 let pp_lines pp = Fmt.(list ~sep:(any "\n") pp)

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -14,9 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val hpad_of_lines : string list -> int
+open Astring
 
-type loaded_file = { lexbuf : Lexing.lexbuf; string : string }
+let pp_pad ppf = function
+  | 0 -> ()
+  | i -> Fmt.string ppf (String.v ~len:i (fun _ -> ' '))
 
-val load_file : filename:string -> loaded_file
-val err : Lexing.lexbuf -> ('a, Format.formatter, unit, 'b) format4 -> 'a
+let pp_lines pp = Fmt.(list ~sep:(any "\n") pp)

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -14,9 +14,5 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val hpad_of_lines : string list -> int
-
-type loaded_file = { lexbuf : Lexing.lexbuf; string : string }
-
-val load_file : filename:string -> loaded_file
-val err : Lexing.lexbuf -> ('a, Format.formatter, unit, 'b) format4 -> 'a
+val pp_pad : int Fmt.t
+val pp_lines : 'a Fmt.t -> 'a list Fmt.t

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -358,7 +358,6 @@ let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
           with_non_det non_deterministic non_det ~on_skip_execution:print_block
             ~on_keep_old_output:det ~on_evaluation:det
       | Cram { language = _; non_det } ->
-          (* t.contents for md files is wrong, it's missing the begin and end *)
           let tests = Cram.of_lines t.contents in
           with_non_det non_deterministic non_det ~on_skip_execution:print_block
             ~on_keep_old_output:(fun () ->

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -101,8 +101,6 @@ let resolve_root file dir root =
 let run_cram_tests ?syntax t ?root ppf temp_file pad tests =
   (* TODO: for some reason this doesn't use Block.pp *)
   Block.pp_header ?syntax ppf t;
-  (* TODO: this is ugly but required to print multiline cram blocks in Mli correctly *)
-  (match syntax with Some Mli -> Fmt.pf ppf "\n" | _ -> ());
   List.iter
     (fun test ->
       let root = root_dir ?root ~block:t () in
@@ -120,7 +118,7 @@ let run_cram_tests ?syntax t ?root ppf temp_file pad tests =
           | `Ellipsis -> Output.pp ~pad ppf `Ellipsis
           | `Output line ->
               let line = ansi_color_strip line in
-              Output.pp ?syntax ~pad ppf (`Output line))
+              Output.pp ~pad ppf (`Output line))
         output;
       Cram.pp_exit_code ~pad ppf n)
     tests;

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -99,8 +99,10 @@ let resolve_root file dir root =
   match root with None -> dir / file | Some r -> r / dir / file
 
 let run_cram_tests ?syntax t ?root ppf temp_file pad tests =
+  (* TODO: for some reason this doesn't use Block.pp *)
   Block.pp_header ?syntax ppf t;
-  let pad = match syntax with Some Cram -> pad + 2 | _ -> pad in
+  (* TODO: this is ugly but required to print multiline cram blocks in Mli correctly *)
+  (match syntax with Some Mli -> Fmt.pf ppf "\n" | _ -> ());
   List.iter
     (fun test ->
       let root = root_dir ?root ~block:t () in

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -311,11 +311,7 @@ let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
           with_non_det non_deterministic non_det ~command:print_block
             ~output:det ~det
       | Cram { language = _; non_det } ->
-          let pad, tests =
-            Cram.of_lines
-              ~syntax:(Option.value ~default:Normal syntax)
-              ~loc:t.loc t.contents
-          in
+          let pad, tests = Cram.of_lines t.contents in
           with_non_det non_deterministic non_det ~command:print_block
             ~output:(fun () ->
               print_block ();
@@ -326,10 +322,7 @@ let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
             ~det:(fun () ->
               run_cram_tests ?syntax t ?root ppf temp_file pad tests)
       | Toplevel { non_det; env } ->
-          let phrases =
-            let syntax = Util.Option.value syntax ~default:Normal in
-            Toplevel.of_lines ~syntax ~loc:t.loc t.contents
-          in
+          let phrases = Toplevel.of_lines ~loc:t.loc t.contents in
           with_non_det non_deterministic non_det ~command:print_block
             ~output:(fun () ->
               assert (syntax <> Some Cram);

--- a/lib/toplevel.ml
+++ b/lib/toplevel.ml
@@ -18,7 +18,6 @@ let src = Logs.Src.create "ocaml-mdx"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 open Astring
-(* open Misc *)
 
 type t = {
   (* TODO: move vpad and hpad to `toplevel_tests` *)
@@ -77,16 +76,16 @@ let pp_command ppf (t : t) =
   | [] -> ()
   | l ->
       pp_vpad ppf t;
-      let sep ppf () = Fmt.pf ppf "\n%a  " Misc.pp_pad t.hpad in
+      let sep ppf () = Fmt.pf ppf "\n%a  " Pp.pp_pad t.hpad in
       let blank = Fmt.any "\n" in
-      Fmt.pf ppf "%a# %a" Misc.pp_pad t.hpad
+      Fmt.pf ppf "%a# %a" Pp.pp_pad t.hpad
         (pp_list_string_nonblank ~sep ~blank)
         l
 
 let pp ppf (t : t) =
   pp_command ppf t;
   Fmt.string ppf "\n";
-  Misc.pp_lines (Output.pp ~pad:t.vpad) ppf t.output
+  Pp.pp_lines (Output.pp ~pad:t.vpad) ppf t.output
 
 let lexbuf ~(pos : Lexing.position) s =
   let lexbuf = Lexing.from_string s in

--- a/lib/toplevel.ml
+++ b/lib/toplevel.ml
@@ -127,7 +127,6 @@ let rec hpad_of_lines = function
           !i)
 
 let of_lines ~(loc : Location.t) t =
-  Log.debug (fun l -> l "Toplevel lines to parse %a" Fmt.Dump.(list string) t);
   let pos = loc.loc_start in
   let pos = { pos with pos_lnum = pos.pos_lnum - 1 } in
   let hpad = hpad_of_lines t in

--- a/lib/toplevel.ml
+++ b/lib/toplevel.ml
@@ -128,6 +128,8 @@ let rec hpad_of_lines = function
 
 let of_lines ~(loc : Location.t) t =
   let pos = loc.loc_start in
+  (* Location.t considers the first line to be 1, whereas the tokenizer
+     assumes lines start with 0. *)
   let pos = { pos with pos_lnum = pos.pos_lnum - 1 } in
   let hpad = hpad_of_lines t in
   let t, end_pad = end_pad_of_lines t in

--- a/lib/toplevel.ml
+++ b/lib/toplevel.ml
@@ -114,11 +114,23 @@ let unpad hpad line =
       if String.length line < hpad then Fmt.failwith "invalid padding: %S" line
       else String.with_index_range line ~first:hpad
 
+let rec hpad_of_lines = function
+  | [] -> 0
+  | h :: hs -> (
+      match Util.String.all_blank h with
+      | true -> hpad_of_lines hs
+      | false ->
+          let i = ref 0 in
+          while !i < String.length h && h.[!i] = ' ' do
+            incr i
+          done;
+          !i)
+
 let of_lines ~(loc : Location.t) t =
   Log.debug (fun l -> l "Toplevel lines to parse %a" Fmt.Dump.(list string) t);
   let pos = loc.loc_start in
   let pos = { pos with pos_lnum = pos.pos_lnum - 1 } in
-  let hpad = Misc.hpad_of_lines t in
+  let hpad = hpad_of_lines t in
   let t, end_pad = end_pad_of_lines t in
   let lines = List.map (unpad hpad) t in
   let lines = String.concat ~sep:"\n" lines in

--- a/lib/toplevel.ml
+++ b/lib/toplevel.ml
@@ -81,22 +81,18 @@ let vpad_of_lines t =
   in
   aux 0 t
 
-let of_lines ~syntax ~(loc : Location.t) t =
+let of_lines ~syntax:_ ~(loc : Location.t) t =
   let pos = loc.loc_start in
-  let hpad =
-    match syntax with Syntax.Mli -> pos.pos_cnum + 2 | _ -> hpad_of_lines t
-  in
+  let hpad = hpad_of_lines t in
   let unpad line =
-    match syntax with
-    | Syntax.Mli -> String.trim line
-    | Syntax.Normal | Syntax.Cram ->
-        if String.is_empty line then line
-        else if String.length line < hpad then
+    match String.is_empty @@ String.trim line with
+    | true -> line
+    | false ->
+        if String.length line < hpad then
           Fmt.failwith "invalid padding: %S" line
         else String.with_index_range line ~first:hpad
   in
   let lines = List.map unpad t in
-  let lines = match syntax with Syntax.Mli -> "" :: lines | _ -> lines in
   let lines = String.concat ~sep:"\n" lines in
   let lines = Lexer_top.token (lexbuf ~pos lines) in
   let vpad, lines = vpad_of_lines lines in

--- a/lib/toplevel.ml
+++ b/lib/toplevel.ml
@@ -81,7 +81,7 @@ let vpad_of_lines t =
   in
   aux 0 t
 
-let of_lines ~syntax:_ ~(loc : Location.t) t =
+let of_lines ~(loc : Location.t) t =
   let pos = loc.loc_start in
   let hpad = hpad_of_lines t in
   let unpad line =

--- a/lib/toplevel.ml
+++ b/lib/toplevel.ml
@@ -18,7 +18,7 @@ let src = Logs.Src.create "ocaml-mdx"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 open Astring
-open Misc
+(* open Misc *)
 
 type t = {
   (* TODO: move vpad and hpad to `toplevel_tests` *)
@@ -77,14 +77,16 @@ let pp_command ppf (t : t) =
   | [] -> ()
   | l ->
       pp_vpad ppf t;
-      let sep ppf () = Fmt.pf ppf "\n%a  " pp_pad t.hpad in
+      let sep ppf () = Fmt.pf ppf "\n%a  " Misc.pp_pad t.hpad in
       let blank = Fmt.any "\n" in
-      Fmt.pf ppf "%a# %a" pp_pad t.hpad (pp_list_string_nonblank ~sep ~blank) l
+      Fmt.pf ppf "%a# %a" Misc.pp_pad t.hpad
+        (pp_list_string_nonblank ~sep ~blank)
+        l
 
 let pp ppf (t : t) =
   pp_command ppf t;
   Fmt.string ppf "\n";
-  pp_lines (Output.pp ~pad:t.vpad) ppf t.output
+  Misc.pp_lines (Output.pp ~pad:t.vpad) ppf t.output
 
 let lexbuf ~(pos : Lexing.position) s =
   let lexbuf = Lexing.from_string s in
@@ -117,7 +119,7 @@ let of_lines ~(loc : Location.t) t =
   Log.debug (fun l -> l "Toplevel lines to parse %a" Fmt.Dump.(list string) t);
   let pos = loc.loc_start in
   let pos = { pos with pos_lnum = pos.pos_lnum - 1 } in
-  let hpad = hpad_of_lines t in
+  let hpad = Misc.hpad_of_lines t in
   let t, end_pad = end_pad_of_lines t in
   let lines = List.map (unpad hpad) t in
   let lines = String.concat ~sep:"\n" lines in

--- a/lib/toplevel.mli
+++ b/lib/toplevel.mli
@@ -25,11 +25,15 @@ type t = {
 }
 (** The type for top-level phrases. *)
 
+type toplevel_tests = { tests : t list; end_pad : string option }
+
 (** {2 Pretty-printing} *)
 
 val dump : t Fmt.t
 (** [dump] is the printer for dumping toplevel phrases. Useful for
    debugging. *)
+
+val dump_toplevel_tests : toplevel_tests Fmt.t
 
 val pp : t Fmt.t
 (** [pp] is the pretty-printer for top-level phrases. [pad] is the
@@ -41,6 +45,6 @@ val pp_command : t Fmt.t
 
 (** {2 Parser} *)
 
-val of_lines : loc:Location.t -> string list -> t list
+val of_lines : loc:Location.t -> string list -> toplevel_tests
 (** [of_lines ~loc lines] is the list of toplevel blocks from location [loc].
     Return the vertical and horizontal whitespace padding as well. *)

--- a/lib/toplevel.mli
+++ b/lib/toplevel.mli
@@ -41,6 +41,6 @@ val pp_command : t Fmt.t
 
 (** {2 Parser} *)
 
-val of_lines : syntax:Syntax.t -> loc:Location.t -> string list -> t list
+val of_lines : loc:Location.t -> string list -> t list
 (** [of_lines ~loc lines] is the list of toplevel blocks from location [loc].
     Return the vertical and horizontal whitespace padding as well. *)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -104,6 +104,7 @@ module String = struct
     | hd :: tl -> aux hd tl
 
   let english_conjonction words = english_concat ~last_sep:"and" words
+  let all_blank = Astring.String.for_all Astring.Char.Ascii.is_white
 end
 
 module List = struct
@@ -113,6 +114,19 @@ module List = struct
       | h :: t -> ( match f h with Some x -> Some x | None -> aux t)
     in
     aux l
+
+  let partition_until f xs =
+    let rec loop = function
+      | [] -> ([], [])
+      | x :: xs -> (
+          match f x with
+          | true ->
+              let trueish, falseish = loop xs in
+              (x :: trueish, falseish)
+          | false -> ([], x :: xs))
+    in
+    let trueish, falseish = loop xs in
+    (List.rev trueish, falseish)
 end
 
 module Array = struct

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -56,12 +56,16 @@ end
 
 module List : sig
   val find_map : ('a -> 'b option) -> 'a list -> 'b option
+  val partition_until : ('a -> bool) -> 'a list -> 'a list * 'a list
 end
 
 module String : sig
   val english_conjonction : string list -> string
   (** [english_conjonction ["a"; "b"; "c"]] returns ["a, b and c"].
       @raise Invalid_argument when called on the empty list. *)
+
+  val all_blank : string -> bool
+  (** [all_blank s] is true if every character of s is a whitespace *)
 end
 
 module Sexp : sig

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -228,6 +228,18 @@
  (action (diff labels-syntax/test-case.md labels-syntax.actual)))
 
 (rule
+ (target labels-syntax-mli.actual)
+ (deps (package mdx) (source_tree labels-syntax-mli))
+ (action
+  (with-stdout-to %{target}
+   (chdir labels-syntax-mli
+    (run ocaml-mdx test --output - --syntax=mli test-case.mli)))))
+
+(rule
+ (alias runtest)
+ (action (diff labels-syntax-mli/test-case.mli labels-syntax-mli.actual)))
+
+(rule
  (target line-delimiters.actual)
  (deps (package mdx) (source_tree line-delimiters))
  (action

--- a/test/bin/mdx-test/expect/empty-lines/test-case.md.expected
+++ b/test/bin/mdx-test/expect/empty-lines/test-case.md.expected
@@ -2,13 +2,13 @@ This shell block contains an empty line within a padded block:
 
 ```sh
  $ echo ''
-
+ 
 ```
 
 ```sh
   $ echo "Hello..." && echo "" && echo "world!"
   Hello...
-
+  
   world!
 ```
 

--- a/test/bin/mdx-test/expect/exit/test-case.md
+++ b/test/bin/mdx-test/expect/exit/test-case.md
@@ -1,4 +1,4 @@
-Exit codes are udated properly:
+Exit codes are updated properly:
 
 
 ```sh

--- a/test/bin/mdx-test/expect/labels-syntax-mli/test-case.mli
+++ b/test/bin/mdx-test/expect/labels-syntax-mli/test-case.mli
@@ -1,0 +1,28 @@
+(** We are testing the label syntax in [mli] files.
+
+    {1 Set environment variables}
+
+    Environment variables can be loaded in an ocaml block environment.
+
+    {@ocaml set-FOO=bar,set-BAR=foo[
+    # print_endline (Sys.getenv "FOO");;
+    bar
+    - : unit = ()
+    # print_endline (Sys.getenv "BAR");;
+    foo
+    - : unit = ()
+    ]}
+
+    {3 Non-deterministic Outputs}
+
+    {@sh non-deterministic=output[
+    $ echo $RANDOM
+    4150
+    ]}
+
+    {3 Non-deterministic Commands}
+
+    {@sh non-deterministic=command[
+    $ touch toto
+    ]}
+*)

--- a/test/bin/mdx-test/expect/labels-syntax-mli/test-case.opts
+++ b/test/bin/mdx-test/expect/labels-syntax-mli/test-case.opts
@@ -1,0 +1,1 @@
+--syntax=mli

--- a/test/bin/mdx-test/expect/multilines-mli/test-case.mli
+++ b/test/bin/mdx-test/expect/multilines-mli/test-case.mli
@@ -21,10 +21,7 @@ This works for normal OCaml fragments:
   | n -> n * fact (n-1)
 ]}
 
-The formatting for multilines in .mli files is the following:
-- The first line is indented two spaces after the comment opening
-- The other lines are indented to keep the original indentation relative to the
-  first line
+The formatting for multilines in .mli files should be preserved exactly:
 
   {[
     match None with

--- a/test/bin/mdx-test/expect/multilines-mli/test-case.mli
+++ b/test/bin/mdx-test/expect/multilines-mli/test-case.mli
@@ -33,4 +33,15 @@ The formatting for multilines in .mli files is the following:
       | None -> ()
       | Some b -> b
   ]}
+
+It should also work fine for toplevel descriptions (as in
+[multilines/test-case.md]):
+
+{@ocaml[
+  # let rec fact = function
+    | 1 -> 1
+    | n -> n * fact (n-1)
+    ;;
+  val fact : int -> int = <fun>
+]}
 *)

--- a/test/bin/mdx-test/misc/environment-variable-unset/test-case.md
+++ b/test/bin/mdx-test/misc/environment-variable-unset/test-case.md
@@ -7,5 +7,5 @@ Environment variables can be unset in an shell and bash blocks.
 
 ```sh unset-VAR
   $ echo $VAR
-
+  
 ```


### PR DESCRIPTION
The reason for this is due to us wanting to have the spaces available in MDX, so we know all the whitespace, so we can format it the way it came in from the user.

This also addresses the parsing issue for multiline toplevel blocks.

Closes #394