### PR TITLE
Avoid infinite loop in lexer on unclosed code block

### DIFF
--- a/lib/lexer_mdx.mll
+++ b/lib/lexer_mdx.mll
@@ -56,7 +56,8 @@ rule text section = parse
         `Text str :: text section lexbuf }
 
 and block = parse
-  | eof | ws* as end_pad "```" ws* eol
+  | eof { [""] }
+  | ws* as end_pad "```" ws* eol
     { newline lexbuf;
       [end_pad] }
   | ([^'\n']* as str) eol

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -576,6 +576,18 @@
  (action (diff trailing-whitespaces/test-case.md.expected trailing-whitespaces.actual)))
 
 (rule
+ (target unclosed-block.actual)
+ (deps (package mdx) (source_tree unclosed-block))
+ (action
+  (with-stdout-to %{target}
+   (chdir unclosed-block
+    (run ocaml-mdx test --output - test-case.md)))))
+
+(rule
+ (alias runtest)
+ (action (diff unclosed-block/test-case.md.expected unclosed-block.actual)))
+
+(rule
  (target warnings.actual)
  (deps (package mdx) (source_tree warnings))
  (action

--- a/test/bin/mdx-test/expect/unclosed-block/test-case.md
+++ b/test/bin/mdx-test/expect/unclosed-block/test-case.md
@@ -1,0 +1,7 @@
+Here is a good block:
+
+```ocaml
+```
+
+And here is one that is not closed, this should not cause an infinite loop in the lexer:
+```

--- a/test/bin/mdx-test/expect/unclosed-block/test-case.md.expected
+++ b/test/bin/mdx-test/expect/unclosed-block/test-case.md.expected
@@ -1,0 +1,8 @@
+Here is a good block:
+
+```ocaml
+```
+
+And here is one that is not closed, this should not cause an infinite loop in the lexer:
+```
+```


### PR DESCRIPTION
An unclosed code block will cause the lexer to loop infinitely in the 'block' rule, because 'eof' is part of the 'eol' rule and it'll keep matching the last rule.

Add a separate rule for eof that terminates immediately, the way the first rule was written it would expect closing quotes after eof which would never match eof.