### PR TITLE
Upgrade OCamlformat to 0.26.1

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Upgrade to OCamlformat 0.26.0
+d86ecaca08f2cec5bedf62867847dbfa410d9e6d
+# Upgrade to OCamlformat 0.26.1
+50f9458a29b9310fba4652179e4cf77ded1cd6de

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.24.1
+version=0.26.0
 profile=conventional
 ocaml-version=4.08.0

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.26.0
+version=0.26.1
 profile=conventional
 ocaml-version=4.08.0

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -122,13 +122,13 @@ module Phrase = struct
                 Location.Error (Lexbuf.shift_location_error startpos error)
           in
           (if lexbuf.Lexing.lex_last_action <> Lexbuf.semisemi_action then
-           let rec aux () =
-             match Lexer.token lexbuf with
-             | Parser.SEMISEMI | Parser.EOF -> ()
-             | exception Lexer.Error (_, _) -> ()
-             | _ -> aux ()
-           in
-           aux ());
+             let rec aux () =
+               match Lexer.token lexbuf with
+               | Parser.SEMISEMI | Parser.EOF -> ()
+               | exception Lexer.Error (_, _) -> ()
+               | _ -> aux ()
+             in
+             aux ());
           Error exn
     in
     { startpos; parsed }


### PR DESCRIPTION
The aim of this preview is to gather feedback.

This is a bug-fix release and is compatible with the slightly changed let-binding syntax in OCaml 5.1.
Changelog can be found here: https://github.com/ocaml-ppx/ocamlformat/blob/main/CHANGES.md