### PR TITLE
Restart waitpid call if we get interrupted.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 - Include the content of the line that features the `part-end` MDX directive in
   the output, before that line would've been dropped (#374, #387,
   @Leonidas-from-XIV)
+- Handle EINTR signal on waitpid call by restarting the syscall. (#409, @tmcgilchrist)
 
 #### Removed
 

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -122,8 +122,12 @@ module Array = struct
 end
 
 module Process = struct
+  let rec waitpid_non_intr pid =
+    try Unix.waitpid [] pid
+    with Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_non_intr pid
+
   let wait ~pid =
-    match snd (Unix.waitpid [] pid) with WEXITED n -> n | _ -> 255
+    match snd (waitpid_non_intr pid) with WEXITED n -> n | _ -> 255
 end
 
 module Int = struct


### PR DESCRIPTION
Where [EINTR] means the call is interrupted by a caught signal or the signal does not have the SA_RESTART flag set.

This error was thrown when running an mdx test for [ocurrent/ocurrent](https://github.com/ocurrent/ocurrent):
```
$ (cd _build/default/plugins/git/test && /Users/user/.opam/ocurrent/bin/ocaml-mdx test -o .mdx/test_submodules.md.corrected test_submodules.md) > _build/default/plugins/git/test/.mdx/test_submodules.md.corrected
ocaml-mdx-test: internal error, uncaught exception:
        Unix.Unix_error(Unix.EINTR, "waitpid", "")
```

Based off a suggestion by @talex5 and this OCaml unix library code https://github.com/ocaml/ocaml/blob/trunk/otherlibs/unix/unix_unix.ml#L869-L871


