### PR TITLE
Fix the target called by the mdx test runner

### DIFF
--- a/.github/workflows/dune-build.yml
+++ b/.github/workflows/dune-build.yml
@@ -14,6 +14,4 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Use dune
-        uses: ocaml-dune/setup-dune@v0.0.1
-        with:
-          automagic: true
+        uses: ocaml-dune/setup-dune@v2

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -30,7 +30,7 @@ let run (`Setup ()) _ _ _ _ _ _ _ _ _ _ =
   let dir = Filename.dirname Sys.argv.(0) in
   let cmd =
     match base with
-    | "main.exe" -> dir / "test" / "main.exe"
+    | "main.exe" -> dir / "test" / "main.bc"
     | x when String.length x > 6 && String.sub x 0 6 = "ocaml-" ->
         let x_without_ext, x_ext = split_exe_extension x in
         (dir / x_without_ext) ^ "-test" ^ x_ext


### PR DESCRIPTION
When mdx's tests are run, they use the private executable from the `_build` directory, thus invoking with the private `main.exe` name, which causes us to hit line 33:

```
    | "main.exe" -> dir / "test" / "main.exe"
```

However, under the stricter rules imposed by https://github.com/ocaml/dune/pull/14432 (pending release in dune 3.24), there is cleaner separation when executing binaries, and the `.exe` target isn't available in some scenarios (notably, when running with `dune install mdx --with-test`). The byte code target is always available in this location, and, IIUC, is the intended target.

AFAIU, this should not be visible to users at all, since the would only call mdx thru the public executable installed as `ocaml-mdx`.

Should close https://github.com/realworldocaml/mdx/issues/477

The diagnosis and solution was provided by @alizter at https://github.com/ocaml/dune/issues/14724#issuecomment-4549904300