### PR TITLE
Use `let*` operators instead of infix operators

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -41,12 +41,18 @@ module Result = struct
     let fold ~f ~init l =
       let rec go acc = function
         | [] -> Ok acc
-        | hd :: tl -> f acc hd >>= fun acc -> go acc tl
+        | hd :: tl ->
+            let* acc = f acc hd in
+            go acc tl
       in
       go init l
 
     let map ~f l =
-      fold ~f:(fun acc elm -> f elm >>| fun elm' -> elm' :: acc) ~init:[] l
+      fold
+        ~f:(fun acc elm ->
+          let+ elm' = f elm in
+          elm' :: acc)
+        ~init:[] l
       >>| List.rev
 
     let split l =

--- a/test/lib/test_dep.ml
+++ b/test/lib/test_dep.ml
@@ -50,7 +50,8 @@ let test_of_line =
     let test_name = Printf.sprintf "of_line: %S" line_des in
     let test_fun () =
       let actual =
-        Mdx.of_string Mdx.Normal lines >>| fun lines -> Mdx.Dep.of_lines lines
+        let+ lines = Mdx.of_string Mdx.Normal lines in
+        Mdx.Dep.of_lines lines
       in
       Alcotest.(check (result (list Testable.dep) (list Testable.msg)))
         test_name expected actual


### PR DESCRIPTION
At least in most places. Where it is used as piping operator, it still makes sense to use the infix versions.

Given our lower bound for OCaml is 4.08, it should be okay to use them and I feel them make the code a bit easier to read, since you get to avoid `>>= fun xyzzy ->` overhead.