### PR TITLE
tiny change to allow using the parser that the toplevel uses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 ### unreleased
 
-- tiny change to allow using the parser that the toplevel uses
-  (instead of always the official OCaml parser) (#417, @chetmurthy)
+- Switch to using the parser that toplevel uses (found in a mutable
+  `ref`, instead of always the official OCaml parser).  This allows
+  Camlp5's parser to be used with MDX. (#417, @chetmurthy)
 
 #### Added
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ### unreleased
 
+- tiny change to allow using the parser that the toplevel uses
+  (instead of always the official OCaml parser) (#417, @chetmurthy)
+
 #### Added
 
 #### Changed

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -112,7 +112,7 @@ module Phrase = struct
     let lexbuf = Lexing.from_string contents in
     let startpos = lexbuf.Lexing.lex_start_p in
     let parsed =
-      match Parse.toplevel_phrase lexbuf with
+      match !Toploop.parse_toplevel_phrase lexbuf with
       | phrase -> Ok phrase
       | exception exn ->
           let exn =


### PR DESCRIPTION
The toplevel parser can be swapped-out, and this patch allows to use whatever it is, not just the official OCaml parser.

If you guys could merge this, I can use `mdx` with Camlp5, which would be lovely!