### PR TITLE
Work around lack of `Unix.set_nonblock` on Windows using threads

### DIFF
--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -46,7 +46,7 @@ let redirect ~f =
   let capture buf =
     flush stdout;
     flush stderr;
-    Unix.sleepf 0.001;
+    Unix.sleepf 0.01;
     let rec loop () =
       let was = Buffer.length buf in
       Mutex.lock mutex;
@@ -54,7 +54,7 @@ let redirect ~f =
       Buffer.clear buf_internal;
       Mutex.unlock mutex;
       if Buffer.length buf <> was then (
-        Unix.sleepf 0.0001;
+        Unix.sleepf 0.001;
         loop ())
     in
     loop ()


### PR DESCRIPTION
On Windows `Unix.set_nonblock` fails.

This PR implements a workaround method for pulling the output without blocking by using threads.  I can't say I like the workaround, but implementing proper non-blocking IO on Windows would seem to require a lot more work.  This workaround has been tested at least on Mac OS and Windows.