### PR TITLE
Report location of hangs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Mark the tests as conflicting with dune 3.24.0 due to a bug in
   that release; see https://github.com/ocaml/dune/issues/14724 (@avsm)
+- If a test takes longer than 5 seconds, display a warning with the test's location
+  Also display the location on Ctrl-C (#476, @talex5 @avsm).
 
 ### 2.5.2
 

--- a/README.md
+++ b/README.md
@@ -440,3 +440,18 @@ Those variables are then available in the subsequent blocks
     bar
     - : unit = ()
     ```
+
+### Hanging tests
+
+If a test takes a long time, MDX will write a warning to stderr with the location.
+For example:
+
+<!-- $MDX skip -->
+```sh
+$ dune exec -- ocaml-mdx-test test.md
+warning: test.md:7 has been running for 5 seconds
+```
+
+However, when used with dune the output isn't shown until the whole file
+completes, preventing you from seeing it. To avoid this, use `dune test
+--no-buffer` to disable dune's buffering.

--- a/bin/dune_gen.ml
+++ b/bin/dune_gen.ml
@@ -57,7 +57,11 @@ let run (`Setup ()) (`Prelude prelude) (`Directories dirs) =
   line "    | Some _ -> true";
   line "    | None -> false";
   line "  in";
-  line "  run_exn ~packages ~predicates ~prelude_str:[]";
+  line "  let monitor = Mdx_test.Monitor.create ~output:Unix.stderr in";
+  line "  Mdx_test.Monitor.run monitor;";
+  line "  run_exn ()";
+  line "    ~progress:(Mdx_test.Monitor.update monitor)";
+  line "    ~packages ~predicates ~prelude_str:[]";
   line "    ~non_deterministic";
   line "    ~silent_eval:false ~record_backtrace:false";
   line "    ~syntax:None ~silent:false";

--- a/bin/test/main.ml
+++ b/bin/test/main.ml
@@ -37,10 +37,14 @@ let run_exn (`Setup ()) (`Non_deterministic non_deterministic)
       Mdx_test.Package.compilerlibs_toplevel;
     ]
   in
+  let monitor = Mdx_test.Monitor.create ~output:Unix.stderr in
+  Mdx_test.Monitor.install_signal_handlers monitor;
+  Mdx_test.Monitor.run monitor;
   let predicates = [ Mdx_test.Predicate.byte; Mdx_test.Predicate.toploop ] in
-  Mdx_test.run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax
+  Mdx_test.run_exn () ~non_deterministic ~silent_eval ~record_backtrace ~syntax
     ~silent ~verbose_findlib ~prelude ~prelude_str ~file ~section ~root
     ~force_output ~output ~directives ~packages ~predicates
+    ~progress:(Mdx_test.Monitor.update monitor)
 
 let report_error_in_block block msg =
   let kind =

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -19,7 +19,7 @@ let src = Logs.Src.create "ocaml-mdx"
 module Log = (val Logs.src_log src : Logs.LOG)
 open Astring
 
-type t = { command : string list; output : Output.t list; exit_code : int }
+type t = { command : string list; output : Output.t list; exit_code : int; loc : Lexing.position }
 
 type cram_tests = {
   start_pad : int;
@@ -31,17 +31,21 @@ type cram_tests = {
 let dump_line ppf = function
   | #Output.t as o -> Output.dump ppf o
   | `Exit i -> Fmt.pf ppf "`Exit %d" i
-  | `Command c -> Fmt.pf ppf "`Command %S" c
-  | `Command_first c -> Fmt.pf ppf "`Command_first %S" c
+  | `Command (_pos, c) -> Fmt.pf ppf "`Command %S" c
+  | `Command_first (_pos, c) -> Fmt.pf ppf "`Command_first %S" c
   | `Command_cont c -> Fmt.pf ppf "`Command_cont %S" c
   | `Command_last c -> Fmt.pf ppf "`Command_last %S" c
 
-let dump ppf { command; output; exit_code } =
-  Fmt.pf ppf "{@[command: %a;@ output: %a;@ exit_code: %d]}"
+let pp_loc f (loc : Lexing.position) =
+  Fmt.pf f "%s:%d" loc.pos_fname loc.pos_lnum
+
+let dump ppf { command; output; exit_code; loc } =
+  Fmt.pf ppf "{@[command: %a;@ output: %a;@ exit_code: %d;@ loc: %a]}"
     Fmt.Dump.(list string)
     command
     (Fmt.Dump.list Output.dump)
     output exit_code
+    pp_loc loc
 
 let rec pp_vertical_pad ppf = function
   | 0 -> ()
@@ -131,45 +135,51 @@ let determine_padding lines =
       in
       { start_pad; tests = lines; end_pad }
 
-let of_lines t =
+let of_lines ~loc t =
   let { start_pad; tests; end_pad } = determine_padding t in
+  let loc = { loc with Lexing.pos_lnum = loc.Lexing.pos_lnum + start_pad } in
   let hpad = hpad_of_lines tests in
   let lines = unpad hpad tests in
   let lexer_input =
     lines |> List.map ((Fun.flip String.append) "\n") |> String.concat
   in
-  let lines = Lexer_cram.token (Lexing.from_string lexer_input) in
+  let lines =
+    let x = Lexing.from_string lexer_input in
+    Lexing.set_position x loc;
+    Lexing.set_filename x loc.pos_fname;
+    Lexer_cram.token x
+  in
   Log.debug (fun l ->
       l "Cram.of_lines (pad=%d) %a" hpad Fmt.(Dump.list dump_line) lines);
-  let mk command output ~exit:exit_code =
-    { command; output = List.rev output; exit_code }
+  let mk ~loc command output ~exit:exit_code =
+    { command; output = List.rev output; exit_code; loc }
   in
   let rec command_cont acc = function
     | `Command_cont c :: t -> command_cont (c :: acc) t
     | `Command_last c :: t -> (List.rev (c :: acc), t)
     | _ -> Fmt.failwith "invalid multi-line command"
   in
-  let rec aux command output acc = function
+  let rec aux ~loc command output acc = function
     | [] when command = [] -> List.rev acc
-    | [] -> List.rev (mk command output ~exit:0 :: acc)
-    | `Exit exit :: t -> aux [] [] (mk command output ~exit :: acc) t
-    | (`Ellipsis as o) :: t -> aux command (o :: output) acc t
-    | `Command cmd :: t ->
-        if command = [] then aux [ cmd ] [] acc t
-        else aux [ cmd ] [] (mk command output ~exit:0 :: acc) t
-    | `Command_first cmd :: t ->
+    | [] -> List.rev (mk ~loc command output ~exit:0 :: acc)
+    | `Exit exit :: t -> aux ~loc [] [] (mk ~loc command output ~exit :: acc) t
+    | (`Ellipsis as o) :: t -> aux ~loc command (o :: output) acc t
+    | `Command (loc2, cmd) :: t ->
+        if command = [] then aux ~loc:loc2 [ cmd ] [] acc t
+        else aux ~loc:loc2 [ cmd ] [] (mk ~loc command output ~exit:0 :: acc) t
+    | `Command_first (loc2, cmd) :: t ->
         let cmd, t = command_cont [ cmd ] t in
-        aux cmd [] (mk command output ~exit:0 :: acc) t
-    | (`Output _ as o) :: t -> aux command (o :: output) acc t
+        aux ~loc:loc2 cmd [] (mk ~loc command output ~exit:0 :: acc) t
+    | (`Output _ as o) :: t -> aux ~loc command (o :: output) acc t
     | (`Command_last s | `Command_cont s) :: t ->
-        aux command output acc (`Output s :: t)
+        aux ~loc command output acc (`Output s :: t)
   in
   let hpad, tests =
     match lines with
-    | `Command_first cmd :: t ->
+    | `Command_first (loc, cmd) :: t ->
         let cmd, t = command_cont [ cmd ] t in
-        (hpad, aux cmd [] [] t)
-    | `Command cmd :: t -> (hpad, aux [ cmd ] [] [] t)
+        (hpad, aux ~loc cmd [] [] t)
+    | `Command (loc, cmd) :: t -> (hpad, aux ~loc [ cmd ] [] [] t)
     | [] -> (0, [])
     | `Output line :: _ ->
         if String.length line > 0 && line.[0] = '$' then

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -19,7 +19,12 @@ let src = Logs.Src.create "ocaml-mdx"
 module Log = (val Logs.src_log src : Logs.LOG)
 open Astring
 
-type t = { command : string list; output : Output.t list; exit_code : int; loc : Lexing.position }
+type t = {
+  command : string list;
+  output : Output.t list;
+  exit_code : int;
+  loc : Lexing.position;
+}
 
 type cram_tests = {
   start_pad : int;
@@ -44,8 +49,7 @@ let dump ppf { command; output; exit_code; loc } =
     Fmt.Dump.(list string)
     command
     (Fmt.Dump.list Output.dump)
-    output exit_code
-    pp_loc loc
+    output exit_code pp_loc loc
 
 let rec pp_vertical_pad ppf = function
   | 0 -> ()

--- a/lib/cram.mli
+++ b/lib/cram.mli
@@ -16,7 +16,12 @@
 
 (** Cram tests *)
 
-type t = { command : string list; output : Output.t list; exit_code : int; loc : Lexing.position }
+type t = {
+  command : string list;
+  output : Output.t list;
+  exit_code : int;
+  loc : Lexing.position;
+}
 
 type cram_tests = {
   start_pad : int;

--- a/lib/cram.mli
+++ b/lib/cram.mli
@@ -16,7 +16,7 @@
 
 (** Cram tests *)
 
-type t = { command : string list; output : Output.t list; exit_code : int }
+type t = { command : string list; output : Output.t list; exit_code : int; loc : Lexing.position }
 
 type cram_tests = {
   start_pad : int;
@@ -41,8 +41,8 @@ val command_line : t -> string
 
 (** {2 Parser} *)
 
-val of_lines : string list -> cram_tests
-(** [of_lines l] parses the commands [l]. *)
+val of_lines : loc:Lexing.position -> string list -> cram_tests
+(** [of_lines ~loc l] parses the commands [l]. *)
 
 (** {2 Pretty-printer} *)
 

--- a/lib/lexer_cram.mll
+++ b/lib/lexer_cram.mll
@@ -8,13 +8,14 @@ let digit = ['0' - '9']
 rule token = parse
  | eof               { [] }
  | "[" (digit+ as str) "]" ws* eol
-                     { `Exit (int_of_string str) :: token lexbuf }
- | ws* "..." ws* eol { `Ellipsis :: token lexbuf }
+                     { Lexing.new_line lexbuf; `Exit (int_of_string str) :: token lexbuf }
+ | ws* "..." ws* eol { Lexing.new_line lexbuf; `Ellipsis :: token lexbuf }
  | ws* "$ "              {
+      let loc = Lexing.lexeme_start_p lexbuf in
       let buf = Buffer.create 8 in
       let line, cont = command_line buf lexbuf in
-      if cont then `Command_first line :: token lexbuf
-      else `Command line :: token lexbuf
+      if cont then `Command_first (loc, line) :: token lexbuf
+      else `Command (loc, line) :: token lexbuf
     }
  | ws* "> "              {
       let buf = Buffer.create 8 in
@@ -22,7 +23,7 @@ rule token = parse
       if cont then `Command_cont line :: token lexbuf
       else `Command_last line :: token lexbuf
     }
- | eol               { `Output "" :: token lexbuf }
+ | eol               { Lexing.new_line lexbuf; `Output "" :: token lexbuf }
  | _ as c            {
      let buf = Buffer.create 8 in
      Buffer.add_char buf c;
@@ -31,8 +32,8 @@ rule token = parse
    }
 
 and command_line buf = parse
- | '\\' ws* eol { Buffer.contents buf, true }
- | eol          { Buffer.contents buf, false }
+ | '\\' ws* eol { Lexing.new_line lexbuf; Buffer.contents buf, true }
+ | eol          { Lexing.new_line lexbuf; Buffer.contents buf, false }
  | '\"'   {
      let xbuf = Buffer.create 8 in
      Buffer.add_char xbuf '\"';
@@ -46,7 +47,7 @@ and string buf = parse
  | _ as c        { Buffer.add_char buf c; string buf lexbuf }
 
 and line buf = parse
- | eol    { Buffer.contents buf }
+ | eol    { Lexing.new_line lexbuf; Buffer.contents buf }
  | _ as c { Buffer.add_char buf c; line buf lexbuf }
 
 {

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -18,6 +18,67 @@ open Mdx
 open Astring
 open Mdx.Util.Result.Infix
 
+module Monitor = struct
+  type progress = {
+    start_time : float;
+    loc : Lexing.position;
+  }
+
+  type t = {
+    output : Unix.file_descr;
+    mutable progress : progress option;
+  }
+
+  let create ~output =
+    let output = Unix.dup output in
+    { output; progress = None }
+
+  let update t loc = t.progress <- Some { start_time = Unix.gettimeofday (); loc }
+
+  let pp_loc f (loc : Lexing.position) =
+    Fmt.pf f "%s:%d" loc.pos_fname loc.pos_lnum
+
+  let run_thread t =
+    let out = Format.formatter_of_out_channel (Unix.out_channel_of_descr t.output) in
+    let default_threshold = 5.0 in
+    let rec aux ~last ~threshold =
+      Unix.sleep 1;
+      match t.progress with
+      | None -> aux ~last ~threshold
+      | Some x when x.loc <> last -> aux ~last:x.loc ~threshold:default_threshold
+      | Some { start_time; loc } ->
+        let delay = Unix.gettimeofday () -. start_time in
+        if delay < threshold -. 0.1 then aux ~last ~threshold
+        else (
+          Format.fprintf out "warning: %a has been running for %.0f seconds@." pp_loc loc delay;
+          aux ~last ~threshold:(threshold *. 2.0)
+        )
+    in
+    aux ~last:Lexing.dummy_pos ~threshold:default_threshold
+
+  let output t fmt =
+    fmt |> Fmt.kstr (fun msg ->
+        ignore (Unix.write_substring t.output msg 0 (String.length msg) : int)
+      )
+
+  let handle_interrupt t _n =
+    Sys.(set_signal sigint) Signal_default;
+    t.progress |> Option.iter (fun progress -> output t "\n%a: interrupted\n" pp_loc progress.loc);
+    exit 1
+
+  let handle_usr1 t _n =
+    match t.progress with
+    | None -> output t "Not running any tests (USR1 received)\n"
+    | Some progress -> output t "%a (USR1 received)\n" pp_loc progress.loc
+
+  let install_signal_handlers t =
+    Sys.(set_signal sigint) (Signal_handle (handle_interrupt t));
+    Sys.(set_signal sigusr1) (Signal_handle (handle_usr1 t))
+
+  let run t =
+    ignore (Thread.create run_thread t : Thread.t)
+end
+
 let src = Logs.Src.create "cram.test"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -234,9 +295,10 @@ let eval_ocaml ~(block : Block.t) ?syntax ?root c ppf errors =
 
 let lines = function Ok x | Error x -> x
 
-let run_toplevel_tests ?syntax ?root c ppf Toplevel.{ tests; end_pad } block =
+let run_toplevel_tests ?syntax ?root ~progress c ppf Toplevel.{ tests; end_pad } block =
   Block.pp_header ?syntax ppf block;
   let pp_test ppf (test : Toplevel.t) =
+    progress test.pos;
     let lines = eval_test ?root ~block c test.command |> lines |> split_lines in
     let output_received = List.map output_from_line lines in
     let output_expected = test.output in
@@ -324,9 +386,9 @@ let preludes ~prelude ~prelude_str =
   | fs, [] -> List.map parse fs
   | _ -> Fmt.failwith "only one of --prelude or --prelude-str should be used"
 
-let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
+let run_exn ?(progress=ignore) ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
     ~verbose_findlib ~prelude ~prelude_str ~file ~section ~root ~force_output
-    ~output ~directives ~packages ~predicates =
+    ~output ~directives ~packages ~predicates () =
   Printexc.record_backtrace record_backtrace;
   let syntax =
     match syntax with Some syntax -> Some syntax | None -> Syntax.infer ~file
@@ -339,6 +401,7 @@ let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
 
   let test_block ~ppf ~temp_file t =
     let print_block () = Block.pp ?syntax ppf t in
+    progress t.loc.loc_start;
     if Block.is_active ?section t then
       match Block.value t with
       | Raw _ -> print_block ()
@@ -389,7 +452,7 @@ let run_exn ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
             ~on_evaluation:(fun () ->
               assert (syntax <> Some Cram);
               Mdx_top.in_env env (fun () ->
-                  run_toplevel_tests ?syntax ?root c ppf phrases t))
+                  run_toplevel_tests ?syntax ?root ~progress c ppf phrases t))
     else print_block ()
   in
   let gen_corrected file_contents items =

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -72,8 +72,11 @@ module Monitor = struct
     | Some progress -> output t "%a (USR1 received)\n" pp_loc progress.loc
 
   let install_signal_handlers t =
-    Sys.(set_signal sigint) (Signal_handle (handle_interrupt t));
-    Sys.(set_signal sigusr1) (Signal_handle (handle_usr1 t))
+    (* Not sure what Windows would do if we tried to set these, so skip for now. *)
+    if Sys.os_type = "Unix" then (
+      Sys.(set_signal sigint) (Signal_handle (handle_interrupt t));
+      Sys.(set_signal sigusr1) (Signal_handle (handle_usr1 t))
+    )
 
   let run t = ignore (Thread.create run_thread t : Thread.t)
 end

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -19,51 +19,51 @@ open Astring
 open Mdx.Util.Result.Infix
 
 module Monitor = struct
-  type progress = {
-    start_time : float;
-    loc : Lexing.position;
-  }
-
-  type t = {
-    output : Unix.file_descr;
-    mutable progress : progress option;
-  }
+  type progress = { start_time : float; loc : Lexing.position }
+  type t = { output : Unix.file_descr; mutable progress : progress option }
 
   let create ~output =
     let output = Unix.dup output in
     { output; progress = None }
 
-  let update t loc = t.progress <- Some { start_time = Unix.gettimeofday (); loc }
+  let update t loc =
+    t.progress <- Some { start_time = Unix.gettimeofday (); loc }
 
   let pp_loc f (loc : Lexing.position) =
     Fmt.pf f "%s:%d" loc.pos_fname loc.pos_lnum
 
   let run_thread t =
-    let out = Format.formatter_of_out_channel (Unix.out_channel_of_descr t.output) in
+    let out =
+      Format.formatter_of_out_channel (Unix.out_channel_of_descr t.output)
+    in
     let default_threshold = 5.0 in
     let rec aux ~last ~threshold =
       Unix.sleep 1;
       match t.progress with
       | None -> aux ~last ~threshold
-      | Some x when x.loc <> last -> aux ~last:x.loc ~threshold:default_threshold
+      | Some x when x.loc <> last ->
+          aux ~last:x.loc ~threshold:default_threshold
       | Some { start_time; loc } ->
-        let delay = Unix.gettimeofday () -. start_time in
-        if delay < threshold -. 0.1 then aux ~last ~threshold
-        else (
-          Format.fprintf out "warning: %a has been running for %.0f seconds@." pp_loc loc delay;
-          aux ~last ~threshold:(threshold *. 2.0)
-        )
+          let delay = Unix.gettimeofday () -. start_time in
+          if delay < threshold -. 0.1 then aux ~last ~threshold
+          else (
+            Format.fprintf out "warning: %a has been running for %.0f seconds@."
+              pp_loc loc delay;
+            aux ~last ~threshold:(threshold *. 2.0))
     in
     aux ~last:Lexing.dummy_pos ~threshold:default_threshold
 
   let output t fmt =
-    fmt |> Fmt.kstr (fun msg ->
-        ignore (Unix.write_substring t.output msg 0 (String.length msg) : int)
-      )
+    fmt
+    |> Fmt.kstr (fun msg ->
+           ignore
+             (Unix.write_substring t.output msg 0 (String.length msg) : int))
 
   let handle_interrupt t _n =
     Sys.(set_signal sigint) Signal_default;
-    t.progress |> Option.iter (fun progress -> output t "\n%a: interrupted\n" pp_loc progress.loc);
+    t.progress
+    |> Option.iter (fun progress ->
+           output t "\n%a: interrupted\n" pp_loc progress.loc);
     exit 1
 
   let handle_usr1 t _n =
@@ -75,8 +75,7 @@ module Monitor = struct
     Sys.(set_signal sigint) (Signal_handle (handle_interrupt t));
     Sys.(set_signal sigusr1) (Signal_handle (handle_usr1 t))
 
-  let run t =
-    ignore (Thread.create run_thread t : Thread.t)
+  let run t = ignore (Thread.create run_thread t : Thread.t)
 end
 
 let src = Logs.Src.create "cram.test"
@@ -136,7 +135,7 @@ let get_env unset_variables =
   Array.of_list (List.map (String.concat ~sep:"=") env)
 
 let run_test ?root ~progress unset_variables temp_file t =
-  progress (t.Cram.loc);
+  progress t.Cram.loc;
   let cmd = Cram.command_line t in
   let env = get_env unset_variables in
   Log.info (fun l -> l "exec: %S" cmd);
@@ -296,7 +295,8 @@ let eval_ocaml ~(block : Block.t) ?syntax ?root c ppf errors =
 
 let lines = function Ok x | Error x -> x
 
-let run_toplevel_tests ?syntax ?root ~progress c ppf Toplevel.{ tests; end_pad } block =
+let run_toplevel_tests ?syntax ?root ~progress c ppf Toplevel.{ tests; end_pad }
+    block =
   Block.pp_header ?syntax ppf block;
   let pp_test ppf (test : Toplevel.t) =
     progress test.pos;
@@ -387,9 +387,10 @@ let preludes ~prelude ~prelude_str =
   | fs, [] -> List.map parse fs
   | _ -> Fmt.failwith "only one of --prelude or --prelude-str should be used"
 
-let run_exn ?(progress=ignore) ~non_deterministic ~silent_eval ~record_backtrace ~syntax ~silent
-    ~verbose_findlib ~prelude ~prelude_str ~file ~section ~root ~force_output
-    ~output ~directives ~packages ~predicates () =
+let run_exn ?(progress = ignore) ~non_deterministic ~silent_eval
+    ~record_backtrace ~syntax ~silent ~verbose_findlib ~prelude ~prelude_str
+    ~file ~section ~root ~force_output ~output ~directives ~packages ~predicates
+    () =
   Printexc.record_backtrace record_backtrace;
   let syntax =
     match syntax with Some syntax -> Some syntax | None -> Syntax.infer ~file
@@ -428,7 +429,8 @@ let run_exn ?(progress=ignore) ~non_deterministic ~silent_eval ~record_backtrace
               print_block ();
               let unset_variables = Block.unset_variables t in
               List.iter
-                (fun t -> ignore (run_test ?root ~progress unset_variables temp_file t))
+                (fun t ->
+                  ignore (run_test ?root ~progress unset_variables temp_file t))
                 tests.Cram.tests)
             ~on_evaluation:(fun () ->
               run_cram_tests ?syntax t ?root ~progress ppf temp_file tests)

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -135,7 +135,8 @@ let get_env unset_variables =
   let env = List.fold_left f env unset_variables in
   Array.of_list (List.map (String.concat ~sep:"=") env)
 
-let run_test ?root unset_variables temp_file t =
+let run_test ?root ~progress unset_variables temp_file t =
+  progress (t.Cram.loc);
   let cmd = Cram.command_line t in
   let env = get_env unset_variables in
   Log.info (fun l -> l "exec: %S" cmd);
@@ -180,7 +181,7 @@ let pad_output ~pad_blank hpad outputs =
           | true, true | false, _ -> `Output (Fmt.str "%s%s" string_pad s)))
     outputs
 
-let run_cram_tests ?syntax t ?root ppf temp_file
+let run_cram_tests ?syntax t ?root ~progress ppf temp_file
     (Cram.{ hpad; tests; end_pad; start_pad } as cram_tests) =
   Block.pp_header ?syntax ppf t;
   Log.debug (fun l ->
@@ -192,7 +193,7 @@ let run_cram_tests ?syntax t ?root ppf temp_file
   let pp_test ppf (test : Cram.t) =
     let root = root_dir ?root ~block:t () in
     let unset_variables = Block.unset_variables t in
-    let n = run_test ?root unset_variables temp_file test in
+    let n = run_test ?root ~progress unset_variables temp_file test in
     let lines = Mdx.Util.File.read_lines temp_file in
     let output_expected = test.output in
     let output_received = List.map output_from_line lines in
@@ -421,16 +422,16 @@ let run_exn ?(progress=ignore) ~non_deterministic ~silent_eval ~record_backtrace
           with_non_det non_deterministic non_det ~on_skip_execution:print_block
             ~on_keep_old_output:det ~on_evaluation:det
       | Cram { language = _; non_det } ->
-          let tests = Cram.of_lines t.contents in
+          let tests = Cram.of_lines ~loc:t.loc.loc_start t.contents in
           with_non_det non_deterministic non_det ~on_skip_execution:print_block
             ~on_keep_old_output:(fun () ->
               print_block ();
               let unset_variables = Block.unset_variables t in
               List.iter
-                (fun t -> ignore (run_test ?root unset_variables temp_file t))
+                (fun t -> ignore (run_test ?root ~progress unset_variables temp_file t))
                 tests.Cram.tests)
             ~on_evaluation:(fun () ->
-              run_cram_tests ?syntax t ?root ppf temp_file tests)
+              run_cram_tests ?syntax t ?root ~progress ppf temp_file tests)
       | Toplevel { non_det; env } ->
           let phrases = Toplevel.of_lines ~loc:t.loc t.contents in
           with_non_det non_deterministic non_det ~on_skip_execution:print_block

--- a/lib/test/mdx_test.mli
+++ b/lib/test/mdx_test.mli
@@ -1,5 +1,15 @@
 exception Test_block_failure of Mdx.Block.t * string
 
+module Monitor : sig
+  type t
+
+  val create : output:Unix.file_descr -> t
+
+  val run : t -> unit
+  val update : t -> Lexing.position -> unit
+  val install_signal_handlers : t -> unit
+end
+
 module Package : sig
   val unix : string
   val findlib_top : string
@@ -13,6 +23,7 @@ module Predicate : sig
 end
 
 val run_exn :
+  ?progress:(Lexing.position -> unit) ->
   non_deterministic:bool ->
   silent_eval:bool ->
   record_backtrace:bool ->
@@ -29,4 +40,5 @@ val run_exn :
   directives:Mdx_top.directive list ->
   packages:string list ->
   predicates:string list ->
+  unit ->
   int

--- a/lib/test/mdx_test.mli
+++ b/lib/test/mdx_test.mli
@@ -4,7 +4,6 @@ module Monitor : sig
   type t
 
   val create : output:Unix.file_descr -> t
-
   val run : t -> unit
   val update : t -> Lexing.position -> unit
   val install_signal_handlers : t -> unit

--- a/test/bin/mdx-dune-gen/misc/basic/dune.gen.expected
+++ b/test/bin/mdx-dune-gen/misc/basic/dune.gen.expected
@@ -14,7 +14,11 @@ let run_exn_defaults =
     | Some _ -> true
     | None -> false
   in
-  run_exn ~packages ~predicates ~prelude_str:[]
+  let monitor = Mdx_test.Monitor.create ~output:Unix.stderr in
+  Mdx_test.Monitor.run monitor;
+  run_exn ()
+    ~progress:(Mdx_test.Monitor.update monitor)
+    ~packages ~predicates ~prelude_str:[]
     ~non_deterministic
     ~silent_eval:false ~record_backtrace:false
     ~syntax:None ~silent:false


### PR DESCRIPTION
If a test hangs it's useful to know where.

This commit adds a `?progress` callback to `Mdx_test.run_exn`, which is called when starting each test with its location. The mdx-test binary installs a signal handler for SIGINT which displays the last-known location when called.

Example:

    $ dune exec -- ocaml-mdx-test test.md
    ^C
    test.md:7: interrupted

Sending USR1 will print the current location without exiting.

It also spawns a monitoring thread that reports when part of a test is taking a long time, e.g.

    $ dune exec -- ocaml-mdx-test test.md
    warning: test.md:7 has been running for 5 seconds
    warning: test.md:7 has been running for 10 seconds
    warning: test.md:10 has been running for 5 seconds
    warning: test.md:10 has been running for 10 seconds
    warning: test.md:10 has been running for 20 seconds

The timeout doubles each time. This is intended for use in CI, where currently you just get told that your tests timed out after an hour, with no idea where.

There are a couple of problems when used with dune however:

1. On Ctrl-C, dune terminates the test with SIGKILL, so there's no opportunity to print the current progress.

2. Dune buffers output by default, so you don't see the warnings until the test is over (if it finishes at all), which is pointless. So for this to be useful, you need to do `dune test --no-buffer`.

I expect these could both be fixed with modifications to dune.

TODO:
- [x] Cram tests currently only report the location of the block, not the individual line that's hanging.
- [x] Check this doesn't break things on Windows.

Let me know if this seems like a sensible approach.