### PR TITLE
Allow execution of included OCaml code blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 #### Added
 
 - Handle the error-blocks syntax (#439, @jonludlam, @gpetiot)
+- Allow execution of included OCaml code blocks (#446, @panglesd)
 
 #### Fixed
 

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -30,6 +30,16 @@ let locate_errors ~loc r =
     (fun l -> List.map (fun (`Msg m) -> `Msg (locate_error_msg ~loc m)) l)
     r
 
+module OCaml_kind = struct
+  type t = Impl | Intf
+
+  let infer_from_file file =
+    match Filename.(remove_extension (basename file), extension file) with
+    | _, (".ml" | ".mlt" | ".eliom") -> Some Impl
+    | _, (".mli" | ".eliomi") -> Some Intf
+    | _ -> None
+end
+
 module Header = struct
   type t = Shell of [ `Sh | `Bash ] | OCaml | Other of string
 
@@ -85,7 +95,13 @@ type ocaml_value = {
 }
 
 type toplevel_value = { env : Ocaml_env.t; non_det : Label.non_det option }
-type include_ocaml_file = { part_included : string option }
+
+type include_ocaml_file = {
+  part_included : string option;
+  ocaml_value : ocaml_value option;
+  kind : OCaml_kind.t;
+}
+
 type include_other_file = { header : Header.t option }
 
 type include_file_kind =
@@ -117,6 +133,12 @@ type t = {
   delim : string option;
   value : value;
 }
+
+let get_ocaml_value t =
+  match t.value with
+  | OCaml ocaml_value -> Some ocaml_value
+  | Include { file_kind = Fk_ocaml { ocaml_value; _ }; _ } -> ocaml_value
+  | _ -> None
 
 let dump_section = Fmt.(Dump.pair int string)
 
@@ -191,24 +213,22 @@ let pp_error ?syntax ?delim ppf outputs =
         outputs err_delim
   | _ -> ()
 
-let has_output t =
-  match t.value with
-  | OCaml { errors = []; _ } -> false
-  | OCaml { errors = _; _ } -> true
+let has_errors t =
+  match get_ocaml_value t with
+  | Some { errors = _ :: _; _ } -> true
   | _ -> false
 
 let pp_value ?syntax ppf t =
   let delim = t.delim in
-  match t.value with
-  | OCaml { errors = []; _ } -> ()
-  | OCaml { errors; _ } ->
+  match get_ocaml_value t with
+  | Some { errors; _ } ->
       let errors = error_padding errors in
       pp_error ?syntax ?delim ppf errors
   | _ -> ()
 
 let pp_footer ?syntax ppf t =
   let delim =
-    if has_output t then (
+    if has_errors t then (
       pp_value ?syntax ppf t;
       None)
     else t.delim
@@ -379,13 +399,16 @@ let get_block_config l =
     file_inc = get_label (function File x -> Some x | _ -> None) l;
   }
 
+let mk_ocaml_value env non_det errors header =
+  { env = Ocaml_env.mk env; non_det; errors; header }
+
 let mk_ocaml ~loc ~config ~header ~contents ~errors =
   let kind = "OCaml" in
   match config with
   | { file_inc = None; part = None; env; non_det; _ } -> (
       (* TODO: why does this call guess_ocaml_kind when infer_block already did? *)
       match guess_ocaml_kind contents with
-      | `Code -> Ok (OCaml { env = Ocaml_env.mk env; non_det; errors; header })
+      | `Code -> Ok (OCaml (mk_ocaml_value env non_det errors header))
       | `Toplevel ->
           loc_error ~loc "toplevel syntax is not allowed in OCaml blocks.")
   | { file_inc = Some _; _ } -> label_not_allowed ~loc ~label:"file" ~kind
@@ -423,13 +446,31 @@ let mk_toplevel ~loc ~config ~contents ~errors =
 let mk_include ~loc ~config ~header ~errors =
   let kind = "include" in
   match config with
-  | { file_inc = Some file_included; part; non_det = None; env = None; _ } -> (
-      let* () = check_no_errors ~loc errors in
-      match header with
-      | Some Header.OCaml ->
-          let file_kind = Fk_ocaml { part_included = part } in
+  | { file_inc = Some file_included; part; non_det; env; _ } -> (
+      let kind =
+        match header with
+        | Some Header.OCaml -> `OCaml
+        | None -> (
+            match OCaml_kind.infer_from_file file_included with
+            | Some _ -> `OCaml
+            | None -> `Other)
+        | _ -> `Other
+      in
+      match kind with
+      | `OCaml ->
+          let kind =
+            Util.Option.value ~default:OCaml_kind.Impl
+              (OCaml_kind.infer_from_file file_included)
+          in
+          let part_included = part in
+          let ocaml_value =
+            match kind with
+            | Impl -> Some (mk_ocaml_value env non_det errors header)
+            | Intf -> None
+          in
+          let file_kind = Fk_ocaml { part_included; ocaml_value; kind } in
           Ok (Include { file_included; file_kind })
-      | _ -> (
+      | `Other -> (
           match part with
           | None ->
               let file_kind = Fk_other { header } in
@@ -437,9 +478,6 @@ let mk_include ~loc ~config ~header ~errors =
           | Some _ ->
               label_not_allowed ~loc ~label:"part" ~kind:"non-OCaml include"))
   | { file_inc = None; _ } -> label_required ~loc ~label:"file" ~kind
-  | { non_det = Some _; _ } ->
-      label_not_allowed ~loc ~label:"non-deterministic" ~kind
-  | { env = Some _; _ } -> label_not_allowed ~loc ~label:"env" ~kind
 
 let infer_block ~loc ~config ~header ~contents ~errors =
   match config with
@@ -524,7 +562,7 @@ let from_raw raw =
            ~delim:None
 
 let is_active ?section:s t =
-  let active =
+  let active_section =
     match s with
     | Some p -> (
         match t.section with
@@ -532,4 +570,10 @@ let is_active ?section:s t =
         | None -> Re.execp (Re.Perl.compile_pat p) "")
     | None -> true
   in
-  active && t.version_enabled && t.os_type_enabled && not t.skip
+  let can_update_content =
+    match t.value with
+    (* include blocks are always updated even if not executed *)
+    | Include _ -> true
+    | _ -> not t.skip
+  in
+  active_section && t.version_enabled && t.os_type_enabled && can_update_content

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -16,6 +16,10 @@
 
 (** Code blocks headers. *)
 
+module OCaml_kind : sig
+  type t = Impl | Intf
+end
+
 module Header : sig
   type t = Shell of [ `Sh | `Bash ] | OCaml | Other of string
 
@@ -47,6 +51,8 @@ type include_ocaml_file = {
   part_included : string option;
       (** [part_included] is the part of the file to synchronize with.
           If lines is not specified synchronize the whole file. *)
+  ocaml_value : ocaml_value option;
+  kind : OCaml_kind.t;
 }
 
 type include_other_file = { header : Header.t option }

--- a/test/bin/mdx-test/expect/dune.inc
+++ b/test/bin/mdx-test/expect/dune.inc
@@ -180,6 +180,18 @@
  (action (diff errors/test-case.md errors.actual)))
 
 (rule
+ (target exec-include.actual)
+ (deps (package mdx) (source_tree exec-include))
+ (action
+  (with-stdout-to %{target}
+   (chdir exec-include
+    (run ocaml-mdx test --output - test-case.md)))))
+
+(rule
+ (alias runtest)
+ (action (diff exec-include/test-case.md exec-include.actual)))
+
+(rule
  (target exit.actual)
  (deps (package mdx) (source_tree exit))
  (action

--- a/test/bin/mdx-test/expect/exec-include/code.ml
+++ b/test/bin/mdx-test/expect/exec-include/code.ml
@@ -1,0 +1,7 @@
+(* $MDX part-begin=OK *)
+let f x = x + 1
+(* $MDX part-end *)
+
+(* $MDX part-begin=KO *)
+let k = x = 1
+(* $MDX part-end *)

--- a/test/bin/mdx-test/expect/exec-include/code.mli
+++ b/test/bin/mdx-test/expect/exec-include/code.mli
@@ -1,0 +1,1 @@
+val f : int -> int

--- a/test/bin/mdx-test/expect/exec-include/test-case.md
+++ b/test/bin/mdx-test/expect/exec-include/test-case.md
@@ -1,0 +1,38 @@
+.mli files are included but not executed:
+<!-- $MDX file=code.mli -->
+```ocaml
+val f : int -> int
+```
+
+.mli files are still included when `skip` is used:
+<!-- $MDX file=code.mli,skip -->
+```ocaml
+val f : int -> int
+```
+
+.ml files are included and executed:
+<!-- $MDX file=code.ml,part=OK -->
+```ocaml
+let f x = x + 1
+```
+
+<!-- $MDX file=code.ml,part=KO -->
+```ocaml
+let k = x = 1
+```
+```mdx-error
+Line 1, characters 9-10:
+Error: Unbound value x
+```
+
+
+.ml files are still included but no longer executed when `skip` is used:
+<!-- $MDX file=code.ml,part=OK,skip -->
+```ocaml
+let f x = x + 1
+```
+
+<!-- $MDX file=code.ml,part=KO,skip -->
+```ocaml
+let k = x = 1
+```

--- a/test/bin/mdx-test/expect/parts-begin-end/test-case.md
+++ b/test/bin/mdx-test/expect/parts-begin-end/test-case.md
@@ -1,7 +1,7 @@
 Mdx can also understand ocaml code blocks:
 
 
-```ocaml file=parts-begin-end.ml,part=toto
+```ocaml file=parts-begin-end.ml,part=toto,skip
 # let x = 3;;
 val x : int = 3
 # let y = 4;;
@@ -14,13 +14,13 @@ val y : int = 4
 - : unit = ()
 ```
 
-```ocaml file=parts-begin-end.ml,part=z_zz
+```ocaml file=parts-begin-end.ml,part=z_zz,skip
 ```
 
-```ocaml file=parts-begin-end.ml,part=4-2
+```ocaml file=parts-begin-end.ml,part=4-2,skip
 ```
 
-```ocaml file=parts-begin-end.ml
+```ocaml file=parts-begin-end.ml,skip
 ```
 
 ```ocaml
@@ -31,5 +31,5 @@ val x : int = 2
 - : unit = ()
 ```
 
-```ocaml file=parts-begin-end.ml,part=indented
+```ocaml file=parts-begin-end.ml,part=indented,skip
 ```

--- a/test/bin/mdx-test/expect/parts-begin-end/test-case.md.expected
+++ b/test/bin/mdx-test/expect/parts-begin-end/test-case.md.expected
@@ -1,7 +1,7 @@
 Mdx can also understand ocaml code blocks:
 
 
-```ocaml file=parts-begin-end.ml,part=toto
+```ocaml file=parts-begin-end.ml,part=toto,skip
 let x = 34
 let f = 42.3
 let s = "toto"
@@ -13,18 +13,18 @@ let () =
 ;;
 ```
 
-```ocaml file=parts-begin-end.ml,part=z_zz
+```ocaml file=parts-begin-end.ml,part=z_zz,skip
 let () =
   print_string s
 ;;
 ```
 
-```ocaml file=parts-begin-end.ml,part=4-2
+```ocaml file=parts-begin-end.ml,part=4-2,skip
 let () =
   f x print_int;
 ```
 
-```ocaml file=parts-begin-end.ml
+```ocaml file=parts-begin-end.ml,skip
 let () =
   ();
   ()
@@ -63,7 +63,7 @@ val x : int = 2
 - : unit = ()
 ```
 
-```ocaml file=parts-begin-end.ml,part=indented
+```ocaml file=parts-begin-end.ml,part=indented,skip
   let () = fooooooooooooooooooooooooooooooooooooooooooo in
   if not fooooooooo then foooooooooooo
 ```

--- a/test/bin/mdx-test/expect/sync-to-md/test-case.md
+++ b/test/bin/mdx-test/expect/sync-to-md/test-case.md
@@ -1,7 +1,7 @@
 Mdx can also understand ocaml code blocks:
 
 
-```ocaml file=sync_to_md.ml,part=toto
+```ocaml file=sync_to_md.ml,part=toto,skip
 # let x = 3;;
 val x : int = 3
 # let y = 4;;
@@ -14,16 +14,16 @@ val y : int = 4
 - : unit = ()
 ```
 
-```ocaml file=sync_to_md.ml,part=zzz
+```ocaml file=sync_to_md.ml,part=zzz,skip
 ```
 
-```ocaml file=sync_to_md.ml,part=42
+```ocaml file=sync_to_md.ml,part=42,skip
 ```
 
 ```ocaml file=sync_to_md.ml,part=
 ```
 
-```ocaml file=sync_to_md.ml
+```ocaml file=sync_to_md.ml,skip
 ```
 
 ```ocaml

--- a/test/bin/mdx-test/expect/sync-to-md/test-case.md.expected
+++ b/test/bin/mdx-test/expect/sync-to-md/test-case.md.expected
@@ -1,7 +1,7 @@
 Mdx can also understand ocaml code blocks:
 
 
-```ocaml file=sync_to_md.ml,part=toto
+```ocaml file=sync_to_md.ml,part=toto,skip
 let x = 34
 let f = 42.3
 let s = "toto"
@@ -13,13 +13,13 @@ let () =
 ;;
 ```
 
-```ocaml file=sync_to_md.ml,part=zzz
+```ocaml file=sync_to_md.ml,part=zzz,skip
 let () =
   print_string s
 ;;
 ```
 
-```ocaml file=sync_to_md.ml,part=42
+```ocaml file=sync_to_md.ml,part=42,skip
 let () =
   f x print_int
 ```
@@ -31,7 +31,7 @@ let () =
 ;;
 ```
 
-```ocaml file=sync_to_md.ml
+```ocaml file=sync_to_md.ml,skip
 let () =
   ();
   ()


### PR DESCRIPTION
This PR allows to execute OCaml code blocks.

This is useful whenever someone wants to separate the actual code from the mdx-experiments on it.

For instance:

```ocaml
(** file.ml *)

let rec compute = [%something]
```

````markdown
<!-- mdx_doc.md -->

Here is the code of the function we are studying:
```ocaml exec,file=file.ml
let rec compute = [%something]
```
This function is very interesting! 
```ocaml
# compute 1 ;;
- : int = 2
# compute 2 ;;
- : int = 1
```
````

Without this PR, we would have an "unbound value" error for the `compute` function. This will prove especially useful for the [odoc reference driver](https://github.com/ocaml/odoc/blob/master/doc/driver.mld).

I added a `exec` flag to execute an included code block only for backward compatibility.