### PR TITLE
Add `os_type` label to enable/disable based on `Sys.os_type`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 #### Added
 
+- Add `os_type` label to enable/disable based on `Sys.os_type` (#433,
+  @polytypic)
+
 - Make MDX compatible with OCaml 5.1 (#435, @polytypic and @kit-ty-kate)
 
 #### Changed

--- a/README.md
+++ b/README.md
@@ -390,6 +390,33 @@ The version number can be of the following forms:
 - `X.Y`
 - `X.Y.Z`
 
+#### Matching based on the `os_type` (since mdx 2.4.0)
+
+Block can be processed or ignored depending on the current
+[`os_type`](https://v2.ocaml.org/api/Sys.html#VALos_type).
+
+For example, different blocks could be enabled depending on whether we are on
+Windows or not:
+
+    ```ocaml
+    #require "unix"
+    ```
+
+    <!-- $MDX os_type<>Win32 -->
+    ```ocaml
+    # Unix.nice 0
+    - : int = 0
+    ```
+
+    <!-- $MDX os_type=Win32 -->
+    ```ocaml
+    # Unix.nice 0
+    Exception: Invalid_argument "Unix.nice not implemented".
+    ```
+
+The `os_type` values should be written in ASCII and are compared case
+insensitively.
+
 #### Environment variables declaration
 
 Environment variables can be declared at the beginning of a block:

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -101,6 +101,8 @@ type t = {
   skip : bool;
   version_enabled : bool;
       (** Whether the current OCaml version complies with the block's version. *)
+  os_type_enabled : bool;
+      (** Whether the current os type complies with the block's version. *)
   set_variables : (string * string) list;
   unset_variables : string list;
   value : value;

--- a/lib/label.ml
+++ b/lib/label.ml
@@ -89,6 +89,7 @@ type t =
   | Skip
   | Non_det of non_det option
   | Version of Relation.t * Ocaml_version.t
+  | Os_type of Relation.t * string
   | Set of string * string
   | Unset of string
   | Block_kind of block_kind
@@ -115,6 +116,7 @@ let pp ppf = function
   | Non_det (Some Nd_command) -> Fmt.string ppf "non-deterministic=command"
   | Version (op, v) ->
       Fmt.pf ppf "version%a%a" Relation.pp op Ocaml_version.pp v
+  | Os_type (op, v) -> Fmt.pf ppf "os_type%a%s" Relation.pp op v
   | Set (v, x) -> Fmt.pf ppf "set-%s=%s" v x
   | Unset x -> Fmt.pf ppf "unset-%s" x
   | Block_kind bk -> pp_block_kind ppf bk
@@ -170,6 +172,7 @@ let interpret label value =
           | Ok v -> Ok (Version (op, v))
           | Error (`Msg e) ->
               Util.Result.errorf "Invalid `version` label value: %s." e)
+  | "os_type" -> requires_value ~label ~value (fun op v -> Ok (Os_type (op, v)))
   | "non-deterministic" -> (
       match value with
       | None -> Ok (Non_det None)

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -42,6 +42,7 @@ type t =
   | Skip
   | Non_det of non_det option
   | Version of Relation.t * Ocaml_version.t
+  | Os_type of Relation.t * string
   | Set of string * string
   | Unset of string
   | Block_kind of block_kind

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -372,6 +372,18 @@
  (action (diff ocaml-errors-ellipsis/test-case.md ocaml-errors-ellipsis.actual)))
 
 (rule
+ (target os_type.actual)
+ (deps (package mdx) (source_tree os_type))
+ (action
+  (with-stdout-to %{target}
+   (chdir os_type
+    (run ocaml-mdx test --output - test-case.md)))))
+
+(rule
+ (alias runtest)
+ (action (diff os_type/test-case.md os_type.actual)))
+
+(rule
  (target padding.actual)
  (deps (package mdx) (source_tree padding))
  (action

--- a/test/bin/mdx-test/expect/os_type/test-case.md
+++ b/test/bin/mdx-test/expect/os_type/test-case.md
@@ -1,0 +1,13 @@
+Mdx can skip blocks based on `os_type`:
+
+```ocaml os_type<>Win32
+# #require "unix"
+# Unix.nice 0
+- : int = 0
+```
+
+```ocaml os_type=Win32
+# #require "unix"
+# Unix.nice 0
+Exception: Invalid_argument "Unix.nice not implemented".
+```


### PR DESCRIPTION
This PR adds ability to skip blocks by comparing against `Sys.os_type`.

The desire to have something like this arose when [working to allow Eio's MDX based tests to run on Windows](https://github.com/ocaml-multicore/eio/pull/589) and I'm using this feature there.

Also related is the [issue that proposes a more general ability to skip blocks](https://github.com/realworldocaml/mdx/issues/393).  The feature that this proposes is less ambitious (less general) and very similar to the existing OCaml `version` constraint supported by MDX and the implementation follows the same pattern.