### PR TITLE
More precise warning detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 - Handle the error-blocks syntax (#439, @jonludlam, @gpetiot)
 
+#### Fixed
+
+- Reduce false-positives while detecting warnings (#440, @Julow)
+
 ### 2.3.1
 
 #### Added

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -203,9 +203,11 @@ let rec error_padding = function
       let xs = error_padding xs in
       x :: xs
 
+let contains_warnings l =
+  String.is_prefix ~affix:"Warning" l || String.is_infix ~affix:"\nWarning" l
+
 let eval_ocaml ~(block : Block.t) ?syntax ?root c ppf errors =
   let cmd = block.contents |> remove_padding in
-  let contains_warnings = String.is_infix ~affix:"Warning" in
   let error_lines =
     match eval_test ?root ~block c cmd with
     | Ok lines -> List.filter contains_warnings lines

--- a/test/bin/mdx-test/expect/warnings/test-case.md
+++ b/test/bin/mdx-test/expect/warnings/test-case.md
@@ -35,9 +35,6 @@ Test against some false positives:
 ```ocaml
 let x = [ "Warning" ]
 ```
-```mdx-error
-val x : string list = ["Warning"]
-```
 
 ```ocaml
 module Warning = struct
@@ -45,10 +42,6 @@ module Warning = struct
 end
 
 let warning = Warning.Warning
-```
-```mdx-error
-module Warning : sig type t = Warning end
-val warning : Warning.t = Warning.Warning
 ```
 
 Intended false positive:

--- a/test/bin/mdx-test/expect/warnings/test-case.md
+++ b/test/bin/mdx-test/expect/warnings/test-case.md
@@ -29,3 +29,36 @@ Warning 9 [missing-record-field-pattern]: the following labels are not bound in 
 y
 Either bind these labels explicitly or add '; _' to the pattern.
 ```
+
+Test against some false positives:
+
+```ocaml
+let x = [ "Warning" ]
+```
+```mdx-error
+val x : string list = ["Warning"]
+```
+
+```ocaml
+module Warning = struct
+  type t = Warning
+end
+
+let warning = Warning.Warning
+```
+```mdx-error
+module Warning : sig type t = Warning end
+val warning : Warning.t = Warning.Warning
+```
+
+Intended false positive:
+
+```ocaml
+let x =
+  if true then
+    prerr_endline "Warning: Assert failed";
+  [ "foo" ]
+```
+```mdx-error
+Warning: Assert failed
+```


### PR DESCRIPTION
Fix https://github.com/realworldocaml/mdx/issues/434

Reduce false-positive while detecting warnings by searching for the "Warning" at the beginning of a line only.
