### PR TITLE
Avoid picking result < 1.5

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,4 +38,6 @@
    (>= 2.3.0))
   (odoc-parser (>= 1.0.0))
   (lwt :with-test)
-  (alcotest :with-test)))
+  (alcotest :with-test))
+ (conflicts
+   (result (< 1.5))))

--- a/mdx.opam
+++ b/mdx.opam
@@ -34,6 +34,9 @@ depends: [
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
If some dependency pulls an older `result` as a dependency, it will shadow the Result module and cause failures because it doesn't expose the expected functions.

Thanks to @kit-ty-kate.