### PR TITLE
Parse env only once

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -68,9 +68,11 @@ let verbose_findlib =
 
 let prelude =
   let parse s =
-    let env, file = Mdx.Prelude.env_and_file s in
-    let parse, _print = Arg.non_dir_file in
-    match parse file with `Ok _ -> `Ok (env, file) | `Error e -> `Error e
+    let env, filename = Mdx.Prelude.env_and_payload s in
+    let parse, _pp = Arg.non_dir_file in
+    match parse filename with
+    | `Ok _ -> `Ok (env, filename)
+    | `Error _ as e -> e
   in
   let prelude = (parse, Mdx.Prelude.pp) in
   let doc =
@@ -91,7 +93,7 @@ let prelude_str =
      not contain any spaces. Multiple prelude strings can be provided: they \
      will be evaluated in the order they are provided on the command-line."
   in
-  let parse s = `Ok (Mdx.Prelude.env_and_file s) in
+  let parse s = `Ok (Mdx.Prelude.env_and_payload s) in
   let prelude = (parse, Mdx.Prelude.pp) in
   named
     (fun x -> `Prelude_str x)

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -68,20 +68,21 @@ let verbose_findlib =
 
 let prelude =
   let parse s =
-    let _, file = Mdx.Prelude.env_and_file s in
-    let parse, _ = Arg.non_dir_file in
-    match parse file with `Ok _ -> `Ok s | `Error e -> `Error e
+    let env, file = Mdx.Prelude.env_and_file s in
+    let parse, _print = Arg.non_dir_file in
+    match parse file with `Ok _ -> `Ok (env, file) | `Error e -> `Error e
   in
-  let prelude = (parse, Fmt.string) in
+  let prelude = (parse, Mdx.Prelude.pp) in
   let doc =
     "A file to load as prelude. Can be prefixed with $(i,env:) to specify a \
      specific environment to load the prelude in. Multiple prelude files can \
-     be provided:they will be evaluated in the order they are provided on the \
+     be provided: they will be evaluated in the order they are provided on the \
      command-line."
   in
   named
     (fun x -> `Prelude x)
-    Arg.(value & opt_all prelude [] & info [ "prelude" ] ~doc ~docv:"FILE")
+    Arg.(
+      value & opt_all prelude [] & info [ "prelude" ] ~doc ~docv:"[ENV:]FILE")
 
 let prelude_str =
   let doc =

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -91,9 +91,12 @@ let prelude_str =
      not contain any spaces. Multiple prelude strings can be provided: they \
      will be evaluated in the order they are provided on the command-line."
   in
+  let parse s = `Ok (Mdx.Prelude.env_and_file s) in
+  let prelude = (parse, Mdx.Prelude.pp) in
   named
     (fun x -> `Prelude_str x)
-    Arg.(value & opt_all string [] & info [ "prelude-str" ] ~doc ~docv:"STR")
+    Arg.(
+      value & opt_all prelude [] & info [ "prelude-str" ] ~doc ~docv:"[ENV:]STR")
 
 let directories =
   let doc = "A list of directories to load for the #directory directive." in

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -10,7 +10,7 @@ val record_backtrace : [> `Record_backtrace of bool ] t
 val silent : [> `Silent of bool ] t
 val verbose_findlib : [> `Verbose_findlib of bool ] t
 val prelude : [> `Prelude of Mdx.Prelude.t list ] t
-val prelude_str : [> `Prelude_str of string list ] t
+val prelude_str : [> `Prelude_str of Mdx.Prelude.t list ] t
 val directories : [> `Directories of string list ] t
 val root : [> `Root of string option ] t
 val force_output : [> `Force_output of bool ] t

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -9,7 +9,7 @@ val silent_eval : [> `Silent_eval of bool ] t
 val record_backtrace : [> `Record_backtrace of bool ] t
 val silent : [> `Silent of bool ] t
 val verbose_findlib : [> `Verbose_findlib of bool ] t
-val prelude : [> `Prelude of string list ] t
+val prelude : [> `Prelude of Mdx.Prelude.t list ] t
 val prelude_str : [> `Prelude_str of string list ] t
 val directories : [> `Directories of string list ] t
 val root : [> `Root of string option ] t

--- a/bin/dune_gen.ml
+++ b/bin/dune_gen.ml
@@ -21,6 +21,25 @@ let run (`Setup ()) (`Prelude prelude) (`Directories dirs) =
     Printf.sprintf "[%s]\n"
       (String.concat ";" (List.map (Printf.sprintf "%S") l))
   in
+
+  let show_ocaml_env = function
+    | Mdx.Ocaml_env.Default -> "Mdx.Ocaml_env.Default"
+    | Mdx.Ocaml_env.User_defined s ->
+        Printf.sprintf "(Mdx.Ocaml_env.User_defined %S)" s
+  in
+
+  let show_env = function
+    | `All -> "`All"
+    | `One ocaml_env -> Printf.sprintf "(`One %s)" (show_ocaml_env ocaml_env)
+  in
+
+  let show_prelude (env, filename) =
+    Printf.sprintf "(%s, %S)" (show_env env) filename
+  in
+
+  let show_preludes preludes =
+    Printf.sprintf "[%s]\n" (String.concat ";" (List.map show_prelude preludes))
+  in
   line "let run_exn_defaults =";
   line "  let open Mdx_test in";
   line "  let packages =";
@@ -46,7 +65,7 @@ let run (`Setup ()) (`Prelude prelude) (`Directories dirs) =
   line "    ~output:(Some `Stdout)";
 
   line "let file = Sys.argv.(1)";
-  line "let prelude = %s" (list prelude);
+  line "let prelude = %s" (show_preludes prelude);
   line "let directives = List.map (fun path ->";
   line "  Mdx_top.Directory path) %s" (list dirs);
   line "let _ = run_exn_defaults";

--- a/bin/dune_gen.ml
+++ b/bin/dune_gen.ml
@@ -22,24 +22,25 @@ let run (`Setup ()) (`Prelude prelude) (`Directories dirs) =
       (String.concat ";" (List.map (Printf.sprintf "%S") l))
   in
 
-  let show_ocaml_env = function
-    | Mdx.Ocaml_env.Default -> "Mdx.Ocaml_env.Default"
+  let pp_ocaml_env ppf = function
+    | Mdx.Ocaml_env.Default -> Fmt.string ppf "Mdx.Ocaml_env.Default"
     | Mdx.Ocaml_env.User_defined s ->
-        Printf.sprintf "(Mdx.Ocaml_env.User_defined %S)" s
+        Fmt.pf ppf "(Mdx.Ocaml_env.User_defined %S)" s
   in
 
-  let show_env = function
-    | `All -> "`All"
-    | `One ocaml_env -> Printf.sprintf "(`One %s)" (show_ocaml_env ocaml_env)
+  let pp_env ppf = function
+    | `All -> Fmt.string ppf "`All"
+    | `One ocaml_env -> Fmt.pf ppf "(`One %a)" pp_ocaml_env ocaml_env
   in
 
-  let show_prelude (env, filename) =
-    Printf.sprintf "(%s, %S)" (show_env env) filename
+  let pp_prelude ppf (env, filename) =
+    Fmt.pf ppf "(%a, %S)" pp_env env filename
   in
 
-  let show_preludes preludes =
-    Printf.sprintf "[%s]\n" (String.concat ";" (List.map show_prelude preludes))
+  let pp_preludes ppf preludes =
+    Fmt.pf ppf "%a" (Fmt.Dump.list pp_prelude) preludes
   in
+
   line "let run_exn_defaults =";
   line "  let open Mdx_test in";
   line "  let packages =";
@@ -65,7 +66,7 @@ let run (`Setup ()) (`Prelude prelude) (`Directories dirs) =
   line "    ~output:(Some `Stdout)";
 
   line "let file = Sys.argv.(1)";
-  line "let prelude = %s" (show_preludes prelude);
+  line "let prelude = %s" ((Fmt.to_to_string pp_preludes) prelude);
   line "let directives = List.map (fun path ->";
   line "  Mdx_top.Directory path) %s" (list dirs);
   line "let _ = run_exn_defaults";

--- a/lib/ocaml_env.ml
+++ b/lib/ocaml_env.ml
@@ -3,6 +3,10 @@ type t = Default | User_defined of string
 let mk = function None | Some "" -> Default | Some s -> User_defined s
 let name = function Default -> "" | User_defined s -> s
 
+let pp ppf = function
+  | Default -> Fmt.string ppf "Default"
+  | User_defined s -> Fmt.pf ppf "User_defined %S" s
+
 type env = t
 
 module Set = Set.Make (struct

--- a/lib/ocaml_env.mli
+++ b/lib/ocaml_env.mli
@@ -2,6 +2,7 @@
 
 type t = Default | User_defined of string
 
+val pp : t Fmt.t
 val name : t -> string
 val mk : string option -> t
 

--- a/lib/prelude.ml
+++ b/lib/prelude.ml
@@ -14,6 +14,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+type t = [ `All | `One of Ocaml_env.t ] * string
+
+let pp ppf = function
+  | `All, filename -> Fmt.pf ppf "(`All, %S)" filename
+  | `One ocaml_env, filename ->
+      Fmt.pf ppf "(`One %a, %S)" Ocaml_env.pp ocaml_env filename
+
 let env_and_file f =
   match Astring.String.cut ~sep:":" f with
   | None -> (`All, f)

--- a/lib/prelude.ml
+++ b/lib/prelude.ml
@@ -21,7 +21,7 @@ let pp ppf = function
   | `One ocaml_env, filename ->
       Fmt.pf ppf "(`One %a, %S)" Ocaml_env.pp ocaml_env filename
 
-let env_and_file f =
+let env_and_payload f =
   match Astring.String.cut ~sep:":" f with
   | None -> (`All, f)
   | Some (e, f) ->

--- a/lib/prelude.mli
+++ b/lib/prelude.mli
@@ -14,7 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val env_and_file : string -> [ `All | `One of Ocaml_env.t ] * string
+type t = [ `All | `One of Ocaml_env.t ] * string
+
+val pp : t Fmt.t
+
+val env_and_file : string -> t
 (** [env_and_file s] returns the environment and file/prelude string described
     by [s].
     I.e. [env_and_file "a:f"] associates [f] to the environment named [a],

--- a/lib/prelude.mli
+++ b/lib/prelude.mli
@@ -18,9 +18,9 @@ type t = [ `All | `One of Ocaml_env.t ] * string
 
 val pp : t Fmt.t
 
-val env_and_file : string -> t
-(** [env_and_file s] returns the environment and file/prelude string described
+val env_and_payload : string -> t
+(** [env_and_payload s] returns the environment and file/prelude string described
     by [s].
-    I.e. [env_and_file "a:f"] associates [f] to the environment named [a],
-    [env_and_file " :f"] associates [f] to the default environment, and
-    [env_and_file "f"] associates [f] to all environments. *)
+    I.e. [env_and_payload "a:f"] associates [f] to the environment named [a],
+    [env_and_payload " :f"] associates [f] to the default environment, and
+    [env_and_payload "f"] associates [f] to all environments. *)

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -314,19 +314,13 @@ let with_non_det ~on_skip_execution ~on_keep_old_output ~on_evaluation
   | _ -> on_evaluation ()
 
 let preludes ~prelude ~prelude_str =
-  let parse_str p =
-    let env, file = Mdx.Prelude.env_and_file p in
-    (env, [ file ])
-  in
-  let parse p =
-    let env, file = p in
-    (env, Mdx.Util.File.read_lines file)
-  in
+  let parse_str (env, content) = (env, [ content ]) in
+  let parse (env, file) = (env, Mdx.Util.File.read_lines file) in
   match (prelude, prelude_str) with
   | [], [] -> []
   | [], fs -> List.map parse_str fs
   | fs, [] -> List.map parse fs
-  | _ -> Fmt.failwith "only one of --prelude or --prelude-str shoud be used"
+  | _ -> Fmt.failwith "only one of --prelude or --prelude-str should be used"
 
 let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
     ~verbose_findlib ~prelude ~prelude_str ~file ~section ~root ~force_output

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -314,14 +314,18 @@ let with_non_det ~on_skip_execution ~on_keep_old_output ~on_evaluation
   | _ -> on_evaluation ()
 
 let preludes ~prelude ~prelude_str =
-  let aux to_lines p =
+  let parse_str p =
     let env, file = Mdx.Prelude.env_and_file p in
-    (env, to_lines file)
+    (env, [ file ])
+  in
+  let parse p =
+    let env, file = p in
+    (env, Mdx.Util.File.read_lines file)
   in
   match (prelude, prelude_str) with
   | [], [] -> []
-  | [], fs -> List.map (aux (fun x -> [ x ])) fs
-  | fs, [] -> List.map (aux Mdx.Util.File.read_lines) fs
+  | [], fs -> List.map parse_str fs
+  | fs, [] -> List.map parse fs
   | _ -> Fmt.failwith "only one of --prelude or --prelude-str shoud be used"
 
 let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent

--- a/lib/test/mdx_test.mli
+++ b/lib/test/mdx_test.mli
@@ -19,7 +19,7 @@ val run_exn :
   syntax:Mdx.Syntax.t option ->
   silent:bool ->
   verbose_findlib:bool ->
-  prelude:string list ->
+  prelude:Mdx.Prelude.t list ->
   prelude_str:string list ->
   file:string ->
   section:string option ->

--- a/lib/test/mdx_test.mli
+++ b/lib/test/mdx_test.mli
@@ -20,7 +20,7 @@ val run_exn :
   silent:bool ->
   verbose_findlib:bool ->
   prelude:Mdx.Prelude.t list ->
-  prelude_str:string list ->
+  prelude_str:Mdx.Prelude.t list ->
   file:string ->
   section:string option ->
   root:string option ->

--- a/test/bin/mdx-dune-gen/misc/basic/dune.gen.expected
+++ b/test/bin/mdx-dune-gen/misc/basic/dune.gen.expected
@@ -22,7 +22,7 @@ let run_exn_defaults =
     ~root:None ~force_output:false
     ~output:(Some `Stdout)
 let file = Sys.argv.(1)
-let prelude = ["prelude.ml";"prelude2.ml"]
+let prelude = [(`All, "prelude.ml"); (`All, "prelude2.ml")]
 
 let directives = List.map (fun path ->
   Mdx_top.Directory path) []

--- a/test/bin/mdx-test/failure/both-prelude/test-case.md.expected
+++ b/test/bin/mdx-test/failure/both-prelude/test-case.md.expected
@@ -1,1 +1,1 @@
-only one of --prelude or --prelude-str shoud be used
+only one of --prelude or --prelude-str should be used


### PR DESCRIPTION
Reported by @emillon, the way the code currently works is to call `Mdx.Prelude.env_and_file` in the CLI, validate it is valid, then discard it and reparse it at a later point in time in `Mdx_test`. This is wasteful but most importantly also confusing.

There is the open question whether `Prelude_str` should support environments as well. At the moment it does and I kept the support for it in this PR but it would be better to either remove it if we deem that support unnecessary or like in `Prelude` move the parsing step to the command line parser.