### PR TITLE
add support for oxcaml-minus39

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.27.0
+version=0.29.0
 profile=conventional
 ocaml-version=4.08.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,10 @@
 
 #### Changed
 
-- Mark the tests as conflicting with dune 3.24.0 due to a bug in
-  that release; see https://github.com/ocaml/dune/issues/14724 (@avsm)
 - If a test takes longer than 5 seconds, display a warning with the test's location
   Also display the location on Ctrl-C (#476, @talex5 @avsm).
+- Mark the tests as conflicting with dune 3.24.0 due to a bug in
+  that release; see https://github.com/ocaml/dune/issues/14724 (@avsm)
 
 ### 2.5.2
 

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -68,9 +68,8 @@ let executable_contents (block : Block.t) =
   in
   line_pairs
   |> List.map (fun (line, contents) ->
-         if contents = [] || Block.ends_by_semi_semi contents then
-           (line, contents)
-         else (line, add_semi_semi contents))
+      if contents = [] || Block.ends_by_semi_semi contents then (line, contents)
+      else (line, add_semi_semi contents))
 
 let run (`Setup ()) (`File file) (`Section section) =
   Mdx.parse_file Markdown file >>! fun t ->

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.5)
+(lang dune 3.21)
 
 (name mdx)
 

--- a/lib/mli_parser.ml
+++ b/lib/mli_parser.ml
@@ -48,12 +48,13 @@ let extract_code_block_info acc ~(location : Lexing.position) ~docstring =
         }
     in
     fun location
-        {
-          O.Ast.meta;
-          delimiter;
-          content = { O.Loc.location = span; value };
-          output;
-        } ->
+      {
+        O.Ast.meta;
+        delimiter;
+        content = { O.Loc.location = span; value };
+        output;
+      }
+    ->
       let metadata =
         Option.map
           (fun { O.Ast.language; tags } ->

--- a/lib/test/mdx_test.ml
+++ b/lib/test/mdx_test.ml
@@ -56,14 +56,13 @@ module Monitor = struct
   let output t fmt =
     fmt
     |> Fmt.kstr (fun msg ->
-           ignore
-             (Unix.write_substring t.output msg 0 (String.length msg) : int))
+        ignore (Unix.write_substring t.output msg 0 (String.length msg) : int))
 
   let handle_interrupt t _n =
     Sys.(set_signal sigint) Signal_default;
     t.progress
     |> Option.iter (fun progress ->
-           output t "\n%a: interrupted\n" pp_loc progress.loc);
+        output t "\n%a: interrupted\n" pp_loc progress.loc);
     exit 1
 
   let handle_usr1 t _n =
@@ -75,8 +74,7 @@ module Monitor = struct
     (* Not sure what Windows would do if we tried to set these, so skip for now. *)
     if Sys.os_type = "Unix" then (
       Sys.(set_signal sigint) (Signal_handle (handle_interrupt t));
-      Sys.(set_signal sigusr1) (Signal_handle (handle_usr1 t))
-    )
+      Sys.(set_signal sigusr1) (Signal_handle (handle_usr1 t)))
 
   let run t = ignore (Thread.create run_thread t : Thread.t)
 end
@@ -486,10 +484,10 @@ let run_exn ?(progress = ignore) ~non_deterministic ~silent_eval
     Buffer.contents buf
   in
   (match output with
-  | Some `Stdout -> Mdx.run_to_stdout ?syntax ~f:gen_corrected file
-  | Some (`File outfile) ->
-      Mdx.run_to_file ?syntax ~outfile ~f:gen_corrected file
-  | None -> Mdx.run ?syntax ~force_output ~f:gen_corrected file)
+    | Some `Stdout -> Mdx.run_to_stdout ?syntax ~f:gen_corrected file
+    | Some (`File outfile) ->
+        Mdx.run_to_file ?syntax ~outfile ~f:gen_corrected file
+    | None -> Mdx.run ?syntax ~force_output ~f:gen_corrected file)
   >>! fun () ->
   Hashtbl.iter (write_parts ~force_output) files;
   0

--- a/lib/top/compat_top.ml
+++ b/lib/top/compat_top.ml
@@ -13,7 +13,9 @@ let lookup_value v env =
 #endif
 
 let find_value env loc id =
-#if OCAML_VERSION >= (4, 10, 0)
+#ifdef OXCAML
+  Env.lookup_value ~loc id env |> fun (p, w, _) -> (p, w)
+#elif OCAML_VERSION >= (4, 10, 0)
   Env.lookup_value ~loc id env
 #else
   Typetexp.find_value env loc id
@@ -27,14 +29,18 @@ let find_type env loc id =
 #endif
 
 let find_constructor env loc id =
-#if OCAML_VERSION >= (4, 10, 0)
+#ifdef OXCAML
+  Env.lookup_constructor ~loc Env.Positive id env |> fst
+#elif OCAML_VERSION >= (4, 10, 0)
   Env.lookup_constructor ~loc Env.Positive id env
 #else
   Typetexp.find_constructor env loc id
 #endif
 
 let find_module env loc id =
-#if OCAML_VERSION >= (4, 10, 0)
+#ifdef OXCAML
+  Env.lookup_module ~loc id env |> fun (p, w, _) -> (p, w)
+#elif OCAML_VERSION >= (4, 10, 0)
   Env.lookup_module ~loc id env
 #else
   Typetexp.find_module env loc id
@@ -48,7 +54,9 @@ let find_modtype env loc id =
 #endif
 
 let find_class env loc id =
-#if OCAML_VERSION >= (4, 10, 0)
+#ifdef OXCAML
+  Env.lookup_class ~loc id env |> fun (p, w, _) -> (p, w)
+#elif OCAML_VERSION >= (4, 10, 0)
   Env.lookup_class ~loc id env
 #else
   Typetexp.find_class env loc id
@@ -62,7 +70,9 @@ let find_class_type env loc id =
 #endif
 
 let type_structure env str loc =
-#if OCAML_VERSION >= (4, 14, 0)
+#ifdef OXCAML
+  let tstr, _, _, _, _, env =
+#elif OCAML_VERSION >= (4, 14, 0)
   let tstr, _, _, _, env =
 #else
   let tstr, _, _, env =
@@ -96,7 +106,16 @@ let extension_constructor
   ; ext_private
   ; ext_loc
   ; ext_attributes
-#if OCAML_VERSION >= (5, 3, 0)
+#ifdef OXCAML
+  ; ext_shape = Constructor_uniform_value
+  ; ext_constant = true
+  ; ext_uid = (
+    let unit_info =
+      Unit_info.make ~check_modname:false ~source_file:"__NONE__"
+        ~for_pack_prefix:Compilation_unit.Prefix.empty Intf "mdx"
+    in
+    Uid.mk ~current_unit:(Some unit_info))
+#elif OCAML_VERSION >= (5, 3, 0)
   ; ext_uid = Uid.mk ~current_unit:None
 #elif OCAML_VERSION >= (4, 11, 0)
   ; ext_uid = Uid.mk ~current_unit:"mdx"
@@ -122,8 +141,13 @@ let match_env
     env =
   ignore (constraints, persistent, copy_types, value_unbound, module_unbound);
   match env with
+#ifdef OXCAML
+  | Env.Env_value (summary, id, _, _) ->
+    value summary id
+#else
   | Env.Env_value (summary, id, _) ->
     value summary id
+#endif
   | Env_empty -> empty ()
   | Env_open (summary, pid) ->
     open_ summary pid
@@ -132,13 +156,20 @@ let match_env
 #else
   | Env_functor_arg (summary, id) -> functor_arg summary id
 #endif
+#ifdef OXCAML
+  | Env_module (summary, id, presence, _, _, _) ->
+#else
   | Env_module (summary, id, presence, _) ->
+#endif
     let present = match presence with
       | Mp_present -> true
       | Mp_absent -> false
     in
     module_ summary id ~present
   | Env_type (summary, _, _) -> type_ summary
+#ifdef OXCAML
+  | Env_jkind (summary, _, _) -> type_ summary
+#endif
   | Env_modtype (summary, _, _) -> modtype summary
   | Env_cltype (summary, _, _) -> cltype summary
   | Env_class (summary, id, _) -> class_ summary id
@@ -298,7 +329,14 @@ let mk_fun loc exp =
     { Parsetree.pparam_loc= loc
     ; pparam_desc= Pparam_val (label, default, punit) }
   in
+#ifdef OXCAML
+  let function_constraint : Parsetree.function_constraint =
+    { mode_annotations = []; ret_mode_annotations = []; ret_type_constraint = None }
+  in
+  Ast_helper.Exp.function_ [param] function_constraint (Pfunction_body exp)
+#else
   Ast_helper.Exp.function_ [param] None (Pfunction_body exp)
+#endif
 #else
   Ast_helper.Exp.fun_ label default punit exp
 #endif

--- a/lib/top/compat_top.mli
+++ b/lib/top/compat_top.mli
@@ -32,7 +32,11 @@ val type_structure :
 val extension_constructor :
   ext_type_path:Path.t ->
   ext_type_params:Types.type_expr list ->
+#ifdef OXCAML
+  ext_args:Types.constructor_argument list ->
+#else
   ext_args:Types.type_expr list ->
+#endif
   ext_ret_type:Types.type_expr option ->
   ext_private:Asttypes.private_flag ->
   ext_loc:Location.t ->

--- a/lib/top/dune
+++ b/lib/top/dune
@@ -1,10 +1,23 @@
+(rule
+ (target cppo_flags)
+ (action
+  (with-stdout-to
+   %{target}
+   (run ocaml %{dep:gen_cppo_flags.ml} %{ocaml_version}))))
+
 (library
  (name mdx_top)
  (public_name mdx.top)
  (modes byte)
+ (modules (:standard \ gen_cppo_flags))
  (preprocess
   (action
-   (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
+   (run
+    %{bin:cppo}
+    -V
+    OCAML:%{ocaml_version}
+    %{read-lines:cppo_flags}
+    %{input-file})))
  (libraries
   unix
   mdx

--- a/lib/top/dune
+++ b/lib/top/dune
@@ -1,9 +1,18 @@
 (rule
+ (target ox.config)
+ (action
+  (with-accepted-exit-codes
+   (or 0 2)
+   (with-stdout-to
+    %{target}
+    (run %{ocamlopt} -config-var ox)))))
+
+(rule
  (target cppo_flags)
  (action
   (with-stdout-to
    %{target}
-   (run ocaml %{dep:gen_cppo_flags.ml} %{ocaml_version}))))
+   (run ocaml %{dep:gen_cppo_flags.ml} %{dep:ox.config}))))
 
 (library
  (name mdx_top)

--- a/lib/top/dune
+++ b/lib/top/dune
@@ -18,7 +18,8 @@
  (name mdx_top)
  (public_name mdx.top)
  (modes byte)
- (modules (:standard \ gen_cppo_flags))
+ (modules
+  (:standard \ gen_cppo_flags))
  (preprocess
   (action
    (run

--- a/lib/top/dune
+++ b/lib/top/dune
@@ -1,25 +1,24 @@
 (rule
- (target ox.config)
- (action
-  (with-accepted-exit-codes
-   (or 0 2)
-   (with-stdout-to
-    %{target}
-    (run %{ocamlopt} -config-var ox)))))
-
-(rule
  (target cppo_flags)
+ (enabled_if %{ocaml-config:ox})
  (action
   (with-stdout-to
    %{target}
-   (run ocaml %{dep:gen_cppo_flags.ml} %{dep:ox.config}))))
+   (echo "-D\nOXCAML"))))
+
+(rule
+ (target cppo_flags)
+ (enabled_if
+  (not %{ocaml-config:ox}))
+ (action
+  (with-stdout-to
+   %{target}
+   (echo ""))))
 
 (library
  (name mdx_top)
  (public_name mdx.top)
  (modes byte)
- (modules
-  (:standard \ gen_cppo_flags))
  (preprocess
   (action
    (run

--- a/lib/top/gen_cppo_flags.ml
+++ b/lib/top/gen_cppo_flags.ml
@@ -1,12 +1,6 @@
-(* OxCaml compilers report a version of the form X.Y.Z+ox *)
+(* OxCaml compilers answer "true" to [ocamlopt -config-var ox] *)
 let () =
-  let version = Sys.argv.(1) in
-  let is_oxcaml =
-    (* When min supported version is ocaml>=4.13 we can use String.ends_with *)
-    match String.index_opt version '+' with
-    | Some i ->
-        let build = String.sub version (i + 1) (String.length version - i - 1) in
-        String.length build >= 2 && String.sub build 0 2 = "ox"
-    | None -> false
-  in
-  if is_oxcaml then print_string "-D\nOXCAML\n"
+  let ic = open_in_bin Sys.argv.(1) in
+  let contents = really_input_string ic (in_channel_length ic) in
+  close_in ic;
+  if String.trim contents = "true" then print_string "-D\nOXCAML\n"

--- a/lib/top/gen_cppo_flags.ml
+++ b/lib/top/gen_cppo_flags.ml
@@ -1,0 +1,12 @@
+(* OxCaml compilers report a version of the form X.Y.Z+ox *)
+let () =
+  let version = Sys.argv.(1) in
+  let is_oxcaml =
+    (* When min supported version is ocaml>=4.13 we can use String.ends_with *)
+    match String.index_opt version '+' with
+    | Some i ->
+        let build = String.sub version (i + 1) (String.length version - i - 1) in
+        String.length build >= 2 && String.sub build 0 2 = "ox"
+    | None -> false
+  in
+  if is_oxcaml then print_string "-D\nOXCAML\n"

--- a/lib/top/gen_cppo_flags.ml
+++ b/lib/top/gen_cppo_flags.ml
@@ -1,6 +1,0 @@
-(* OxCaml compilers answer "true" to [ocamlopt -config-var ox] *)
-let () =
-  let ic = open_in_bin Sys.argv.(1) in
-  let contents = really_input_string ic (in_channel_length ic) in
-  close_in ic;
-  if String.trim contents = "true" then print_string "-D\nOXCAML\n"

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -217,7 +217,11 @@ module Rewrite = struct
     | _ -> path
 
   let is_persistent_value env longident =
+#ifdef OXCAML
+    let is_persistent_path p = Ident.is_global_or_predef (get_id_in_path p) in
+#else
     let is_persistent_path p = Ident.persistent (get_id_in_path p) in
+#endif
     try is_persistent_path (fst (Compat_top.lookup_value longident env))
     with Not_found -> false
 
@@ -239,8 +243,13 @@ module Rewrite = struct
 
   let item ts env pstr_item tstr_item =
     match (pstr_item.Parsetree.pstr_desc, tstr_item.Typedtree.str_desc) with
+#ifdef OXCAML
+    | ( Parsetree.Pstr_eval (e, _),
+        Typedtree.Tstr_eval ({ Typedtree.exp_type = typ; _ }, _, _) ) -> (
+#else
     | ( Parsetree.Pstr_eval (e, _),
         Typedtree.Tstr_eval ({ Typedtree.exp_type = typ; _ }, _) ) -> (
+#endif
         match Compat_top.ctype_get_desc typ with
         | Types.Tconstr (path, _, _) -> apply ts env pstr_item path e
         | _ -> pstr_item)
@@ -465,13 +474,23 @@ let add_directive ~name ~doc kind =
                 s.txt
 #endif
               | Longident.Lapply _ ->
+#ifdef OXCAML
+                  Format.printf "Invalid path %a@."
+                    (Format_doc.compat Printtyp.longident) lid;
+#else
                   Format.printf "Invalid path %a@." Printtyp.longident lid;
+#endif
                   raise Exit
             in
             let id = Ident.create_persistent s in
             let sg = to_sig env loc id lid in
             Printtyp.wrap_printing_env ~error:false env (fun () ->
+#ifdef OXCAML
+                Format.printf "@[%a@]@."
+                  (Format_doc.compat Printtyp.signature) sg)
+#else
                 Format.printf "@[%a@]@." Printtyp.signature sg)
+#endif
           with
           | Not_found -> Format.printf "@[Unknown element.@]@."
           | Exit -> ()
@@ -533,7 +552,11 @@ let mty_path =
   let open Types in
   function
   | Mty_alias path -> Some path
+#ifdef OXCAML
+  | Mty_ident _ | Mty_signature _ | Mty_functor _ | Mty_strengthen _ -> None
+#else
   | Mty_ident _ | Mty_signature _ | Mty_functor _ -> None
+#endif
 
 let map_sig_attributes ~f =
   let open Types in
@@ -686,7 +709,11 @@ let init ~verbose:v ~silent:s ~verbose_findlib ~directives ~packages ~predicates
   t
 
 let envs = Hashtbl.create 8
+#ifdef OXCAML
+let is_predef_or_global id = Ident.is_predef id || Ident.is_global id
+#else
 let is_predef_or_global id = Ident.is_predef id || Ident.global id
+#endif
 
 let rec save_summary acc s =
   let default_case summary = save_summary acc summary in

--- a/mdx.opam
+++ b/mdx.opam
@@ -18,7 +18,7 @@ license: "ISC"
 homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
-  "dune" {>= "3.5"}
+  "dune" {>= "3.21"}
   "ocaml" {>= "4.08.0"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
@@ -54,3 +54,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/realworldocaml/mdx.git"
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This is done via checking for a +ox suffix in the version string, and then adjusting for the parsetree changes. Shouldn't be any behavioural change on stock OCaml at all.