### PR TITLE
Fix path representations that are causing expect-like tests to fail in dune 3.24

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### unreleased
+
+### Changed
+
+- Paths are normalized to drop the directory prefix ("./" on MacOs and Linux)
+  before pretty printing them (#482, @shonfeder).
+
 ### 2.6.0
 
 #### Added

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -2,6 +2,17 @@ open Cmdliner
 
 let named wrapper = Term.(app (const wrapper))
 
+let normalize_file_path filename =
+  let local_prefix = Filename.current_dir_name ^ Filename.dir_sep in
+  let len_prefix = String.length local_prefix in
+  if
+    String.length filename >= len_prefix
+    && String.equal (String.sub filename 0 len_prefix) local_prefix
+  then
+    (* Strip current directory prefix *)
+    String.sub filename len_prefix (String.length filename - len_prefix)
+  else filename
+
 let non_deterministic =
   let doc = "Run non-deterministic tests." in
   let env = Cmd.Env.info ~doc "MDX_RUN_NON_DETERMINISTIC" in

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -1,6 +1,7 @@
 open Cmdliner.Term
 
 val named : ('a -> 'b) -> 'a t -> 'b t
+val normalize_file_path : string -> string
 val non_deterministic : [> `Non_deterministic of bool ] t
 val syntax : [> `Syntax of Mdx.Syntax.t option ] t
 val file : [> `File of string ] t

--- a/bin/dune_gen.ml
+++ b/bin/dune_gen.ml
@@ -34,7 +34,7 @@ let run (`Setup ()) (`Prelude prelude) (`Directories dirs) =
   in
 
   let pp_prelude ppf (env, filename) =
-    Fmt.pf ppf "(%a, %S)" pp_env env filename
+    Fmt.pf ppf "(%a, %S)" pp_env env (Cli.normalize_file_path filename)
   in
 
   let pp_preludes ppf preludes =

--- a/bin/pp.ml
+++ b/bin/pp.ml
@@ -30,7 +30,8 @@ let vpad_of_lines t =
   in
   aux 0 t
 
-let pp_line_directive ppf (file, line) = Fmt.pf ppf "#%d %S" line file
+let pp_line_directive ppf (file, line) =
+  Fmt.pf ppf "#%d %S" line (Cli.normalize_file_path file)
 
 let rec add_semi_semi = function
   | [] -> []

--- a/dune-project
+++ b/dune-project
@@ -41,5 +41,4 @@
   result
   (alcotest :with-test))
  (conflicts
-   (result (< 1.5))
-   (dune (and :with-test (= 3.24.0)))))
+   (result (< 1.5))))

--- a/mdx.opam
+++ b/mdx.opam
@@ -37,7 +37,6 @@ depends: [
 ]
 conflicts: [
   "result" {< "1.5"}
-  "dune" {with-test & = "3.24.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
In https://github.com/ocaml/dune/pull/15156 , release in dune 3.24, the representation of paths was change so that paths would always include their local directory prefix. Test fixtures that depend on the unnormalized representation of paths coming from dune start breaking as a result.

The two changes offered here fix the test breakage reported at https://github.com/realworldocaml/mdx/pull/478#issuecomment-5036254826 and should make https://github.com/realworldocaml/mdx/pull/479 unnecessary for new release.

An alternative approach would be just promote the changes to the file representation into the test fixtures. However, normalizing and fully specifying path representations is the more robust choice if they get printed into text fixtures, IMO.