### PR TITLE
support OCaml 5.3

### DIFF
--- a/lib/top/compat_top.ml
+++ b/lib/top/compat_top.ml
@@ -96,7 +96,11 @@ let extension_constructor
   ; ext_private
   ; ext_loc
   ; ext_attributes
-#if OCAML_VERSION >= (4, 11, 0)
+#if OCAML_VERSION >= (5, 3, 0)
+  ; ext_uid = Uid.mk
+      ~current_unit:
+        (Some (Unit_info.make ~source_file:"mdx.ml" Impl "mdx"))
+#elif OCAML_VERSION >= (4, 11, 0)
   ; ext_uid = Uid.mk ~current_unit:"mdx"
 #endif
   }

--- a/lib/top/compat_top.ml
+++ b/lib/top/compat_top.ml
@@ -97,9 +97,7 @@ let extension_constructor
   ; ext_loc
   ; ext_attributes
 #if OCAML_VERSION >= (5, 3, 0)
-  ; ext_uid = Uid.mk
-      ~current_unit:
-        (Some (Unit_info.make ~source_file:"mdx.ml" Impl "mdx"))
+  ; ext_uid = Uid.mk ~current_unit:None
 #elif OCAML_VERSION >= (4, 11, 0)
   ; ext_uid = Uid.mk ~current_unit:"mdx"
 #endif

--- a/mdx.opam
+++ b/mdx.opam
@@ -28,7 +28,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "cmdliner" {>= "1.1.0"}
   "re" {>= "1.7.2"}
-  "ocaml-version" {>= "3.6.5"}
+  "ocaml-version" {>= "2.3.0"}
   "lwt" {with-test}
   "camlp-streams"
   "result"

--- a/test/bin/mdx-test/expect/errors/test-case.md
+++ b/test/bin/mdx-test/expect/errors/test-case.md
@@ -64,10 +64,18 @@ first
 Exception: Failure "second".
 ```
 
-```ocaml version>=4.08
+```ocaml version>=4.08,version<5.3
 # let x =
   1 + "42";;
 Line 2, characters 7-11:
 Error: This expression has type string but an expression was expected of type
+         int
+```
+
+```ocaml version>=5.3
+# let x =
+  1 + "42";;
+Line 2, characters 7-11:
+Error: This constant has type string but an expression was expected of type
          int
 ```

--- a/test/bin/mdx-test/expect/lines/test-case.md
+++ b/test/bin/mdx-test/expect/lines/test-case.md
@@ -56,13 +56,23 @@ Error: This expression has type string but an expression was expected of type
          int
 ```
 
-```ocaml version>=4.08
+```ocaml version>=4.08,version<5.3
 # let f x = function
   | 0 -> 1
   | n ->
   n + "foo";;
 Line 4, characters 7-12:
 Error: This expression has type string but an expression was expected of type
+         int
+```
+
+```ocaml version>=5.3
+# let f x = function
+  | 0 -> 1
+  | n ->
+  n + "foo";;
+Line 4, characters 7-12:
+Error: This constant has type string but an expression was expected of type
          int
 ```
 

--- a/test/bin/mdx-test/expect/mlt/test-case.md
+++ b/test/bin/mdx-test/expect/mlt/test-case.md
@@ -30,12 +30,22 @@ Error: This expression has type string but an expression was expected of type
          int
 ```
 
-```ocaml version>=4.08
+```ocaml version>=4.08,version<5.3
 # #require "fmt";;
 # let x = 3;;
 val x : int = 3
 # x + "foo";;
 Line 1, characters 5-10:
 Error: This expression has type string but an expression was expected of type
+         int
+```
+
+```ocaml version>=5.3
+# #require "fmt";;
+# let x = 3;;
+val x : int = 3
+# x + "foo";;
+Line 1, characters 5-10:
+Error: This constant has type string but an expression was expected of type
          int
 ```

--- a/test/bin/mdx-test/expect/simple-mld/test-case.mld
+++ b/test/bin/mdx-test/expect/simple-mld/test-case.mld
@@ -59,11 +59,20 @@ Indentation test:
   val x : int = 1
 ]}
 
-{delim@ocaml[
+{delim@ocaml version<5.3[
   let f = 1 + "2"
 ]delim[
 {err@mdx-error[
 Line 1, characters 15-18:
 Error: This expression has type string but an expression was expected of type
+         int
+]err}]}
+
+{delim@ocaml version>=5.3[
+  let f = 1 + "2"
+]delim[
+{err@mdx-error[
+Line 1, characters 15-18:
+Error: This constant has type string but an expression was expected of type
          int
 ]err}]}

--- a/test/bin/mdx-test/expect/simple-mli/test-case.mli
+++ b/test/bin/mdx-test/expect/simple-mli/test-case.mli
@@ -51,12 +51,23 @@ val bar : string
 val baz : string
 
 (**
-{[
+{@ocaml version<5.3[
   let f = 1 + "2"
 ][
 {err@mdx-error[
 Line 1, characters 15-18:
 Error: This expression has type string but an expression was expected of type
+         int
+]err}]}
+*)
+
+(**
+{@ocaml version>=5.3[
+  let f = 1 + "2"
+][
+{err@mdx-error[
+Line 1, characters 15-18:
+Error: This constant has type string but an expression was expected of type
          int
 ]err}]}
 *)


### PR DESCRIPTION
the expect tests still have some failures like this if ran on 5.3. Any advice on how to make them conditional?

```
File "test/bin/mdx-test/expect/simple-mli/test-case.mli", line 1, characters 0-0:
diff --git a/_build/default/test/bin/mdx-test/expect/simple-mli/test-case.mli b/_build/default/test/bin/mdx-test/expect/simple-mli.actual
index ad197127..ad54569e 100644
--- a/_build/default/test/bin/mdx-test/expect/simple-mli/test-case.mli
+++ b/_build/default/test/bin/mdx-test/expect/simple-mli.actual
@@ -56,7 +56,7 @@ val baz : string
 ][
 {err@mdx-error[
 Line 1, characters 15-18:
-Error: This expression has type string but an expression was expected of type
+Error: This constant has type string but an expression was expected of type
          int
 ]err}]}
 *)
```