### PR TITLE
Add note about using mdx with mli files

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ dune promote
 Now the documentation is up-to-date and running `dune runtest` again should be
 successful!
 
+Note that to use the `dune runtest/promote` workflow with `mli` files,
+you will need to adjust the `mdx` stanza in the `dune` file, as by
+[default](https://dune.readthedocs.io/en/latest/dune-files.html#mdx-since-2-4),
+Dune only checks markdown files with `mdx`.  E.g.,
+
+```
+(mdx
+ (files :standard - *.mli))
+```
+
 ### Supported Extensions
 
 #### Labels


### PR DESCRIPTION
By default, Dune only processes markdown files with mdx.  This note gives an example of how to use Dune and mdx in mli files.

It's just a small change to the readme, but if it was there, it would have saved me a few minutes skimming through the Dune docs to figure out what to do.  Do you think it is a helpful addition to the readme?